### PR TITLE
Use 'inspect_message' in each user canister

### DIFF
--- a/v2/backend/canisters/group/api/Cargo.toml
+++ b/v2/backend/canisters/group/api/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/group/client/Cargo.toml
+++ b/v2/backend/canisters/group/client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 group_canister = { path = "../api" }
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 types = { path = "../../../libraries/types" }
 utils = { path = "../../../libraries/utils" }

--- a/v2/backend/canisters/group/impl/Cargo.toml
+++ b/v2/backend/canisters/group/impl/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3.16"
 group_canister = { path = "../api" }
 group_index_canister = { path = "../../group_index/api" }
 group_index_canister_client = { path = "../../group_index/client" }
-ic-cdk = { version = "0.3.1", default-features = false }
-ic-cdk-macros = "0.3.1"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677" }
 log = "0.4.14"
 notifications_canister = { path = "../../notifications/api" }
 notifications_canister_client = { path = "../../notifications/client" }

--- a/v2/backend/canisters/group_index/api/Cargo.toml
+++ b/v2/backend/canisters/group_index/api/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/group_index/client/Cargo.toml
+++ b/v2/backend/canisters/group_index/client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 group_index_canister = { path = "../api" }
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 types = { path = "../../../libraries/types" }
 utils = { path = "../../../libraries/utils" }

--- a/v2/backend/canisters/group_index/impl/Cargo.toml
+++ b/v2/backend/canisters/group_index/impl/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 candid = "0.7.5"
 group_canister = { path = "../../group/api" }
 group_index_canister = { path = "../api" }
-ic-cdk = { version = "0.3.1", default-features = false }
-ic-cdk-macros = "0.3.1"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677" }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }
 utils = { path = "../../../libraries/utils" }

--- a/v2/backend/canisters/notifications/api/Cargo.toml
+++ b/v2/backend/canisters/notifications/api/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/notifications/client/Cargo.toml
+++ b/v2/backend/canisters/notifications/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 notifications_canister = { path = "../api" }
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/notifications/impl/Cargo.toml
+++ b/v2/backend/canisters/notifications/impl/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
-ic-cdk-macros = "0.3.1"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677" }
 notifications_canister = { path = "../api" }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/user/api/Cargo.toml
+++ b/v2/backend/canisters/user/api/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 serde = "1.0.126"
 types = { path = "../../../libraries/types" }

--- a/v2/backend/canisters/user/client/Cargo.toml
+++ b/v2/backend/canisters/user/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 types = { path = "../../../libraries/types" }
 user_canister = { path = "../api" }

--- a/v2/backend/canisters/user/impl/Cargo.toml
+++ b/v2/backend/canisters/user/impl/Cargo.toml
@@ -17,8 +17,8 @@ group_canister = { path = "../../group/api" }
 group_canister_client = { path = "../../group/client" }
 group_index_canister = { path = "../../group_index/api" }
 group_index_canister_client = { path = "../../group_index/client" }
-ic-cdk = { version = "0.3.1", default-features = false }
-ic-cdk-macros = "0.3.1"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677" }
 itertools = "0.10.1"
 log = "0.4.14"
 notifications_canister = { path = "../../notifications/api" }

--- a/v2/backend/canisters/user/impl/src/lifecycle/inspect_message.rs
+++ b/v2/backend/canisters/user/impl/src/lifecycle/inspect_message.rs
@@ -1,0 +1,19 @@
+use crate::{RuntimeState, RUNTIME_STATE};
+use ic_cdk_macros::inspect_message;
+
+#[inspect_message]
+fn inspect_message() {
+    // All valid ingress messages are either from the owner or are calls to 'deposit_cycles'
+    let method_name = ic_cdk::api::call::method_name();
+    if &method_name[..] == "deposit_cycles" {
+        ic_cdk::api::call::accept_message();
+    } else {
+        RUNTIME_STATE.with(|state| accept_if_owner(state.borrow().as_ref().unwrap()));
+    }
+}
+
+fn accept_if_owner(runtime_state: &RuntimeState) {
+    if runtime_state.is_caller_owner() {
+        ic_cdk::api::call::accept_message();
+    }
+}

--- a/v2/backend/canisters/user/impl/src/lifecycle/mod.rs
+++ b/v2/backend/canisters/user/impl/src/lifecycle/mod.rs
@@ -1,1 +1,2 @@
 mod init;
+mod inspect_message;

--- a/v2/backend/canisters/user_index/api/Cargo.toml
+++ b/v2/backend/canisters/user_index/api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 phonenumber = "0.3.1"
 serde = "1.0.126"
 serde_bytes = "0.11"

--- a/v2/backend/canisters/user_index/client/Cargo.toml
+++ b/v2/backend/canisters/user_index/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 types = { path = "../../../libraries/types" }
 user_index_canister = { path = "../api" }

--- a/v2/backend/canisters/user_index/impl/Cargo.toml
+++ b/v2/backend/canisters/user_index/impl/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
-ic-cdk-macros = "0.3.1"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677" }
 itertools = "0.10.1"
 phonenumber = "0.3.1"
 serde = "1.0.126"

--- a/v2/backend/libraries/types/Cargo.toml
+++ b/v2/backend/libraries/types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 candid = "0.7.5"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 phonenumber = { version = "0.3.1", optional = true }
 serde = "1.0.126"
 serde_bytes = "0.11.5"

--- a/v2/backend/libraries/utils/Cargo.toml
+++ b/v2/backend/libraries/utils/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 candid = "0.7.5"
 getrandom = { version = "0.2.3", features = ["js"] }
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 rand = "0.7.3"
 serde = "1.0.126"

--- a/v2/backend/notification_service/shared/Cargo.toml
+++ b/v2/backend/notification_service/shared/Cargo.toml
@@ -10,7 +10,7 @@ candid = "0.7.5"
 futures = "0.3.16"
 garcon = "0.2.3"
 ic-agent = "0.6.0"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 log = "0.4.14"
 notifications_canister = { path = "../../canisters/notifications/api" }
 openssl = { version = "0.10.35", features = ["vendored"] }

--- a/v2/backend/sms_service/Cargo.toml
+++ b/v2/backend/sms_service/Cargo.toml
@@ -11,7 +11,7 @@ candid = "0.7.5"
 futures = "0.3.16"
 garcon = "0.2.3"
 ic-agent = "0.6.0"
-ic-cdk = { version = "0.3.1", default-features = false }
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs", rev = "2e6452cf280e4334bf5ac6d08c07525eddaf0677", default-features = false }
 lambda_runtime = "0.3.0"
 openssl = { version = "0.10.35", features = ["vendored"] }
 serde = "1.0.126"


### PR DESCRIPTION
On each canister, if 'inspect_message' is implemented, it will be called on receipt of each ingress message before that message is gossiped to the other canisters in the subnet. Therefore it is much cheaper (maybe even free) to reject messages where possible using 'inspect_message' rather than letting them go through consensus and only then rejecting them.