### PR TITLE
Username validation

### DIFF
--- a/v2/backend/canisters/user_index/impl/src/updates/set_username.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/set_username.rs
@@ -305,7 +305,7 @@ mod tests {
         assert!(matches!(validate_username("ab__c"), UsernameValidationResult::Invalid));
         assert!(matches!(validate_username("ab,c"), UsernameValidationResult::Invalid));
         assert!(matches!(validate_username("abcé"), UsernameValidationResult::Invalid));
-        assert!(matches!(validate_username("abcé"), UsernameValidationResult::Invalid));
+        assert!(matches!(validate_username("abcṷ"), UsernameValidationResult::Invalid));
         assert!(matches!(validate_username("abc王"), UsernameValidationResult::Invalid));
     }
 }


### PR DESCRIPTION
This implements the following rules
- Min length 3
- Max length 25
- All chars must be in the set A-Za-z0-9 or an underscore
- Can't start or end with underscore
- Can't contain 2 underscores in a row

I think we should support other alphabets going forward but its hard to do so while also excluding diacritics, which I think we need to exclude otherwise people can easily create usernames which look almost exactly the same as others (eg. 'Elon_Mṷsk')