### PR TITLE
prevent race condition

### DIFF
--- a/v2/frontend/src/fsm/chat.machine.spec.ts
+++ b/v2/frontend/src/fsm/chat.machine.spec.ts
@@ -86,6 +86,7 @@ const directContext: ChatContext = {
     replyingTo: undefined,
     localReactions: {},
     markRead: fakeMessageReadTracker,
+    initialised: false,
 };
 
 GroupIndexClient.create = jest.fn();
@@ -104,6 +105,7 @@ const groupContext: ChatContext = {
     replyingTo: undefined,
     localReactions: {},
     markRead: fakeMessageReadTracker,
+    initialised: false,
 };
 
 describe("chat machine transitions", () => {

--- a/v2/frontend/src/fsm/home.machine.ts
+++ b/v2/frontend/src/fsm/home.machine.ts
@@ -590,6 +590,7 @@ export const schema: MachineConfig<HomeContext, any, HomeEvents> = {
                                                 replyingTo: ctx.replyingTo,
                                                 localReactions: {},
                                                 markRead: ctx.markRead,
+                                                initialised: false,
                                             }),
                                             `chat-${key}`
                                         ),


### PR DESCRIPTION
Make sure that we do not start responding to chat updates until after we have loaded the initial page of _previous_ messages. It can cause a race condition if we do not enforce this. 