### PR TITLE
Set user_index min cycles balance to 5T

### DIFF
--- a/v2/backend/canisters/user_index/impl/src/lib.rs
+++ b/v2/backend/canisters/user_index/impl/src/lib.rs
@@ -15,7 +15,7 @@ mod model;
 mod queries;
 mod updates;
 
-const MIN_CYCLES_BALANCE: Cycles = 2_000_000_000_000; // 5T
+const MIN_CYCLES_BALANCE: Cycles = 5_000_000_000_000; // 5T
 const USER_CANISTER_INITIAL_CYCLES_BALANCE: Cycles = 500_000_000_000; // 0.5T cycles
 const USER_CANISTER_TOP_UP_AMOUNT: Cycles = 100_000_000_000; // 0.1T cycles
 const CONFIRMATION_CODE_EXPIRY_MILLIS: u64 = 60 * 60 * 1000; // 1 hour


### PR DESCRIPTION
If its cycles balance ever drops below this limit the user_index will stop creating new user canisters to protect itself from running out of cycles