### PR TITLE
Revert to Rust edition 2018 due to some incompatibilities with 2021

### DIFF
--- a/v2/backend/canister_installer/Cargo.toml
+++ b/v2/backend/canister_installer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_installer"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canister_upgrader/Cargo.toml
+++ b/v2/backend/canister_upgrader/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_upgrader"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group/api/Cargo.toml
+++ b/v2/backend/canisters/group/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/group/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group/client/Cargo.toml
+++ b/v2/backend/canisters/group/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group/impl/Cargo.toml
+++ b/v2/backend/canisters/group/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group_index/api/Cargo.toml
+++ b/v2/backend/canisters/group_index/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_index_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group_index/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/group_index/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_index_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group_index/client/Cargo.toml
+++ b/v2/backend/canisters/group_index/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_index_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/group_index/impl/Cargo.toml
+++ b/v2/backend/canisters/group_index/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "group_index_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/notifications/api/Cargo.toml
+++ b/v2/backend/canisters/notifications/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notifications_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 default-run = "notifications_canister"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/v2/backend/canisters/notifications/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/notifications/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notifications_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/notifications/client/Cargo.toml
+++ b/v2/backend/canisters/notifications/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notifications_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/notifications/impl/Cargo.toml
+++ b/v2/backend/canisters/notifications/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notifications_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/online_users_aggregator/api/Cargo.toml
+++ b/v2/backend/canisters/online_users_aggregator/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "online_users_aggregator_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/online_users_aggregator/client/Cargo.toml
+++ b/v2/backend/canisters/online_users_aggregator/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "online_users_aggregator_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/online_users_aggregator/impl/Cargo.toml
+++ b/v2/backend/canisters/online_users_aggregator/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "online_users_aggregator_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/open_storage_index/api/Cargo.toml
+++ b/v2/backend/canisters/open_storage_index/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open_storage_index_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/open_storage_index/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/open_storage_index/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open_storage_index_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user/api/Cargo.toml
+++ b/v2/backend/canisters/user/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/user/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user/client/Cargo.toml
+++ b/v2/backend/canisters/user/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user/impl/Cargo.toml
+++ b/v2/backend/canisters/user/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user_index/api/Cargo.toml
+++ b/v2/backend/canisters/user_index/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_index_canister"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user_index/c2c_client/Cargo.toml
+++ b/v2/backend/canisters/user_index/c2c_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_index_canister_c2c_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user_index/client/Cargo.toml
+++ b/v2/backend/canisters/user_index/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_index_canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/canisters/user_index/impl/Cargo.toml
+++ b/v2/backend/canisters/user_index/impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "user_index_canister_impl"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/data_generator/Cargo.toml
+++ b/v2/backend/data_generator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "data_generator"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/integration_tests/Cargo.toml
+++ b/v2/backend/integration_tests/Cargo.toml
@@ -4,7 +4,7 @@
 name = "integration_tests"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/candid_gen/Cargo.toml
+++ b/v2/backend/libraries/candid_gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candid_gen"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/canister_api_macros/Cargo.toml
+++ b/v2/backend/libraries/canister_api_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_api_macros"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/canister_client/Cargo.toml
+++ b/v2/backend/libraries/canister_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_client"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/canister_client_macros/Cargo.toml
+++ b/v2/backend/libraries/canister_client_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_client_macros"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/canister_logger/Cargo.toml
+++ b/v2/backend/libraries/canister_logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canister_logger"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/chat_events/Cargo.toml
+++ b/v2/backend/libraries/chat_events/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chat_events"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/cycles_utils/Cargo.toml
+++ b/v2/backend/libraries/cycles_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cycles_utils"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/http_request/Cargo.toml
+++ b/v2/backend/libraries/http_request/Cargo.toml
@@ -2,7 +2,7 @@
 name = "http_request"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/ledger_utils/Cargo.toml
+++ b/v2/backend/libraries/ledger_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ledger_utils"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/search/Cargo.toml
+++ b/v2/backend/libraries/search/Cargo.toml
@@ -2,7 +2,7 @@
 name = "search"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/serializer/Cargo.toml
+++ b/v2/backend/libraries/serializer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serializer"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/types/Cargo.toml
+++ b/v2/backend/libraries/types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "types"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/libraries/utils/Cargo.toml
+++ b/v2/backend/libraries/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "utils"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/v2/backend/notification_pusher/aws/Cargo.toml
+++ b/v2/backend/notification_pusher/aws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notification_pusher_aws"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.51"

--- a/v2/backend/notification_pusher/cli/Cargo.toml
+++ b/v2/backend/notification_pusher/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notification_pusher_cli"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.51"

--- a/v2/backend/notification_pusher/shared/Cargo.toml
+++ b/v2/backend/notification_pusher/shared/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shared"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.51"

--- a/v2/backend/sms_service/Cargo.toml
+++ b/v2/backend/sms_service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sms_service"
 version = "0.1.0"
 authors = ["Hamish Peebles <hamishpeebles@gmail.com>", "Matt Grogan <megrogan@gmail.com>", "Julian Jelfs <julian.jelfs@gmail.com>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.11-alpha", package = "aws-sdk-dynamodb" }


### PR DESCRIPTION
Some of the dependencies aren't happy when trying to compile to wasm using Rust edition 2021, so reverting back to 2018 for now.