### PR TITLE
Remove 'into_iter' from places where it is already implied

### DIFF
--- a/v2/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/group/impl/src/updates/delete_messages.rs
+++ b/v2/backend/canisters/group/impl/src/updates/delete_messages.rs
@@ -17,7 +17,7 @@ fn delete_messages_impl(args: Args, runtime_state: &mut RuntimeState) -> Respons
     if let Some(participant) = runtime_state.data.participants.get_by_principal(&caller) {
         let now = runtime_state.env.now();
 
-        for message_id in args.message_ids.into_iter() {
+        for message_id in args.message_ids {
             runtime_state.data.events.delete_message(
                 participant.user_id,
                 participant.role.can_delete_messages(),

--- a/v2/backend/canisters/group/impl/src/updates/send_message.rs
+++ b/v2/backend/canisters/group/impl/src/updates/send_message.rs
@@ -56,7 +56,7 @@ fn send_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
         let mut notification_recipients = runtime_state.data.participants.users_to_notify(sender);
 
         // Also notify any mentioned participants regardless of whether they have muted notifications for the group
-        for u in mentioned_users.into_iter() {
+        for u in mentioned_users {
             if runtime_state.data.participants.add_mention(&u, message_index) {
                 notification_recipients.insert(u);
             }

--- a/v2/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/group_index/impl/src/queries/c2c_filter_groups.rs
+++ b/v2/backend/canisters/group_index/impl/src/queries/c2c_filter_groups.rs
@@ -15,7 +15,7 @@ fn c2c_active_and_deleted_groups_impl(args: Args, runtime_state: &RuntimeState) 
 
     let mut active_groups = Vec::new();
     let mut upgrades_in_progress = Vec::new();
-    for chat_id in args.chat_ids.into_iter() {
+    for chat_id in args.chat_ids {
         if let Some(g) = runtime_state.data.private_groups.get(&chat_id) {
             if g.upgrade_in_progress() {
                 upgrades_in_progress.push(g.id());

--- a/v2/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/notifications/impl/src/queries/notifications.rs
+++ b/v2/backend/canisters/notifications/impl/src/queries/notifications.rs
@@ -28,7 +28,7 @@ fn add_subscriptions(notifications: Vec<IndexedEvent<NotificationEnvelope>>, run
     let mut active_notifications: Vec<IndexedEvent<NotificationEnvelope>> = Vec::new();
     let mut subscriptions: HashMap<UserId, Vec<SubscriptionInfo>> = HashMap::new();
 
-    for n in notifications.into_iter() {
+    for n in notifications {
         let mut has_subscriptions = false;
 
         for u in n.value.recipients.iter() {

--- a/v2/backend/canisters/online_users_aggregator/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/online_users_aggregator/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/user/impl/src/queries/search_all_messages.rs
+++ b/v2/backend/canisters/user/impl/src/queries/search_all_messages.rs
@@ -114,7 +114,7 @@ async fn search_all_group_chats(
     let mut successes = Vec::new();
     let mut failures = Vec::new();
 
-    for response in responses.into_iter() {
+    for response in responses {
         match response {
             Ok(result) => {
                 if let group_canister::c2c_search_messages::Response::Success(r) = result {

--- a/v2/backend/canisters/user/impl/src/updates/c2c_delete_messages.rs
+++ b/v2/backend/canisters/user/impl/src/updates/c2c_delete_messages.rs
@@ -22,7 +22,7 @@ fn c2c_delete_messages_impl(args: Args, runtime_state: &mut RuntimeState) -> Res
     if let Some(chat) = runtime_state.data.direct_chats.get_mut(&caller.into()) {
         let now = runtime_state.env.now();
 
-        for message_id in args.message_ids.into_iter() {
+        for message_id in args.message_ids {
             chat.events.delete_message(caller, false, message_id, now);
         }
 

--- a/v2/backend/canisters/user/impl/src/updates/dismiss_alerts.rs
+++ b/v2/backend/canisters/user/impl/src/updates/dismiss_alerts.rs
@@ -18,7 +18,7 @@ fn dismiss_alerts_impl(args: Args, runtime_state: &mut RuntimeState) -> Response
     let now = runtime_state.env.now();
 
     let mut not_found = Vec::new();
-    for ext_id in args.alert_ids.into_iter() {
+    for ext_id in args.alert_ids {
         match AlertId::from_str(&ext_id) {
             Ok(AlertId::Internal(id)) => {
                 if runtime_state.data.alerts.remove(id).is_some() {

--- a/v2/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -37,11 +37,11 @@ fn rehydrate_log_messages(
     trace_messages: Vec<LogMessage>,
     messages_container: &LogMessagesWrapper,
 ) {
-    for message in log_messages.into_iter() {
+    for message in log_messages {
         messages_container.logs.push(message);
     }
 
-    for message in trace_messages.into_iter() {
+    for message in trace_messages {
         messages_container.traces.push(message);
     }
 }

--- a/v2/backend/canisters/user_index/impl/src/updates/c2c_mark_users_online.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/c2c_mark_users_online.rs
@@ -13,7 +13,7 @@ fn c2c_mark_users_online(args: Args) -> Response {
 fn c2c_mark_users_online_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
     let now = runtime_state.env.now();
     let users = &mut runtime_state.data.users;
-    for user in args.users.into_iter() {
+    for user in args.users {
         users.mark_online(&user, now);
     }
     Success

--- a/v2/backend/libraries/http_request/src/logs_handler.rs
+++ b/v2/backend/libraries/http_request/src/logs_handler.rs
@@ -7,7 +7,7 @@ use types::{HeaderField, HttpResponse};
 pub fn encode_logs(messages: Vec<LogMessage>) -> HttpResponse {
     let mut body = Vec::new();
 
-    for message in messages.into_iter() {
+    for message in messages {
         writeln!(&mut body, "{}", message.json).unwrap();
     }
 

--- a/v2/backend/libraries/utils/src/range_set.rs
+++ b/v2/backend/libraries/utils/src/range_set.rs
@@ -9,7 +9,7 @@ pub fn insert_ranges(range_set: &mut RangeSet, message_ranges: &[MessageIndexRan
     for range in message_ranges.iter().map(|r| r.from.into()..=r.to.into()) {
         added.insert_range(range.clone());
         if let Some(intersection) = range_set.insert_range(range) {
-            for r in intersection.into_smallvec().into_iter() {
+            for r in intersection.into_smallvec() {
                 added.remove_range(r);
             }
         }

--- a/v2/backend/notification_pusher/shared/src/actions/push_notifications.rs
+++ b/v2/backend/notification_pusher/shared/src/actions/push_notifications.rs
@@ -62,7 +62,7 @@ async fn handle_notifications(
     let client = WebPushClient::new();
 
     let mut futures = Vec::new();
-    for (user_id, notifications) in grouped_by_user.into_iter() {
+    for (user_id, notifications) in grouped_by_user {
         if let Some(s) = subscriptions.remove(&user_id) {
             futures.push(push_notifications_to_user(
                 user_id,
@@ -106,10 +106,10 @@ fn group_notifications_by_user(envelopes: Vec<IndexedEvent<NotificationEnvelope>
         };
     }
 
-    for n in envelopes.into_iter() {
+    for n in envelopes {
         let notification_bytes = Encode!(&n.value.notification).unwrap();
         let base64 = Rc::new(base64::encode(notification_bytes));
-        for u in n.value.recipients.into_iter() {
+        for u in n.value.recipients {
             assign_notification_to_user(&mut grouped_by_user, u, base64.clone());
         }
     }


### PR DESCRIPTION
I only recently realised you don't need to say `.into_iter()` when doing a for loop