### PR TITLE
Revert "Set test_mode to false and clear trace messages (#1128)"

### DIFF
--- a/v2/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);

--- a/v2/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);

--- a/v2/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);

--- a/v2/backend/canisters/online_users_aggregator/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/online_users_aggregator/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);

--- a/v2/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);

--- a/v2/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/v2/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -17,11 +17,8 @@ fn post_upgrade(args: Args) {
 
     match version {
         StateVersion::V1 => {
-            let (mut data, log_messages, _): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+            let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
                 serializer::deserialize(&bytes).unwrap();
-
-            data.test_mode = false;
-            let trace_messages = Vec::new();
 
             init_logger(data.test_mode);
             init_state(env, data, args.wasm_version);


### PR DESCRIPTION
This reverts commit 7724d9a7af3bc4f14f3e713df1f6347d9940ec99.

The previous commit was a one time update that was needed to set test_mode to false on all of the canisters deployed to live, we can now revert that change.