### PR TITLE
Ensure each Poller instance only runs exactly one instance of its task

### DIFF
--- a/v2/frontend/src/fsm/poller.ts
+++ b/v2/frontend/src/fsm/poller.ts
@@ -7,7 +7,7 @@ export class Poller {
     private lastExecutionTimestamp: number | undefined;
     private stopped = false;
     // Used to ensure each Poller instance runs exactly one instance of its task
-    private runnerId: number | undefined;
+    private runnerId: symbol | undefined;
 
     constructor(
         private fn: () => Promise<void>,
@@ -20,7 +20,7 @@ export class Poller {
     }
 
     private start(hidden: boolean): void {
-        const runnerId = Math.random();
+        const runnerId = Symbol();
         this.runnerId = runnerId;
 
         if (this.timeoutId !== undefined) {


### PR DESCRIPTION
Without this, if `start` is called while the task is running, a second instance of the task runner will start but the previous one will not be cancelled. This can happen when the screen switches from idle to active.