### PR TITLE
use the recommended syntax for division

### DIFF
--- a/v2/frontend/rollup.config.js
+++ b/v2/frontend/rollup.config.js
@@ -125,7 +125,7 @@ export default [
                 preprocess: sveltePreprocess({
                     sourceMap: !production,
                     scss: {
-                        prependData: `@import 'src/styles/mixins.scss';`,
+                        prependData: `@use 'sass:math'; @import 'src/styles/mixins.scss';`,
                     },
                 }),
                 compilerOptions: {

--- a/v2/frontend/src/components/Progress.svelte
+++ b/v2/frontend/src/components/Progress.svelte
@@ -16,7 +16,7 @@
         width: 100%;
         height: $progress-bar-x-large;
         position: relative;
-        border-radius: $progress-bar-x-large / 2;
+        border-radius: math.div($progress-bar-x-large, 2);
         overflow: hidden;
     }
 
@@ -25,7 +25,7 @@
         transition: width 300ms;
         display: block;
         height: 100%;
-        border-radius: $progress-bar-x-large / 2;
+        border-radius: math.div($progress-bar-x-large, 2);
         background-color: var(--button-bg);
         position: relative;
     }

--- a/v2/frontend/src/fsm/home.controller.ts
+++ b/v2/frontend/src/fsm/home.controller.ts
@@ -15,7 +15,7 @@ import {
 } from "../domain/chat/chat.utils";
 import type { DataContent } from "../domain/data/data";
 import type { Notification } from "../domain/notifications";
-import type { User, UsersResponse } from "../domain/user/user";
+import type { User } from "../domain/user/user";
 import { missingUserIds } from "../domain/user/user.utils";
 import { rtcConnectionsManager } from "../domain/webrtc/RtcConnectionsManager";
 import type {

--- a/v2/frontend/svelte.config.js
+++ b/v2/frontend/svelte.config.js
@@ -14,7 +14,7 @@ const preprocessOptions = {
     },
     scss: {
         // prependData: `@import 'v2/frontend/src/styles/mixins.scss';`,
-        prependData: `@import '${mixins}';`,
+        prependData: `@use 'sass:math'; @import '${mixins}';`,
     },
 };
 module.exports = {


### PR DESCRIPTION
this gets rid of an annoying compile warning that's been there for ages. 