### PR TITLE
Fix syncing of new users to OpenStorage

### DIFF
--- a/v2/backend/canisters/user_index/impl/src/updates/mod.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/mod.rs
@@ -1,3 +1,7 @@
+use crate::model::user::PhoneStatus;
+use crate::DEFAULT_OPEN_STORAGE_USER_BYTE_LIMIT;
+use types::RegistrationFee;
+
 pub mod add_super_admin;
 pub mod c2c_mark_send_message_failed;
 pub mod c2c_mark_users_online;
@@ -16,3 +20,11 @@ pub mod submit_phone_number;
 pub mod upgrade_canister;
 pub mod upgrade_user_canister_wasm;
 pub mod wallet_receive;
+
+fn storage_byte_limit_for_new_user(phone_status: &PhoneStatus, registration_fee: &Option<RegistrationFee>) -> u64 {
+    if matches!(phone_status, PhoneStatus::Confirmed(_)) || registration_fee.is_some() {
+        DEFAULT_OPEN_STORAGE_USER_BYTE_LIMIT
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
This checks what the byte limit should be whenever we create a 'CreatedUser', and only if the limit is > 0 will it push the user to OpenStorage. 