### PR TITLE
Add byte limit to confirm_phone_number response

### DIFF
--- a/v2/backend/canisters/user_index/api/can.did
+++ b/v2/backend/canisters/user_index/api/can.did
@@ -46,11 +46,16 @@ type ConfirmPhoneNumberArgs =
 
 type ConfirmPhoneNumberResponse = 
     variant {
-        Success;
+        Success: SuccessResult;
         ConfirmationCodeIncorrect;
         ConfirmationCodeExpired;
         AlreadyClaimed;
         PhoneNumberNotSubmitted;
+    };
+
+type SuccessResult =
+    record {
+        open_storage_limit_bytes: nat64;
     };
 
 type ResendCodeArgs = 

--- a/v2/backend/canisters/user_index/api/src/updates/confirm_phone_number.rs
+++ b/v2/backend/canisters/user_index/api/src/updates/confirm_phone_number.rs
@@ -8,9 +8,14 @@ pub struct Args {
 
 #[derive(CandidType, Deserialize, Debug)]
 pub enum Response {
-    Success,
+    Success(SuccessResult),
     ConfirmationCodeIncorrect,
     ConfirmationCodeExpired,
     AlreadyClaimed,
     PhoneNumberNotSubmitted,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+pub struct SuccessResult {
+    pub open_storage_limit_bytes: u64,
 }

--- a/v2/backend/canisters/user_index/impl/src/updates/confirm_phone_number.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/confirm_phone_number.rs
@@ -27,9 +27,13 @@ fn confirm_phone_number_impl(args: Args, runtime_state: &mut RuntimeState) -> Re
                 user_id: caller,
                 byte_limit: new_byte_limit,
             });
-            Success
+            Success(SuccessResult {
+                open_storage_limit_bytes: new_byte_limit,
+            })
         }
-        ConfirmPhoneNumberResult::Success(None) => Success,
+        ConfirmPhoneNumberResult::Success(None) => Success(SuccessResult {
+            open_storage_limit_bytes: 0,
+        }),
         ConfirmPhoneNumberResult::CodeExpired => ConfirmationCodeExpired,
         ConfirmPhoneNumberResult::CodeIncorrect => ConfirmationCodeIncorrect,
         ConfirmPhoneNumberResult::PhoneNumberNotSubmitted => PhoneNumberNotSubmitted,
@@ -63,7 +67,7 @@ mod tests {
 
         let args = Args { confirmation_code };
         let result = confirm_phone_number_impl(args, &mut runtime_state);
-        assert!(matches!(result, Response::Success));
+        assert!(matches!(result, Response::Success(_)));
 
         let user = runtime_state
             .data

--- a/v2/backend/integration_tests/src/verify_user_tests.rs
+++ b/v2/backend/integration_tests/src/verify_user_tests.rs
@@ -79,7 +79,7 @@ async fn verify_user_tests_impl(handle: IcHandle, ctx: &fondue::pot::Context) {
             .unwrap();
         assert!(matches!(
             response,
-            user_index_canister::confirm_phone_number::Response::Success
+            user_index_canister::confirm_phone_number::Response::Success(_)
         ));
         println!("Ok");
     }

--- a/v2/backend/libraries/canister_client/src/operations/gated_register_user.rs
+++ b/v2/backend/libraries/canister_client/src/operations/gated_register_user.rs
@@ -43,7 +43,7 @@ pub async fn gated_register_user(
 
     assert!(matches!(
         confirm_phone_number_response,
-        user_index_canister::confirm_phone_number::Response::Success
+        user_index_canister::confirm_phone_number::Response::Success(_)
     ));
 
     let create_canister_args = user_index_canister::create_canister::Args {};


### PR DESCRIPTION
This is a breaking change so the website must be deployed at the same time with the corresponding changes