### PR TITLE
Transfer ICP to central account when charging users

### DIFF
--- a/v2/backend/canisters/user_index/api/can.did
+++ b/v2/backend/canisters/user_index/api/can.did
@@ -103,15 +103,9 @@ type RefreshAccountBalanceArgs =
 
 type RefreshAccountBalanceResponse =
     variant {
-        Success: AccountCredit;
-        SuccessNoChange: AccountCredit;
+        Success: record { account_balance: ICP; };
         UserNotFound;
         InternalError: text;
-    };
-
-type AccountCredit =
-    record {
-        account_credit: ICP;
     };
 
 type UpgradeStorageArgs =
@@ -121,17 +115,16 @@ type UpgradeStorageArgs =
 
 type UpgradeStorageResponse =
     variant {
-        Success: record {
-            remaining_account_credit: ICP;
-        };
+        Success;
         SuccessNoChange;
         PaymentInsufficient: record {
-            account_credit: ICP;
+            account_balance: ICP;
             amount_required: ICP;
         };
         PaymentNotFound;
         StorageLimitExceeded: nat64; // Returns the storage limit in bytes
         UserNotFound;
+        InternalError: text;
     };
 
 type CreateCanisterArgs =
@@ -224,7 +217,7 @@ type CurrentUserResponse =
             open_storage_limit_bytes: nat64;
             phone_status: PhoneStatus;
             billing_account: AccountIdentifier;
-            account_credit: ICP;
+            account_balance: ICP;
         };
     };
 
@@ -351,10 +344,10 @@ service: {
 
     notify_registration_fee_paid: (NotifyRegistrationFeePaidArgs) -> (NotifyRegistrationFeePaidResponse);
 
-    // Checks the user's ledger account and credits their account if there has been a payment
+    // Checks the user's ledger account and updates the user record with the new balance
     refresh_account_balance: (RefreshAccountBalanceArgs) -> (RefreshAccountBalanceResponse);
 
-    // Increases the user's storage limit in OpenStorage (provided the user has enough credit)
+    // Increases the user's storage limit in OpenStorage (provided the user has deposited enough ICP)
     upgrade_storage: (UpgradeStorageArgs) -> (UpgradeStorageResponse);
 
     // Once the confirm_phone_number call has succeeded (user is in one of the "confirmed" states)

--- a/v2/backend/canisters/user_index/api/src/queries/current_user.rs
+++ b/v2/backend/canisters/user_index/api/src/queries/current_user.rs
@@ -70,5 +70,5 @@ pub struct CreatedResult {
     pub open_storage_limit_bytes: u64,
     pub phone_status: PhoneStatus,
     pub billing_account: AccountIdentifier,
-    pub account_credit: ICP,
+    pub account_balance: ICP,
 }

--- a/v2/backend/canisters/user_index/api/src/updates/refresh_account_balance.rs
+++ b/v2/backend/canisters/user_index/api/src/updates/refresh_account_balance.rs
@@ -8,12 +8,11 @@ pub struct Args {}
 #[derive(CandidType, Deserialize, Debug)]
 pub enum Response {
     Success(SuccessResult),
-    SuccessNoChange(SuccessResult),
     UserNotFound,
     InternalError(String),
 }
 
 #[derive(CandidType, Deserialize, Debug)]
 pub struct SuccessResult {
-    pub account_credit: ICP,
+    pub account_balance: ICP,
 }

--- a/v2/backend/canisters/user_index/api/src/updates/upgrade_storage.rs
+++ b/v2/backend/canisters/user_index/api/src/updates/upgrade_storage.rs
@@ -9,21 +9,17 @@ pub struct Args {
 
 #[derive(CandidType, Deserialize, Debug)]
 pub enum Response {
-    Success(SuccessResult),
+    Success,
     SuccessNoChange,
     PaymentInsufficient(PaymentInsufficientResult),
     PaymentNotFound,
     StorageLimitExceeded(u64), // Returns the storage limit in bytes
     UserNotFound,
-}
-
-#[derive(CandidType, Deserialize, Debug)]
-pub struct SuccessResult {
-    pub remaining_account_credit: ICP,
+    InternalError(String),
 }
 
 #[derive(CandidType, Deserialize, Debug)]
 pub struct PaymentInsufficientResult {
-    pub account_credit: ICP,
+    pub account_balance: ICP,
     pub amount_required: ICP,
 }

--- a/v2/backend/canisters/user_index/impl/src/lib.rs
+++ b/v2/backend/canisters/user_index/impl/src/lib.rs
@@ -4,7 +4,7 @@ use crate::model::user_map::UserMap;
 use candid::{CandidType, Principal};
 use canister_logger::LogMessagesWrapper;
 use canister_state_macros::canister_state;
-use ic_ledger_types::AccountIdentifier;
+use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT};
 use ledger_utils::convert_to_subaccount;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
@@ -86,6 +86,10 @@ impl RuntimeState {
     pub fn generate_6_digit_code(&mut self) -> String {
         let random = self.env.random_u32();
         format!("{:0>6}", random % 1000000)
+    }
+
+    pub fn user_index_ledger_account(&self) -> AccountIdentifier {
+        AccountIdentifier::new(&self.env.canister_id(), &DEFAULT_SUBACCOUNT)
     }
 
     pub fn user_billing_account(&self, user_id: UserId) -> AccountIdentifier {

--- a/v2/backend/canisters/user_index/impl/src/lifecycle/heartbeat.rs
+++ b/v2/backend/canisters/user_index/impl/src/lifecycle/heartbeat.rs
@@ -3,7 +3,7 @@ use crate::{mutate_state, read_state, RuntimeState, MIN_CYCLES_BALANCE, USER_CAN
 use candid::Principal;
 use group_canister::c2c_dismiss_super_admin;
 use ic_cdk_macros::heartbeat;
-use ic_ledger_types::{AccountIdentifier, Memo, DEFAULT_FEE, DEFAULT_SUBACCOUNT};
+use ic_ledger_types::{Memo, DEFAULT_FEE};
 use ledger_utils::convert_to_subaccount;
 use tracing::error;
 use types::{CanisterId, ChatId, Cycles, CyclesTopUp, UserId, Version, ICP};
@@ -265,7 +265,7 @@ mod transfer_registration_fees {
 
     async fn transfer_registration_fee(principal: Principal, amount: ICP) {
         let subaccount = convert_to_subaccount(&principal);
-        let recipient = AccountIdentifier::new(&ic_cdk::id(), &DEFAULT_SUBACCOUNT);
+        let recipient = read_state(|state| state.user_index_ledger_account());
 
         let args = ic_ledger_types::TransferArgs {
             memo: Memo(DEFAULT_MEMO),

--- a/v2/backend/canisters/user_index/impl/src/model/account_billing.rs
+++ b/v2/backend/canisters/user_index/impl/src/model/account_billing.rs
@@ -1,4 +1,5 @@
 use candid::CandidType;
+use ic_ledger_types::BlockIndex;
 use serde::{Deserialize, Serialize};
 use types::{TimestampMillis, ICP};
 
@@ -17,12 +18,7 @@ impl AccountBilling {
         self.charges.push(charge);
     }
 
-    // TODO account for the burned ICP once we implement burning
-    pub fn ledger_balance(&self) -> ICP {
-        ICP::from_e8s(self.payments.iter().map(|p| p.amount.e8s()).sum())
-    }
-
-    pub fn credit(&self) -> ICP {
+    pub fn account_balance(&self) -> ICP {
         let payments_total: u64 = self.payments.iter().map(|p| p.amount.e8s()).sum();
         let charges_total: u64 = self.charges.iter().map(|c| c.amount.e8s()).sum();
 
@@ -40,6 +36,7 @@ pub struct AccountPayment {
 pub struct AccountCharge {
     pub amount: ICP,
     pub timestamp: TimestampMillis,
+    pub block_index: BlockIndex,
     pub details: AccountChargeDetails,
 }
 

--- a/v2/backend/canisters/user_index/impl/src/queries/current_user.rs
+++ b/v2/backend/canisters/user_index/impl/src/queries/current_user.rs
@@ -53,7 +53,7 @@ fn current_user_impl(runtime_state: &RuntimeState) -> Response {
                 };
 
                 let billing_account = runtime_state.user_billing_account(u.user_id);
-                let account_credit = u.account_billing.credit();
+                let account_balance = u.account_billing.account_balance();
 
                 Created(CreatedResult {
                     user_id: u.user_id,
@@ -64,7 +64,7 @@ fn current_user_impl(runtime_state: &RuntimeState) -> Response {
                     open_storage_limit_bytes: u.open_storage_limit_bytes,
                     phone_status,
                     billing_account,
-                    account_credit,
+                    account_balance,
                 })
             }
         }

--- a/v2/backend/canisters/user_index/impl/src/updates/refresh_account_balance.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/refresh_account_balance.rs
@@ -1,11 +1,10 @@
 use crate::model::account_billing::AccountPayment;
 use crate::model::user::User;
 use crate::{mutate_state, read_state, RuntimeState};
-use candid::Principal;
 use canister_api_macros::trace;
 use ic_cdk_macros::update;
 use ic_ledger_types::{AccountBalanceArgs, AccountIdentifier, MAINNET_LEDGER_CANISTER_ID};
-use types::ICP;
+use types::{UserId, ICP};
 use user_index_canister::refresh_account_balance::{Response::*, *};
 
 #[update]
@@ -15,7 +14,11 @@ async fn refresh_account_balance(_args: Args) -> Response {
 }
 
 pub(crate) async fn refresh_account_balance_impl() -> Response {
-    let PrepareResult { caller, billing_account } = match read_state(prepare) {
+    let PrepareResult {
+        user_id,
+        previous_balance,
+        billing_account,
+    } = match read_state(prepare) {
         Ok(prepare_result) => prepare_result,
         Err(response) => return response,
     };
@@ -28,51 +31,44 @@ pub(crate) async fn refresh_account_balance_impl() -> Response {
     )
     .await
     {
-        Ok(balance) => mutate_state(|state| process_balance(caller, balance, state)),
+        Ok(balance) => mutate_state(|state| process_balance(user_id, previous_balance, balance, state)),
         Err(error) => InternalError(format!("{error:?}")),
     }
 }
 
 struct PrepareResult {
-    caller: Principal,
+    user_id: UserId,
+    previous_balance: ICP,
     billing_account: AccountIdentifier,
 }
 
 fn prepare(runtime_state: &RuntimeState) -> Result<PrepareResult, Response> {
     let caller = runtime_state.env.caller();
-    if runtime_state.data.users.get_by_principal(&caller).is_some() {
+    if let Some(User::Created(user)) = runtime_state.data.users.get_by_principal(&caller) {
         Ok(PrepareResult {
-            caller,
-            billing_account: runtime_state.user_billing_account(caller.into()),
+            user_id: user.user_id,
+            previous_balance: user.account_billing.account_balance(),
+            billing_account: runtime_state.user_billing_account(user.user_id),
         })
     } else {
         Err(UserNotFound)
     }
 }
 
-fn process_balance(caller: Principal, balance: ICP, runtime_state: &mut RuntimeState) -> Response {
-    if let Some(User::Created(user)) = runtime_state.data.users.get_by_principal(&caller) {
-        let user_id = user.user_id;
-        let previous_balance = user.account_billing.ledger_balance();
-
-        if balance > previous_balance {
-            let payment_amount = balance - previous_balance;
-            let account_credit = user.account_billing.credit() + payment_amount;
-            let now = runtime_state.env.now();
-            runtime_state.data.users.record_account_payment(
-                &user_id,
-                AccountPayment {
-                    amount: payment_amount,
-                    timestamp: now,
-                },
-            );
-            Success(SuccessResult { account_credit })
-        } else {
-            SuccessNoChange(SuccessResult {
-                account_credit: user.account_billing.credit(),
-            })
-        }
-    } else {
-        UserNotFound
+fn process_balance(user_id: UserId, previous_balance: ICP, new_balance: ICP, runtime_state: &mut RuntimeState) -> Response {
+    if new_balance > previous_balance {
+        let payment_amount = new_balance - previous_balance;
+        let now = runtime_state.env.now();
+        runtime_state.data.users.record_account_payment(
+            &user_id,
+            AccountPayment {
+                amount: payment_amount,
+                timestamp: now,
+            },
+        );
     }
+
+    Success(SuccessResult {
+        account_balance: new_balance,
+    })
 }

--- a/v2/backend/canisters/user_index/impl/src/updates/upgrade_storage.rs
+++ b/v2/backend/canisters/user_index/impl/src/updates/upgrade_storage.rs
@@ -1,94 +1,138 @@
 use crate::model::account_billing::{AccountCharge, AccountChargeDetails, StorageAccountChargeDetails};
-use crate::model::user::User;
-use crate::{mutate_state, RuntimeState};
-use candid::Principal;
+use crate::model::user::{CreatedUser, User};
+use crate::{mutate_state, read_state, RuntimeState};
 use canister_api_macros::trace;
 use ic_cdk_macros::update;
+use ic_ledger_types::{
+    AccountIdentifier, BlockIndex, Memo, TransferArgs, TransferError, DEFAULT_FEE, MAINNET_LEDGER_CANISTER_ID,
+};
+use ledger_utils::convert_to_subaccount;
 use open_storage_index_canister::add_or_update_users::UserConfig;
 use std::cmp::max;
 use types::ICP;
 use user_index_canister::upgrade_storage::{Response::*, *};
+use utils::consts::DEFAULT_MEMO;
 
 const FEE_PER_GB: ICP = ICP::from_e8s(ICP::SUBDIVIDABLE_BY); // 0.1 ICP
 const BYTES_PER_1GB: u64 = 1024 * 1024 * 1024;
 
 #[update]
 #[trace]
-fn upgrade_storage(args: Args) -> Response {
-    mutate_state(|state| upgrade_storage_impl(args, state))
+async fn upgrade_storage(args: Args) -> Response {
+    let PrepareResult {
+        user,
+        new_storage_limit_bytes,
+        charge_amount,
+        user_index_ledger_account,
+    } = match read_state(|state| prepare(args, state)) {
+        Ok(prepare_result) => prepare_result,
+        Err(response) => return response,
+    };
+
+    match ic_ledger_types::transfer(
+        MAINNET_LEDGER_CANISTER_ID,
+        TransferArgs {
+            memo: Memo(DEFAULT_MEMO),
+            amount: charge_amount - DEFAULT_FEE,
+            fee: DEFAULT_FEE,
+            from_subaccount: Some(convert_to_subaccount(&user.user_id.into())),
+            to: user_index_ledger_account,
+            created_at_time: None,
+        },
+    )
+    .await
+    {
+        Ok(Ok(block_index)) => {
+            mutate_state(|state| process_charge(user, new_storage_limit_bytes, charge_amount, block_index, state))
+        }
+        Ok(Err(transfer_error)) => process_error(transfer_error, charge_amount),
+        Err(error) => InternalError(format!("{error:?}")),
+    }
 }
 
-fn upgrade_storage_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
+struct PrepareResult {
+    user: CreatedUser,
+    new_storage_limit_bytes: u64,
+    charge_amount: ICP,
+    user_index_ledger_account: AccountIdentifier,
+}
+
+fn prepare(args: Args, runtime_state: &RuntimeState) -> Result<PrepareResult, Response> {
     let caller = runtime_state.env.caller();
+    let new_storage_limit_bytes = args.new_storage_limit_bytes;
+
     if let Some(User::Created(user)) = runtime_state.data.users.get_by_principal(&caller) {
-        if args.new_storage_limit_bytes > BYTES_PER_1GB {
-            return StorageLimitExceeded(BYTES_PER_1GB);
+        if new_storage_limit_bytes > BYTES_PER_1GB {
+            return Err(StorageLimitExceeded(BYTES_PER_1GB));
         }
 
-        let requested_storage_increase = args.new_storage_limit_bytes.saturating_sub(user.open_storage_limit_bytes);
+        let requested_storage_increase = new_storage_limit_bytes.saturating_sub(user.open_storage_limit_bytes);
         if requested_storage_increase > 0 {
             let charge_amount = calculate_charge(requested_storage_increase);
-            let account_credit = user.account_billing.credit();
+            let account_balance = user.account_billing.account_balance();
 
-            if account_credit == ICP::ZERO {
-                PaymentNotFound
+            if account_balance >= charge_amount {
+                Ok(PrepareResult {
+                    user: user.clone(),
+                    new_storage_limit_bytes,
+                    charge_amount,
+                    user_index_ledger_account: runtime_state.user_index_ledger_account(),
+                })
             } else {
-                match account_credit.e8s().checked_sub(charge_amount.e8s()).map(ICP::from_e8s) {
-                    Some(credit_remaining_after_charge) => mutate_state(|state| {
-                        process_charge(
-                            caller,
-                            args.new_storage_limit_bytes,
-                            charge_amount,
-                            credit_remaining_after_charge,
-                            state,
-                        )
-                    }),
-                    None => PaymentInsufficient(PaymentInsufficientResult {
-                        account_credit,
-                        amount_required: charge_amount,
-                    }),
-                }
+                Err(PaymentInsufficient(PaymentInsufficientResult {
+                    account_balance,
+                    amount_required: charge_amount,
+                }))
             }
         } else {
-            SuccessNoChange
+            Err(SuccessNoChange)
         }
     } else {
-        UserNotFound
+        Err(UserNotFound)
     }
 }
 
 fn process_charge(
-    caller: Principal,
+    user: CreatedUser,
     new_storage_limit_bytes: u64,
     charge_amount: ICP,
-    remaining_account_credit: ICP,
+    block_index: BlockIndex,
     runtime_state: &mut RuntimeState,
 ) -> Response {
-    if let Some(User::Created(user)) = runtime_state.data.users.get_by_principal(&caller) {
-        let user_id = user.user_id;
-        let now = runtime_state.env.now();
+    let now = runtime_state.env.now();
 
-        let charge = AccountCharge {
-            amount: charge_amount,
-            timestamp: now,
-            details: AccountChargeDetails::Storage(StorageAccountChargeDetails {
-                old_bytes_limit: user.open_storage_limit_bytes,
-                new_bytes_limit: new_storage_limit_bytes,
-            }),
-        };
+    let charge = AccountCharge {
+        amount: charge_amount,
+        timestamp: now,
+        block_index,
+        details: AccountChargeDetails::Storage(StorageAccountChargeDetails {
+            old_bytes_limit: user.open_storage_limit_bytes,
+            new_bytes_limit: new_storage_limit_bytes,
+        }),
+    };
 
-        runtime_state.data.users.record_account_charge(&user_id, charge);
-        runtime_state.data.users.set_storage_limit(&user_id, new_storage_limit_bytes);
-        runtime_state.data.open_storage_user_sync_queue.push(UserConfig {
-            user_id: caller,
-            byte_limit: new_storage_limit_bytes,
-        });
+    runtime_state.data.users.record_account_charge(&user.user_id, charge);
 
-        Success(SuccessResult {
-            remaining_account_credit,
-        })
-    } else {
-        UserNotFound
+    runtime_state
+        .data
+        .users
+        .set_storage_limit(&user.user_id, new_storage_limit_bytes);
+
+    runtime_state.data.open_storage_user_sync_queue.push(UserConfig {
+        user_id: user.principal,
+        byte_limit: new_storage_limit_bytes,
+    });
+
+    Success
+}
+
+fn process_error(transfer_error: TransferError, charge_amount: ICP) -> Response {
+    match transfer_error {
+        TransferError::InsufficientFunds { balance } => PaymentInsufficient(PaymentInsufficientResult {
+            account_balance: balance,
+            amount_required: charge_amount,
+        }),
+        error => InternalError(format!("{error:?}")),
     }
 }
 


### PR DESCRIPTION
This simplifies our charging model by transferring ICP from the user's account to the user_index's default account when charging a user. We then only proceed with the operation if the transfer completes.

This allows us to not have to worry about things such as double spending and any race conditions, since the ledger will handle all of that for us.