### PR TITLE
Add 'transaction_hash' to CompletedICPTransfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,11 +925,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1055,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -1148,7 +1149,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "serde",
- "sha2 0.10.1",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
@@ -1669,7 +1670,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
 dependencies = [
- "digest 0.10.2",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2133,6 +2134,9 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ic-ledger-types",
+ "serde",
+ "serde_cbor",
+ "sha2 0.10.2",
  "types",
  "utils",
 ]
@@ -3597,13 +3601,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.2",
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -59,7 +59,7 @@ async fn send_message(mut args: Args) -> Response {
                 if pending_transfer.recipient != args.recipient {
                     return InvalidRequest("Transfer recipient does not match message recipient".to_owned());
                 }
-                match send_icp(pending_transfer).await {
+                match send_icp(pending_transfer, now).await {
                     Ok(completed_transfer) => {
                         c.transfer = CryptocurrencyTransfer::ICP(ICPTransfer::Completed(completed_transfer))
                     }

--- a/backend/libraries/ledger_utils/Cargo.toml
+++ b/backend/libraries/ledger_utils/Cargo.toml
@@ -9,5 +9,8 @@ edition = "2021"
 [dependencies]
 candid = "0.7.10"
 ic-ledger-types = "0.1.1"
+serde = "1.0.126"
+serde_cbor = "0.11.2"
+sha2 = "0.10.2"
 types = { path = "../types" }
 utils = { path = "../utils" }

--- a/backend/libraries/ledger_utils/src/lib.rs
+++ b/backend/libraries/ledger_utils/src/lib.rs
@@ -1,5 +1,8 @@
-use candid::Principal;
-use ic_ledger_types::{AccountIdentifier, Subaccount, DEFAULT_SUBACCOUNT};
+use candid::{CandidType, Principal};
+use ic_ledger_types::{AccountIdentifier, Memo, Subaccount, Timestamp, Tokens, TransferArgs, DEFAULT_SUBACCOUNT};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use types::{TransactionHash, UserId};
 
 pub fn default_ledger_account(principal: Principal) -> AccountIdentifier {
     AccountIdentifier::new(&principal, &DEFAULT_SUBACCOUNT)
@@ -11,4 +14,53 @@ pub fn convert_to_subaccount(principal: &Principal) -> Subaccount {
     subaccount[0] = bytes.len().try_into().unwrap();
     subaccount[1..1 + bytes.len()].copy_from_slice(bytes);
     Subaccount(subaccount)
+}
+
+pub fn transaction_hash(sender: UserId, args: &TransferArgs) -> TransactionHash {
+    let from = default_ledger_account(sender.into());
+
+    let transaction = Transaction {
+        operation: Operation::Transfer {
+            from,
+            to: args.to,
+            amount: args.amount,
+            fee: args.fee,
+        },
+        memo: args.memo,
+        // 'args.created_at_time' must be set otherwise the hash won't match
+        created_at_time: args.created_at_time.unwrap(),
+    };
+
+    let mut state = Sha256::new();
+    state.update(&serde_cbor::ser::to_vec_packed(&transaction).unwrap());
+    state.finalize().into()
+}
+
+/// An operation which modifies account balances
+#[derive(Serialize, Deserialize, CandidType, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Operation {
+    Burn {
+        from: AccountIdentifier,
+        amount: Tokens,
+    },
+    Mint {
+        to: AccountIdentifier,
+        amount: Tokens,
+    },
+    Transfer {
+        from: AccountIdentifier,
+        to: AccountIdentifier,
+        amount: Tokens,
+        fee: Tokens,
+    },
+}
+
+/// An operation with the metadata the client generated attached to it
+#[derive(Serialize, Deserialize, CandidType, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Transaction {
+    pub operation: Operation,
+    pub memo: Memo,
+
+    /// The time this transaction was created.
+    pub created_at_time: Timestamp,
 }

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -11,6 +11,7 @@ type MessageIndex = nat32;
 type Milliseconds = nat64;
 type TimestampMillis = nat64;
 type TimestampNanos = nat64;
+type TransactionHash = blob;
 type UserId = CanisterId;
 
 type AddedToGroupNotification =
@@ -817,6 +818,7 @@ type CompletedICPTransfer =
         fee: ICP;
         memo: Memo;
         block_index: BlockIndex;
+        transaction_hash: TransactionHash;
     };
 
 type FailedICPTransfer =

--- a/backend/libraries/types/src/cryptocurrency.rs
+++ b/backend/libraries/types/src/cryptocurrency.rs
@@ -214,7 +214,14 @@ pub struct PendingICPTransfer {
 }
 
 impl PendingICPTransfer {
-    pub fn completed(&self, sender: UserId, fee: ICP, memo: Memo, block_index: BlockIndex) -> CompletedICPTransfer {
+    pub fn completed(
+        &self,
+        sender: UserId,
+        fee: ICP,
+        memo: Memo,
+        block_index: BlockIndex,
+        transaction_hash: TransactionHash,
+    ) -> CompletedICPTransfer {
         CompletedICPTransfer {
             sender,
             recipient: self.recipient,
@@ -222,6 +229,7 @@ impl PendingICPTransfer {
             fee,
             memo,
             block_index,
+            transaction_hash,
         }
     }
 
@@ -244,6 +252,7 @@ pub struct CompletedICPTransfer {
     pub fee: ICP,
     pub memo: Memo,
     pub block_index: BlockIndex,
+    pub transaction_hash: TransactionHash,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -254,3 +263,5 @@ pub struct FailedICPTransfer {
     pub memo: Memo,
     pub error_message: String,
 }
+
+pub type TransactionHash = [u8; 32];


### PR DESCRIPTION
This will allow us to add a link to each transaction which takes the user to the transaction details on the IC dashboard.

For example - https://dashboard.internetcomputer.org/transaction/d13a3919c6d6fc815ec8718df3ae3a6a1e0cfe9c51aeb8e9fe39fe3cfb78b799