### PR TITLE
Fix text on crypto transfer messages

### DIFF
--- a/frontend/src/components/home/CryptoContent.svelte
+++ b/frontend/src/components/home/CryptoContent.svelte
@@ -18,8 +18,8 @@
     export let groupChat: boolean;
 
     const user = getContext<CreatedUser>(currentUserKey);
-    let transferText = buildCryptoTransferText(user.userId, senderId, content, me);
-    let transactionLinkText = buildTransactionLink(content);
+    $: transferText = buildCryptoTransferText(user.userId, senderId, content, me);
+    $: transactionLinkText = buildTransactionLink(content);
 </script>
 
 {#if transferText !== undefined}

--- a/frontend/src/domain/chat/chat.utils.ts
+++ b/frontend/src/domain/chat/chat.utils.ts
@@ -1283,7 +1283,7 @@ export function buildCryptoTransferText(
     };
 
     const key =
-        content.transfer.kind !== "completed_icp_transfer"
+        content.transfer.kind === "completed_icp_transfer"
             ? "confirmedSent"
             : me
             ? "pendingSentByYou"


### PR DESCRIPTION
It looks like we can remove the `me` argument too but I'm not 100% sure.