### PR TITLE
forked usergeek lib to target es2020

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -9646,8 +9646,8 @@
             }
         },
         "usergeek-ic-js": {
-            "version": "github:usergeek/usergeek-ic-js#44df4ba2b05b18a01429f92482110ed6c5d4dfda",
-            "from": "github:usergeek/usergeek-ic-js",
+            "version": "github:julianjelfs/usergeek-ic-js#bcf4dffb3c1b884f06d34e353c693bae7552ad3d",
+            "from": "github:julianjelfs/usergeek-ic-js",
             "dev": true
         },
         "util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
         "svelte-preprocess": "^4.10.5",
         "tslib": "^2.3.1",
         "typescript": "^4.6.3",
-        "usergeek-ic-js": "github:usergeek/usergeek-ic-js",
+        "usergeek-ic-js": "github:julianjelfs/usergeek-ic-js",
         "util": "0.12.3"
     },
     "dependencies": {


### PR DESCRIPTION
This is not exactly ideal. But it's also not exactly ideal to be pulling directly from usergeek github either, so ...