### PR TITLE
fix caret position when selecting mentions and inline emojis

### DIFF
--- a/frontend/src/components/home/Footer.svelte
+++ b/frontend/src/components/home/Footer.svelte
@@ -62,7 +62,7 @@
     function onDataTransfer(data: DataTransfer): void {
         const text = data.getData("text/plain") || data.getData("text/uri-list");
         if (text) {
-            messageEntry.insertTextAtCaret(text);
+            messageEntry.replaceSelection(text);
         }
         messageContentFromDataTransferItemList([...data.items]);
     }
@@ -83,7 +83,7 @@
     }
 
     function emojiSelected(ev: CustomEvent<string>) {
-        messageEntry?.insertTextAtCaret(ev.detail);
+        messageEntry?.replaceSelection(ev.detail);
     }
 </script>
 

--- a/frontend/src/components/home/MessageEntry.svelte
+++ b/frontend/src/components/home/MessageEntry.svelte
@@ -4,7 +4,7 @@
     import Close from "svelte-material-icons/Close.svelte";
     import HoverIcon from "../HoverIcon.svelte";
     import AudioAttacher from "./AudioAttacher.svelte";
-    import { createEventDispatcher } from "svelte";
+    import { createEventDispatcher, tick } from "svelte";
     import { _ } from "svelte-i18n";
     import Progress from "../Progress.svelte";
     import { iconSize } from "../../stores/iconSize";
@@ -120,7 +120,7 @@
             ? $_("dropFile")
             : $_("enterMessage");
 
-    export function insertTextAtCaret(text: string) {
+    export function replaceSelection(text: string) {
         restoreSelection();
         let range = window.getSelection()?.getRangeAt(0);
         if (range !== undefined) {
@@ -365,6 +365,8 @@
     function replaceTextWith(replacement: string) {
         if (rangeToReplace === undefined) return;
 
+        const start = rangeToReplace[0];
+
         const replaced = `${inp.textContent?.slice(
             0,
             rangeToReplace[0]
@@ -372,7 +374,11 @@
         inp.textContent = replaced;
 
         dispatch("setTextContent", inp.textContent || undefined);
-        setCaretTo(rangeToReplace[0] + replacement.length);
+
+        tick().then(() => {
+            setCaretTo(start + replacement.length);
+        });
+
         rangeToReplace = undefined;
     }
 


### PR DESCRIPTION
As ever, it's a pretty unsatisfactory "fix" resorting to `tick` but I can't really figure out exactly what's going on and this does at least seem to fix the problem. 