### PR TITLE
Remove `Named` from `CryptoAccountFull`

### DIFF
--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -861,7 +861,6 @@ type CryptoAccountFull =
         Mint;
         User: record { UserId; AccountIdentifier };
         UserIndex: AccountIdentifier;
-        Named: record { text; AccountIdentifier };
         Unknown: AccountIdentifier;
     };
 

--- a/backend/libraries/types/src/cryptocurrency.rs
+++ b/backend/libraries/types/src/cryptocurrency.rs
@@ -89,7 +89,6 @@ pub enum CryptoAccountFull {
     Mint,
     User(UserId, AccountIdentifier),
     UserIndex(AccountIdentifier),
-    Named(String, AccountIdentifier),
     Unknown(AccountIdentifier),
 }
 
@@ -222,9 +221,7 @@ impl From<CryptoAccountFull> for CryptoAccount {
         match a {
             CryptoAccountFull::Mint => CryptoAccount::Mint,
             CryptoAccountFull::User(u, _) => CryptoAccount::User(u),
-            CryptoAccountFull::UserIndex(a) | CryptoAccountFull::Named(_, a) | CryptoAccountFull::Unknown(a) => {
-                CryptoAccount::Account(a)
-            }
+            CryptoAccountFull::UserIndex(a) | CryptoAccountFull::Unknown(a) => CryptoAccount::Account(a),
         }
     }
 }

--- a/frontend/src/services/group/candid/idl.js
+++ b/frontend/src/services/group/candid/idl.js
@@ -187,7 +187,6 @@ export const idlFactory = ({ IDL }) => {
   const AccountIdentifier = IDL.Vec(IDL.Nat8);
   const CryptoAccountFull = IDL.Variant({
     'UserIndex' : AccountIdentifier,
-    'Named' : IDL.Tuple(IDL.Text, AccountIdentifier),
     'Mint' : IDL.Null,
     'User' : IDL.Tuple(UserId, AccountIdentifier),
     'Unknown' : AccountIdentifier,

--- a/frontend/src/services/group/candid/types.ts
+++ b/frontend/src/services/group/candid/types.ts
@@ -162,7 +162,6 @@ export type CryptoAccount = { 'Mint' : null } |
   { 'User' : UserId } |
   { 'Account' : AccountIdentifier };
 export type CryptoAccountFull = { 'UserIndex' : AccountIdentifier } |
-  { 'Named' : [string, AccountIdentifier] } |
   { 'Mint' : null } |
   { 'User' : [UserId, AccountIdentifier] } |
   { 'Unknown' : AccountIdentifier };

--- a/frontend/src/services/groupIndex/candid/types.ts
+++ b/frontend/src/services/groupIndex/candid/types.ts
@@ -120,7 +120,6 @@ export type CryptoAccount = { 'Mint' : null } |
   { 'User' : UserId } |
   { 'Account' : AccountIdentifier };
 export type CryptoAccountFull = { 'UserIndex' : AccountIdentifier } |
-  { 'Named' : [string, AccountIdentifier] } |
   { 'Mint' : null } |
   { 'User' : [UserId, AccountIdentifier] } |
   { 'Unknown' : AccountIdentifier };

--- a/frontend/src/services/notifications/candid/notification.js
+++ b/frontend/src/services/notifications/candid/notification.js
@@ -136,7 +136,6 @@ export const Notification = IDL.Variant({
               'Failed' : IDL.Record({
                 'to' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -147,7 +146,6 @@ export const Notification = IDL.Variant({
                 'transaction_hash' : IDL.Vec(IDL.Nat8),
                 'from' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -159,7 +157,6 @@ export const Notification = IDL.Variant({
               'Completed' : IDL.Record({
                 'to' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -171,7 +168,6 @@ export const Notification = IDL.Variant({
                 'block_index' : IDL.Nat64,
                 'from' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -382,7 +378,6 @@ export const Notification = IDL.Variant({
               'Failed' : IDL.Record({
                 'to' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -393,7 +388,6 @@ export const Notification = IDL.Variant({
                 'transaction_hash' : IDL.Vec(IDL.Nat8),
                 'from' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -405,7 +399,6 @@ export const Notification = IDL.Variant({
               'Completed' : IDL.Record({
                 'to' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),
@@ -417,7 +410,6 @@ export const Notification = IDL.Variant({
                 'block_index' : IDL.Nat64,
                 'from' : IDL.Variant({
                   'UserIndex' : IDL.Vec(IDL.Nat8),
-                  'Named' : IDL.Tuple(IDL.Text, IDL.Vec(IDL.Nat8)),
                   'Mint' : IDL.Null,
                   'User' : IDL.Tuple(IDL.Principal, IDL.Vec(IDL.Nat8)),
                   'Unknown' : IDL.Vec(IDL.Nat8),

--- a/frontend/src/services/notifications/candid/types.ts
+++ b/frontend/src/services/notifications/candid/types.ts
@@ -120,7 +120,6 @@ export type CryptoAccount = { 'Mint' : null } |
   { 'User' : UserId } |
   { 'Account' : AccountIdentifier };
 export type CryptoAccountFull = { 'UserIndex' : AccountIdentifier } |
-  { 'Named' : [string, AccountIdentifier] } |
   { 'Mint' : null } |
   { 'User' : [UserId, AccountIdentifier] } |
   { 'Unknown' : AccountIdentifier };

--- a/frontend/src/services/user/candid/idl.js
+++ b/frontend/src/services/user/candid/idl.js
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
   const AccountIdentifier = IDL.Vec(IDL.Nat8);
   const CryptoAccountFull = IDL.Variant({
     'UserIndex' : AccountIdentifier,
-    'Named' : IDL.Tuple(IDL.Text, AccountIdentifier),
     'Mint' : IDL.Null,
     'User' : IDL.Tuple(UserId, AccountIdentifier),
     'Unknown' : AccountIdentifier,

--- a/frontend/src/services/user/candid/types.ts
+++ b/frontend/src/services/user/candid/types.ts
@@ -160,7 +160,6 @@ export type CryptoAccount = { 'Mint' : null } |
   { 'User' : UserId } |
   { 'Account' : AccountIdentifier };
 export type CryptoAccountFull = { 'UserIndex' : AccountIdentifier } |
-  { 'Named' : [string, AccountIdentifier] } |
   { 'Mint' : null } |
   { 'User' : [UserId, AccountIdentifier] } |
   { 'Unknown' : AccountIdentifier };

--- a/frontend/src/services/user/mappers.ts
+++ b/frontend/src/services/user/mappers.ts
@@ -907,10 +907,6 @@ function cryptoAccountFull(candid: ApiCryptoAccountFull): string {
     if ("Mint" in candid) {
         return "Minting Account";
     }
-    if ("Named" in candid) {
-        const [, accountIdentifier] = candid.Named;
-        return bytesToHexString(accountIdentifier);
-    }
     if ("Unknown" in candid) {
         return bytesToHexString(candid.Unknown);
     }

--- a/frontend/src/services/userIndex/candid/types.ts
+++ b/frontend/src/services/userIndex/candid/types.ts
@@ -142,7 +142,6 @@ export type CryptoAccount = { 'Mint' : null } |
   { 'User' : UserId } |
   { 'Account' : AccountIdentifier };
 export type CryptoAccountFull = { 'UserIndex' : AccountIdentifier } |
-  { 'Named' : [string, AccountIdentifier] } |
   { 'Mint' : null } |
   { 'User' : [UserId, AccountIdentifier] } |
   { 'Unknown' : AccountIdentifier };


### PR DESCRIPTION
The account names should be populated on the frontend so that events can be cached without caching old names.