### PR TITLE
Change `involvesMe` to `isFollowedByMe` + consolidate logic

### DIFF
--- a/frontend/src/components/home/ThreadSummary.svelte
+++ b/frontend/src/components/home/ThreadSummary.svelte
@@ -9,7 +9,7 @@
     import { userStore } from "../../stores/user";
     import { formatMessageDate } from "../../utils/date";
     import { messagesRead } from "../../stores/markRead";
-    import { threadsByChatStore } from "../../stores/chat";
+    import { threadsFollowedByMeStore } from "../../stores/chat";
     import { onDestroy } from "svelte";
 
     export let threadSummary: ThreadSummary;
@@ -20,10 +20,7 @@
     export let chatId: string;
     export let threadRootMessageIndex: number;
 
-    $: involvesMe =
-        $threadsByChatStore[chatId]?.find(
-            (t) => t.threadRootMessageIndex === threadRootMessageIndex
-        ) !== undefined;
+    $: isFollowedByMe = $threadsFollowedByMeStore[chatId]?.has(threadRootMessageIndex) ?? false;
 
     $: lastMessageIndex = threadSummary.numberOfReplies - 1; //using this as a surrogate for message index for now
 
@@ -45,7 +42,7 @@
 </script>
 
 <div class="thread-summary-wrapper" class:me class:indent>
-    {#if involvesMe && unreadCount > 0 && me}
+    {#if isFollowedByMe && unreadCount > 0 && me}
         <div
             in:pop={{ duration: 1500 }}
             title={$_("chatSummary.unread", { values: { count: unreadCount.toString() } })}
@@ -93,7 +90,7 @@
                 <div class:selected class="arrow">&#8595;</div></span>
         </div>
     </a>
-    {#if involvesMe && unreadCount > 0 && !me}
+    {#if isFollowedByMe && unreadCount > 0 && !me}
         <div
             in:pop={{ duration: 1500 }}
             title={$_("chatSummary.unread", { values: { count: unreadCount.toString() } })}

--- a/frontend/src/components/home/thread/Thread.svelte
+++ b/frontend/src/components/home/thread/Thread.svelte
@@ -73,6 +73,7 @@
     import { filterWebRtcMessage, parseWebRtcMessage } from "../../../domain/webrtc/rtcHandler";
     import { messagesRead } from "../../../stores/markRead";
     import { unconfirmed } from "../../../stores/unconfirmed";
+    import { threadsFollowedByMeStore } from "stores/chat";
 
     const FROM_BOTTOM_THRESHOLD = 600;
     const api = getContext<ServiceContainer>(apiKey);
@@ -116,7 +117,7 @@
                 events.set([]);
             }
         } else {
-            // we haven't changed the thread we are looking at, but the threads latest index has changed (i.e. an event has been added by someone else)
+            // we haven't changed the thread we are looking at, but the thread's latest index has changed (i.e. an event has been added by someone else)
             if (
                 thread !== undefined &&
                 thread.latestEventIndex !== previousRootEvent?.event.thread?.latestEventIndex
@@ -151,6 +152,7 @@
     $: preview = isPreviewing($chat);
     $: pollsAllowed = canCreatePolls($chat);
     $: unconfirmedKey = `${$chat.chatId}_${threadRootMessageIndex}`;
+    $: isFollowedByMe = $threadsFollowedByMeStore[$chat.chatId]?.has(threadRootMessageIndex) ?? false;
 
     const dispatch = createEventDispatcher();
 
@@ -193,7 +195,7 @@
                 }
             });
 
-            if (userIds.has(currentUser.userId)) {
+            if (isFollowedByMe) {
                 const lastLoadedMessageIdx = lastMessageIndex($events);
                 if (lastLoadedMessageIdx !== undefined) {
                     messagesRead.markThreadRead(

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -126,6 +126,17 @@ export const threadsByChatStore = derived([chatSummariesListStore], ([summaries]
     }, {} as Record<string, ThreadSyncDetails[]>);
 });
 
+export const threadsFollowedByMeStore = derived([threadsByChatStore], ([threadsByChat]) => {
+    return Object.entries(threadsByChat).reduce<Record<string, Set<number>>>((result, [chatId, threads]) => {
+        const set = new Set<number>();
+        for (const thread of threads) {
+            set.add(thread.threadRootMessageIndex)
+        }
+        result[chatId] = set;
+        return result;
+    }, {});
+});
+
 export const proposalTopicsStore = derived(
     [selectedChatStore, snsFunctions],
     ([selectedChat, snsFunctions]): Map<number, string> => {


### PR DESCRIPTION
This ensures the logic which determines whether or not to show the unread count and whether or not to mark a thread as read is exactly the same.

Also, using the term 'followed' is better because in the future we can allow users to follow/unfollow threads regardless of if they are involved in them or not.