### PR TITLE
Revert "Temp hack! Expose canisterIds of deleted groups (#2320)"

### DIFF
--- a/backend/canisters/group_index/impl/src/lib.rs
+++ b/backend/canisters/group_index/impl/src/lib.rs
@@ -74,7 +74,6 @@ impl RuntimeState {
             canister_upgrades_in_progress: canister_upgrades_metrics.in_progress as u64,
             group_wasm_version: self.data.group_canister_wasm.version,
             max_concurrent_canister_upgrades: self.data.max_concurrent_canister_upgrades,
-            deleted_groups: self.data.cached_metrics.deleted_groups.clone(),
         }
     }
 }
@@ -145,7 +144,6 @@ impl Data {
             deleted_public_groups: deleted_group_metrics.public,
             deleted_private_groups: deleted_group_metrics.private,
             group_deleted_notifications_pending: deleted_group_metrics.notifications_pending,
-            deleted_groups: deleted_group_metrics.chat_ids,
             ..Default::default()
         };
 
@@ -210,7 +208,6 @@ pub struct Metrics {
     pub canister_upgrades_in_progress: u64,
     pub group_wasm_version: Version,
     pub max_concurrent_canister_upgrades: usize,
-    pub deleted_groups: Vec<(ChatId, TimestampMillis)>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug, Default)]
@@ -221,5 +218,4 @@ pub struct CachedMetrics {
     pub deleted_public_groups: u64,
     pub deleted_private_groups: u64,
     pub group_deleted_notifications_pending: u64,
-    pub deleted_groups: Vec<(ChatId, TimestampMillis)>,
 }

--- a/backend/canisters/group_index/impl/src/model/deleted_groups.rs
+++ b/backend/canisters/group_index/impl/src/model/deleted_groups.rs
@@ -2,7 +2,7 @@ use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, VecDeque};
-use types::{ChatId, DeletedGroupInfo, TimestampMillis, UserId};
+use types::{ChatId, DeletedGroupInfo, UserId};
 
 #[derive(CandidType, Serialize, Deserialize, Default)]
 pub struct DeletedGroups {
@@ -52,7 +52,6 @@ impl DeletedGroups {
             public,
             private,
             notifications_pending: self.pending_group_deleted_notifications.len() as u64,
-            chat_ids: self.groups.values().map(|g| (g.id, g.timestamp)).collect(),
         }
     }
 }
@@ -61,5 +60,4 @@ pub struct Metrics {
     pub public: u64,
     pub private: u64,
     pub notifications_pending: u64,
-    pub chat_ids: Vec<(ChatId, TimestampMillis)>,
 }


### PR DESCRIPTION
This reverts commit cd05916fc2979024c25694b49feab4d94109b011.