### PR TITLE
Fix missing reactions

### DIFF
--- a/frontend/src/domain/chat/chat.utils.ts
+++ b/frontend/src/domain/chat/chat.utils.ts
@@ -961,27 +961,6 @@ export function containsReaction(userId: string, reaction: string, reactions: Re
     return r ? r.userIds.has(userId) : false;
 }
 
-function mergeMessageEvents(
-    existing: EventWrapper<ChatEvent>,
-    incoming: EventWrapper<ChatEvent>
-): EventWrapper<ChatEvent> {
-    if (
-        existing.event.kind === "message" &&
-        incoming.event.kind === "message" &&
-        existing.event.messageId === incoming.event.messageId
-    ) {
-        return {
-            ...existing,
-            event: {
-                ...existing.event,
-                content: incoming.event.content,
-                thread: incoming.event.thread,
-            },
-        };
-    }
-    return existing;
-}
-
 function partitionEvents(
     events: EventWrapper<ChatEvent>[]
 ): [Record<string, EventWrapper<ChatEvent>>, EventWrapper<ChatEvent>[]] {
@@ -1076,7 +1055,7 @@ export function replaceAffected(
     return events.map((event) => {
         const affectedEvent = affectedEventsLookup[event.index];
         if (affectedEvent !== undefined) {
-            return mergeMessageEvents(event, affectedEvent);
+            return affectedEvent;
         } else if (event.event.kind === "message" && event.event.repliesTo !== undefined) {
             const repliesTo = event.event.repliesTo.eventIndex;
             const affectedReplyContent = affectedEventsLookup[repliesTo];


### PR DESCRIPTION
We used to do [this](https://github.com/dfinity-lab/open-chat/blob/03a0a04be1b818b58385343ecd83e46964ffca4a/frontend/src/domain/chat/chat.utils.ts#L937), but I removed it when local reactions were split out of the events list.

But that wasn't correct because we should still overwrite the local version if more up to date server events are returned as 'affected events'.

And now that we apply the local updates separately we can simply return the affected event from the server as is and the local updates will still take effect.