### PR TITLE
Fix bug where all unconfirmed messages would get the same event index

### DIFF
--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -75,13 +75,12 @@
         currentChatUserIds,
         focusMessageIndex,
         currentChatEditingEvent,
-        nextEventIndex,
-        nextMessageIndex,
         currentChatReplyingTo,
         chatUpdatedStore,
         userGroupKeys,
         currentChatPinnedMessages,
         chatStateStore,
+        nextEventAndMessageIndexes,
     } from "../../stores/chat";
     import {
         FilteredProposals,
@@ -768,14 +767,16 @@
                 return;
             }
 
+            const [nextEventIndex, nextMessageIndex] = nextEventAndMessageIndexes();
+
             const msg = createMessage(
                 user.userId,
-                $nextMessageIndex,
+                nextMessageIndex,
                 textContent,
                 $currentChatReplyingTo,
                 fileToAttach
             );
-            const event = { event: msg, index: $nextEventIndex, timestamp: BigInt(Date.now()) };
+            const event = { event: msg, index: nextEventIndex, timestamp: BigInt(Date.now()) };
 
             sendMessageWithAttachment(api, user, serverChat, chat, events, event, mentioned).then(
                 afterSendMessage
@@ -802,10 +803,12 @@
             content.caption = "";
         }
 
+        const [nextEventIndex, nextMessageIndex] = nextEventAndMessageIndexes();
+
         msg = {
             kind: "message",
             messageId: newMessageId(),
-            messageIndex: $nextMessageIndex,
+            messageIndex: nextMessageIndex,
             sender: user.userId,
             content,
             repliesTo: undefined,
@@ -813,7 +816,7 @@
             edited: false,
             forwarded: msg.content.kind !== "giphy_content",
         };
-        const event = { event: msg, index: $nextEventIndex, timestamp: BigInt(Date.now()) };
+        const event = { event: msg, index: nextEventIndex, timestamp: BigInt(Date.now()) };
 
         forwardMessage(api, user, serverChat, chat, events, event).then(afterSendMessage);
     }

--- a/frontend/src/domain/chat/chat.utils.ts
+++ b/frontend/src/domain/chat/chat.utils.ts
@@ -842,32 +842,22 @@ export function groupMessagesByDate(events: EventWrapper<Message>[]): EventWrapp
     return groupWhile(sameDate, events.filter(eventIsVisible));
 }
 
-export function getNextMessageIndex(
+export function getNextEventAndMessageIndexes(
     chat: ChatSummary,
     unconfirmedMessages: EventWrapper<Message>[]
-): number {
-    let current = chat.latestMessage?.event.messageIndex ?? -1;
+): [number, number] {
+    let eventIndex = chat.latestEventIndex;
+    let messageIndex = chat.latestMessage?.event.messageIndex ?? -1;
     if (unconfirmedMessages.length > 0) {
-        const messageIndex = unconfirmedMessages[unconfirmedMessages.length - 1].event.messageIndex;
-        if (messageIndex > current) {
-            current = messageIndex;
+        const lastUnconfirmed = unconfirmedMessages[unconfirmedMessages.length - 1];
+        if (lastUnconfirmed.index > eventIndex) {
+            eventIndex = lastUnconfirmed.index;
+        }
+        if (lastUnconfirmed.event.messageIndex > messageIndex) {
+            messageIndex = lastUnconfirmed.event.messageIndex;
         }
     }
-    return current + 1;
-}
-
-export function getNextEventIndex(
-    chat: ChatSummary,
-    unconfirmedMessages: EventWrapper<Message>[]
-): number {
-    let current = chat.latestEventIndex;
-    if (unconfirmedMessages.length > 0) {
-        const eventIndex = unconfirmedMessages[unconfirmedMessages.length - 1].index;
-        if (eventIndex > current) {
-            current = eventIndex;
-        }
-    }
-    return current + 1;
+    return [eventIndex + 1, messageIndex + 1];
 }
 
 export function latestLoadedMessageIndex(events: EventWrapper<ChatEvent>[]): number | undefined {

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -17,8 +17,7 @@ import {
     getContentAsText,
     getFirstUnreadMention,
     getFirstUnreadMessageIndex,
-    getNextEventIndex,
-    getNextMessageIndex,
+    getNextEventAndMessageIndexes,
     mergeServerEvents,
     mergeServerEventsWithLocalUpdates,
     mergeUnconfirmedIntoSummary,
@@ -149,21 +148,16 @@ export const selectedChatStore = derived(
     }
 );
 
-export const nextMessageIndex = derived([selectedServerChatStore, unconfirmed], ([$selectedServerChatStore, $unconfirmed]) => {
-    if ($selectedServerChatStore === undefined) return 0;
-    return getNextMessageIndex(
-        $selectedServerChatStore,
-        $unconfirmed[$selectedServerChatStore.chatId]?.messages ?? []
+export function nextEventAndMessageIndexes(): [number, number] {
+    const chat = get(selectedServerChatStore);
+    if (chat === undefined) {
+        return [0, 0];
+    }
+    return getNextEventAndMessageIndexes(
+        chat,
+        unconfirmed.getMessages(chat.chatId)
     );
-});
-
-export const nextEventIndex = derived([selectedServerChatStore, unconfirmed], ([$selectedServerChatStore, $unconfirmed]) => {
-    if ($selectedServerChatStore === undefined) return 0;
-    return getNextEventIndex(
-        $selectedServerChatStore,
-        $unconfirmed[$selectedServerChatStore.chatId]?.messages ?? []
-    );
-});
+}
 
 export const isProposalGroup = derived([selectedChatStore], ([$selectedChat]) => {
     return (


### PR DESCRIPTION
This fixes the issue... but I feel like these indexes should be calculated on demand by a normal function rather than via a derived store.