### PR TITLE
95% fix for legacy routes

### DIFF
--- a/frontend/app/src/components/Router.svelte
+++ b/frontend/app/src/components/Router.svelte
@@ -181,6 +181,17 @@
             track,
             () => (route = Home)
         );
+        // legacy route
+        page(
+            "/:chatId/:messageIndex?/:threadMessageIndex?",
+            parsePathParams(
+                globalGroupChatSelectedRoute(
+                    $communitiesEnabled ? { kind: "group_chat" } : { kind: "none" }
+                )
+            ),
+            track,
+            () => (route = Home)
+        );
         page(
             "*",
             parsePathParams(() => ({ kind: "not_found_route" })),


### PR DESCRIPTION
it will assume that all legacy routes are group chats which is a lot better than nothing and probably accounts for the vast majority. I might try to do something that addresses direct chats separately. 