### PR TITLE
break out of retry loop on DestinationInvalid

### DIFF
--- a/frontend/openchat-agent/src/services/candidService.ts
+++ b/frontend/openchat-agent/src/services/candidService.ts
@@ -1,7 +1,7 @@
 import { Actor, HttpAgent, Identity } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
-import { AuthError, SessionExpiryError } from "openchat-shared";
+import { AuthError, DestinationInvalidError, SessionExpiryError } from "openchat-shared";
 import type { AgentConfig } from "../config";
 import { ReplicaNotUpToDateError, toCanisterResponseError } from "./error";
 
@@ -61,6 +61,7 @@ export abstract class CandidService {
                 )}, args: ${JSON.stringify(args)}`;
                 if (
                     !(responseErr instanceof SessionExpiryError) &&
+                    !(responseErr instanceof DestinationInvalidError) &&
                     !(responseErr instanceof AuthError) &&
                     retries < MAX_RETRIES
                 ) {

--- a/frontend/openchat-agent/src/services/error.ts
+++ b/frontend/openchat-agent/src/services/error.ts
@@ -4,6 +4,7 @@ import {
     HttpError,
     SessionExpiryError,
     AuthError,
+    DestinationInvalidError,
 } from "openchat-shared";
 
 export class ReplicaNotUpToDateError extends Error {
@@ -40,6 +41,11 @@ export function toCanisterResponseError(
     }
 
     let code = 500;
+
+    if (error.message.includes("DestinationInvalid")) {
+        // this will allow us to short-circuit the retry mechanism in this circumstance
+        return new DestinationInvalidError(error);
+    }
 
     const statusLine = error.message
         .split("\n")

--- a/frontend/openchat-shared/src/domain/error.ts
+++ b/frontend/openchat-shared/src/domain/error.ts
@@ -25,3 +25,10 @@ export class SessionExpiryError extends HttpError {
         this.name = "SessionExpiryError";
     }
 }
+
+export class DestinationInvalidError extends HttpError {
+    constructor(error: Error) {
+        super(404, error);
+        this.name = "DestinationInvalidError";
+    }
+}


### PR DESCRIPTION
We might get DestinationInvalid if a group has been delete for example. In this case there is no point in retrying, it's better to fail fast. 