### PR TITLE
Bugs

### DIFF
--- a/frontend/app/src/components/home/ChatList.svelte
+++ b/frontend/app/src/components/home/ChatList.svelte
@@ -63,7 +63,9 @@
     $: user = $userStore[createdUser.userId];
     $: lowercaseSearch = searchTerm.toLowerCase();
     $: showWhatsHot =
-        $chatListScope.kind === "none" && !$discoverHotGroupsDismissed && !searchResultsAvailable;
+        ($chatListScope.kind === "none" || $chatListScope.kind === "group_chat") &&
+        !$discoverHotGroupsDismissed &&
+        !searchResultsAvailable;
     $: showBrowseChannnels = $chatListScope.kind === "community" && !searchResultsAvailable;
     $: unreadDirectChats = client.unreadDirectChats;
     $: unreadGroupChats = client.unreadGroupChats;

--- a/frontend/app/src/components/home/ChatList.svelte
+++ b/frontend/app/src/components/home/ChatList.svelte
@@ -29,7 +29,7 @@
     import { mobileWidth } from "../../stores/screenDimensions";
     import { discoverHotGroupsDismissed } from "../../stores/settings";
     import { communitiesEnabled } from "../../utils/features";
-    import { pushRightPanelHistory } from "../../stores/rightPanel";
+    import { pushRightPanelHistory, rightPanelHistory } from "../../stores/rightPanel";
     import GroupChatsHeader from "./communities/GroupChatsHeader.svelte";
     import DirectChatsHeader from "./communities/DirectChatsHeader.svelte";
     import FavouriteChatsHeader from "./communities/FavouriteChatsHeader.svelte";
@@ -191,9 +191,11 @@
 
     function showChannels() {
         if ($chatListScope.kind === "community") {
-            pushRightPanelHistory({
-                kind: "community_channels",
-            });
+            rightPanelHistory.set([
+                {
+                    kind: "community_channels",
+                },
+            ]);
         }
     }
 </script>

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -9,7 +9,6 @@
     import RightPanel from "./RightPanel.svelte";
     import EditCommunity from "./communities/edit/Edit.svelte";
     import {
-        MessageMatch,
         ChatSummary,
         EnhancedReplyContext,
         AccessRules,
@@ -777,7 +776,7 @@
             name: "",
             description: "",
             historyVisible: true,
-            public: true,
+            public: false,
             frozen: false,
             members: [],
             permissions: {

--- a/frontend/app/src/components/home/communities/CommunityMenu.svelte
+++ b/frontend/app/src/components/home/communities/CommunityMenu.svelte
@@ -16,7 +16,7 @@
     import MenuItem from "../../MenuItem.svelte";
     import type { CommunitySummary, OpenChat } from "openchat-client";
     import { createEventDispatcher, getContext } from "svelte";
-    import { pushRightPanelHistory } from "../../../stores/rightPanel";
+    import { rightPanelHistory } from "../../../stores/rightPanel";
 
     const client = getContext<OpenChat>("client");
 
@@ -58,15 +58,17 @@
     }
 
     function showMembers() {
-        pushRightPanelHistory({ kind: "show_community_members" });
+        rightPanelHistory.set([{ kind: "show_community_members" }]);
     }
     function invite() {
-        canInvite && pushRightPanelHistory({ kind: "invite_community_users" });
+        canInvite && rightPanelHistory.set([{ kind: "invite_community_users" }]);
     }
     function showChannels() {
-        pushRightPanelHistory({
-            kind: "community_channels",
-        });
+        rightPanelHistory.set([
+            {
+                kind: "community_channels",
+            },
+        ]);
     }
 
     function editCommunity() {

--- a/frontend/app/src/components/home/nav/LeftNav.svelte
+++ b/frontend/app/src/components/home/nav/LeftNav.svelte
@@ -32,6 +32,7 @@
     $: unreadGroupChats = client.unreadGroupChats;
     $: unreadFavouriteChats = client.unreadFavouriteChats;
     $: unreadCommunityChannels = client.unreadCommunityChannels;
+    $: communityExplorer = $pathParams.kind === "communities_route";
 
     let iconSize = $mobileWidth ? "1.2em" : "1.4em"; // in this case we don't want to use the standard store
 
@@ -96,7 +97,7 @@
         {/if}
 
         <LeftNavItem
-            selected={$chatListScope.kind === "direct_chat"}
+            selected={$chatListScope.kind === "direct_chat" && !communityExplorer}
             label={$_("communities.directChats")}
             unread={$unreadDirectChats}
             on:click={directChats}>
@@ -106,7 +107,7 @@
         </LeftNavItem>
 
         <LeftNavItem
-            selected={$chatListScope.kind === "group_chat"}
+            selected={$chatListScope.kind === "group_chat" && !communityExplorer}
             label={$_("communities.groupChats")}
             unread={$unreadGroupChats}
             on:click={groupChats}>
@@ -116,7 +117,7 @@
         </LeftNavItem>
 
         <LeftNavItem
-            selected={$chatListScope.kind === "favourite"}
+            selected={$chatListScope.kind === "favourite" && !communityExplorer}
             separator
             label={$_("communities.favourites")}
             unread={$unreadFavouriteChats}
@@ -130,13 +131,16 @@
     <div class="middle">
         {#each $communities as community, i}
             <LeftNavItem
-                selected={community === $selectedCommunity && $chatListScope.kind !== "favourite"}
+                selected={community === $selectedCommunity &&
+                    $chatListScope.kind !== "favourite" &&
+                    !communityExplorer}
                 unread={$unreadCommunityChannels.get(community.id) ?? 0}
                 label={community.name}
                 on:click={() => selectCommunity(community)}>
                 <Avatar
                     selected={community === $selectedCommunity &&
-                        $chatListScope.kind !== "favourite"}
+                        $chatListScope.kind !== "favourite" &&
+                        !communityExplorer}
                     url={client.communityAvatarUrl(community.avatar)}
                     size={avatarSize} />
             </LeftNavItem>
@@ -145,7 +149,7 @@
 
     <div class="bottom">
         <LeftNavItem
-            selected={$pathParams.kind === "communities_route"}
+            selected={communityExplorer}
             label={"Explore communities"}
             on:click={exploreCommunities}>
             <div class="explore hover">

--- a/frontend/app/src/components/home/nav/MainMenu.svelte
+++ b/frontend/app/src/components/home/nav/MainMenu.svelte
@@ -24,17 +24,17 @@
 </script>
 
 <Menu>
-    <MenuItem on:click={() => dispatch("halloffame")}>
-        <span class="halloffame" slot="icon">👑</span>
-        <span slot="text">{$_("halloffame.menu")}</span>
+    <MenuItem on:click={() => dispatch("wallet")}>
+        <Wallet size={$iconSize} color={"var(--icon-inverted-txt)"} slot="icon" />
+        <span slot="text">{$_("wallet")}</span>
     </MenuItem>
     <MenuItem on:click={() => dispatch("upgrade")}>
         <span class="diamond-icon" slot="icon">💎</span>
         <span slot="text">{$canExtendDiamond ? $_("upgrade.extend") : $_("upgrade.diamond")}</span>
     </MenuItem>
-    <MenuItem on:click={() => dispatch("wallet")}>
-        <Wallet size={$iconSize} color={"var(--icon-inverted-txt)"} slot="icon" />
-        <span slot="text">{$_("wallet")}</span>
+    <MenuItem on:click={() => dispatch("halloffame")}>
+        <span class="halloffame" slot="icon">👑</span>
+        <span slot="text">{$_("halloffame.menu")}</span>
     </MenuItem>
     <MenuItem separator />
     <MenuItem on:click={() => page("/home")}>

--- a/frontend/app/src/components/home/profile/UserProfile.svelte
+++ b/frontend/app/src/components/home/profile/UserProfile.svelte
@@ -147,7 +147,7 @@
     }
 
     function userAvatarSelected(ev: CustomEvent<{ url: string; data: Uint8Array }>): void {
-        client.setUserAvatar(ev.detail.data).then((success) => {
+        client.setUserAvatar(ev.detail.data, ev.detail.url).then((success) => {
             if (success) {
                 toastStore.showSuccessToast("avatarUpdated");
             } else {

--- a/frontend/app/src/components/home/profile/UserProfile.svelte
+++ b/frontend/app/src/components/home/profile/UserProfile.svelte
@@ -148,9 +148,7 @@
 
     function userAvatarSelected(ev: CustomEvent<{ url: string; data: Uint8Array }>): void {
         client.setUserAvatar(ev.detail.data, ev.detail.url).then((success) => {
-            if (success) {
-                toastStore.showSuccessToast("avatarUpdated");
-            } else {
+            if (!success) {
                 toastStore.showFailureToast("avatarUpdateFailed");
             }
         });

--- a/frontend/app/src/routes.ts
+++ b/frontend/app/src/routes.ts
@@ -28,7 +28,6 @@ function qs(ctx: PageJS.Context): URLSearchParams {
 export function communitesRoute(_ctx: PageJS.Context): RouteParams {
     return {
         kind: "communities_route",
-        scope: { kind: "none" },
     };
 }
 
@@ -286,7 +285,7 @@ export type SelectedChannelRoute = RouteCommon & {
     open: boolean;
 };
 
-export type CommunitiesRoute = RouteCommon & {
+export type CommunitiesRoute = {
     kind: "communities_route";
 };
 

--- a/frontend/openchat-agent/src/services/common/chatMappers.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappers.ts
@@ -155,6 +155,7 @@ import {
     ResetInviteCodeResponse,
     KinicGovernanceCanisterId,
     HotOrNotGovernanceCanisterId,
+    ThreadSyncDetails,
 } from "openchat-shared";
 import type { WithdrawCryptoArgs } from "../user/candid/types";
 import type {
@@ -1546,11 +1547,21 @@ export function communityChannelSummary(
             myMetrics:
                 optional(candid.membership, (m) => chatMetrics(m.my_metrics)) ?? emptyChatMetrics(),
             readByMeUpTo: latestMessage?.event.messageIndex,
-            latestThreads: [],
+            latestThreads:
+                optional(candid.membership, (m) => m.latest_threads.map(threadSyncDetails)) ?? [],
             mentions: [],
             archived: false,
         },
         isDefault: candid.is_default,
+    };
+}
+
+export function threadSyncDetails(candid: ApiGroupCanisterThreadDetails): ThreadSyncDetails {
+    return {
+        threadRootMessageIndex: candid.root_message_index,
+        lastUpdated: candid.last_updated,
+        latestEventIndex: candid.latest_event,
+        latestMessageIndex: candid.latest_message,
     };
 }
 

--- a/frontend/openchat-agent/src/services/community/candid/idl.d.ts
+++ b/frontend/openchat-agent/src/services/community/candid/idl.d.ts
@@ -66,6 +66,7 @@ import {
     RegisterPollVoteResponse,
     ImportGroupResponse,
     ManageDefaultChannelsResponse,
+    GroupCanisterThreadDetails,
 } from "./types";
 export {
     _SERVICE as CommunityService,
@@ -134,6 +135,7 @@ export {
     RegisterPollVoteResponse as ApiRegisterPollVoteResponse,
     ImportGroupResponse as ApiImportGroupResponse,
     ManageDefaultChannelsResponse as ApiManageDefaultChannelsResponse,
+    GroupCanisterThreadDetails as ApiGroupCanisterThreadDetails,
 };
 
 export const idlFactory: IDL.InterfaceFactory;

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -2032,12 +2032,20 @@ export class OpenChatAgent extends EventTarget {
         }
     }
 
-    pinChat(chatId: ChatIdentifier, communitiesEnabled: boolean): Promise<PinChatResponse> {
-        return this.userClient.pinChat(chatId, communitiesEnabled);
+    pinChat(
+        chatId: ChatIdentifier,
+        communitiesEnabled: boolean,
+        favourite: boolean
+    ): Promise<PinChatResponse> {
+        return this.userClient.pinChat(chatId, communitiesEnabled, favourite);
     }
 
-    unpinChat(chatId: ChatIdentifier, communitiesEnabled: boolean): Promise<UnpinChatResponse> {
-        return this.userClient.unpinChat(chatId, communitiesEnabled);
+    unpinChat(
+        chatId: ChatIdentifier,
+        communitiesEnabled: boolean,
+        favourite: boolean
+    ): Promise<UnpinChatResponse> {
+        return this.userClient.unpinChat(chatId, communitiesEnabled, favourite);
     }
 
     archiveChat(chatId: ChatIdentifier): Promise<ArchiveChatResponse> {
@@ -2364,7 +2372,7 @@ export class OpenChatAgent extends EventTarget {
         if (updates.kind === "success" && updates.tokenDetails !== undefined) {
             const updated = {
                 lastUpdated: updates.lastUpdated,
-                tokenDetails: updates.tokenDetails
+                tokenDetails: updates.tokenDetails,
             };
             setRegistry(updated);
             return updated;

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -933,17 +933,13 @@ export class OpenChat extends OpenChatAgentWorker {
             });
     }
 
-    setUserAvatar(data: Uint8Array): Promise<boolean> {
-        this.user = {
-            ...this.user,
-            ...data,
-        };
-
+    setUserAvatar(data: Uint8Array, url: string): Promise<boolean> {
         const partialUser = this._liveState.userStore[this.user.userId];
         if (partialUser) {
             userStore.add({
                 ...partialUser,
-                ...data,
+                blobData: data,
+                blobUrl: url,
             });
         }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -833,8 +833,7 @@ export class OpenChat extends OpenChatAgentWorker {
             });
     }
 
-    private pinLocally(chatId: ChatIdentifier): void {
-        const scope = this._liveState.chatListScope.kind;
+    private pinLocally(chatId: ChatIdentifier, scope: ChatListScope["kind"]): void {
         globalStateStore.update((state) => {
             const ids = state.pinnedChats[scope];
             if (!ids.find((id) => chatIdentifiersEqual(id, chatId))) {
@@ -850,8 +849,7 @@ export class OpenChat extends OpenChatAgentWorker {
         });
     }
 
-    private unpinLocally(chatId: ChatIdentifier): void {
-        const scope = this._liveState.chatListScope.kind;
+    private unpinLocally(chatId: ChatIdentifier, scope: ChatListScope["kind"]): void {
         globalStateStore.update((state) => {
             const ids = state.pinnedChats[scope];
             const index = ids.findIndex((id) => chatIdentifiersEqual(id, chatId));
@@ -876,23 +874,35 @@ export class OpenChat extends OpenChatAgentWorker {
     }
 
     pinChat(chatId: ChatIdentifier): Promise<boolean> {
-        this.pinLocally(chatId);
-        return this.sendRequest({ kind: "pinChat", chatId, communitiesEnabled })
+        const scope = this._liveState.chatListScope.kind;
+        this.pinLocally(chatId, scope);
+        return this.sendRequest({
+            kind: "pinChat",
+            chatId,
+            communitiesEnabled,
+            favourite: scope === "favourite",
+        })
             .then((resp) => resp === "success")
             .catch((err) => {
                 this._logger.error("Error pinning chat", err);
-                this.unpinLocally(chatId);
+                this.unpinLocally(chatId, scope);
                 return false;
             });
     }
 
     unpinChat(chatId: ChatIdentifier): Promise<boolean> {
-        this.unpinLocally(chatId);
-        return this.sendRequest({ kind: "unpinChat", chatId, communitiesEnabled })
+        const scope = this._liveState.chatListScope.kind;
+        this.unpinLocally(chatId, scope);
+        return this.sendRequest({
+            kind: "unpinChat",
+            chatId,
+            communitiesEnabled,
+            favourite: scope === "favourite",
+        })
             .then((resp) => resp === "success")
             .catch((err) => {
                 this._logger.error("Error unpinning chat", err);
-                this.pinLocally(chatId);
+                this.pinLocally(chatId, scope);
                 return false;
             });
     }

--- a/frontend/openchat-shared/src/domain/worker.ts
+++ b/frontend/openchat-shared/src/domain/worker.ts
@@ -674,12 +674,14 @@ type BlockUserFromDirectChat = {
 type UnpinChat = {
     chatId: ChatIdentifier;
     communitiesEnabled: boolean;
+    favourite: boolean;
     kind: "unpinChat";
 };
 
 type PinChat = {
     chatId: ChatIdentifier;
     communitiesEnabled: boolean;
+    favourite: boolean;
     kind: "pinChat";
 };
 

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -444,7 +444,7 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
 
             case "pinChat":
                 agent
-                    .pinChat(payload.chatId, payload.communitiesEnabled)
+                    .pinChat(payload.chatId, payload.communitiesEnabled, payload.favourite)
                     .then((response) =>
                         sendResponse(correlationId, {
                             response,
@@ -455,7 +455,7 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
 
             case "unpinChat":
                 agent
-                    .unpinChat(payload.chatId, payload.communitiesEnabled)
+                    .unpinChat(payload.chatId, payload.communitiesEnabled, payload.favourite)
                     .then((response) =>
                         sendResponse(correlationId, {
                             response,


### PR DESCRIPTION
* New groups should default to private
* Toast to tell me Avatar successfully updated. Is that necessary? Surely failure toast is enough? And why does the avatar not immediately change on the FE? 
* "Top referrers" shouldn't be the first item in the main menu
* Pinning a favourite actually pins it in the main context list
* hot groups button not showing at bottom of groups chat list
* Clicking "browse channels" multiple times keeps adding it to the right panel history
* If you explore communities the Favourites icon is selected too