### PR TITLE
prevent ios problems with clicks inside hoverables

### DIFF
--- a/frontend/app/src/components/Button.svelte
+++ b/frontend/app/src/components/Button.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    import { isTouchDevice } from "../utils/devices";
+
     export let cls = "";
     export let loading: boolean = false;
     export let disabled: boolean = false;
@@ -9,10 +12,25 @@
     export let hollow: boolean = false;
     export let title: string | undefined = undefined;
     export let square: boolean = false;
+
+    const dispatch = createEventDispatcher();
+
+    function click(ev: MouseEvent) {
+        if (!isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
+
+    function touchstart(ev: TouchEvent) {
+        if (isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
 </script>
 
 <button
-    on:click|stopPropagation
+    on:click|stopPropagation={click}
+    on:touchstart|stopPropagation={touchstart}
     class={cls}
     class:loading
     class:disabled

--- a/frontend/app/src/components/home/PollAnswer.svelte
+++ b/frontend/app/src/components/home/PollAnswer.svelte
@@ -7,8 +7,10 @@
     import TooltipPopup from "../TooltipPopup.svelte";
     import TooltipWrapper from "../TooltipWrapper.svelte";
     import type { OpenChat, UserLookup } from "openchat-client";
-    import { getContext } from "svelte";
+    import { createEventDispatcher, getContext } from "svelte";
+    import { isTouchDevice } from "../../utils/devices";
 
+    const dispatch = createEventDispatcher();
     const client = getContext<OpenChat>("client");
 
     export let finished: boolean;
@@ -57,10 +59,28 @@
             }
         }
     }
+
+    function click(ev: MouseEvent) {
+        if (!isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
+
+    function touchstart(ev: TouchEvent) {
+        if (isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
 </script>
 
 <TooltipWrapper position={"right"} align={"center"} enable={showVotes}>
-    <div slot="target" class:readonly class="answer-text" class:finished on:click>
+    <div
+        slot="target"
+        class:readonly
+        class="answer-text"
+        class:finished
+        on:click|stopPropagation={click}
+        on:touchstart|stopPropagation={touchstart}>
         <Progress bg={"button"} {percent}>
             <div class="label">
                 <span>{answer}</span>

--- a/frontend/app/src/components/home/PrizeContent.svelte
+++ b/frontend/app/src/components/home/PrizeContent.svelte
@@ -29,8 +29,8 @@
         : client.formatTimeRemaining($now500, Number(content.endDate));
     let progressWidth = 0;
 
-    function claim(e: MouseEvent) {
-        if (e.isTrusted && chatId.kind === "group_chat") {
+    function claim(e: CustomEvent<MouseEvent | TouchEvent>) {
+        if (e.detail.isTrusted && chatId.kind === "group_chat") {
             claimsStore.add(messageId);
             client
                 .claimPrize(chatId, messageId)

--- a/frontend/app/src/components/home/TextContent.svelte
+++ b/frontend/app/src/components/home/TextContent.svelte
@@ -42,6 +42,10 @@
     $: youtubeStartTime = youtubeMatch
         ? new URL(youtubeMatch[0]).searchParams.get("t") || "0"
         : "0";
+
+    function expand() {
+        expanded = true;
+    }
 </script>
 
 {#if !youtubeMatch}
@@ -51,7 +55,7 @@
     {/if}
     {#if twitterLinkMatch}
         {#if !expanded}
-            <span on:click={() => (expanded = true)} class="expand" title={$_("showTweet")}>
+            <span on:touchstart={expand} on:click={expand} class="expand" title={$_("showTweet")}>
                 <ArrowExpand viewBox="0 -3 24 24" size={"1em"} color={"var(--txt)"} />
             </span>
         {:else}
@@ -65,7 +69,7 @@
         <Markdown suppressLinks={pinned} {text} />
     {/if}
     {#if !expanded}
-        <span on:click={() => (expanded = true)} class="expand" title={$_("showVideo")}>
+        <span on:click={expand} on:touchstart={expand} class="expand" title={$_("showVideo")}>
             <ArrowExpand viewBox="0 -3 24 24" size={"1em"} color={"var(--txt)"} />
         </span>
     {:else}

--- a/frontend/app/src/components/home/Tweet.svelte
+++ b/frontend/app/src/components/home/Tweet.svelte
@@ -56,7 +56,7 @@
                 4em,
                 2em,
                 var(--button-spinner),
-                "/assets/twitter.svg",
+                "/assets/twitter.svg?x",
                 0.8s,
                 1
             );

--- a/frontend/app/src/components/home/proposals/ProposalVoteButton.svelte
+++ b/frontend/app/src/components/home/proposals/ProposalVoteButton.svelte
@@ -3,6 +3,10 @@
     import ThumbUp from "svelte-material-icons/ThumbUp.svelte";
     import ThumbDown from "svelte-material-icons/ThumbDown.svelte";
     import { iconSize } from "../../../stores/iconSize";
+    import { createEventDispatcher } from "svelte";
+    import { isTouchDevice } from "../../../utils/devices";
+
+    const dispatch = createEventDispatcher();
 
     export let mode: "yes" | "no";
     export let percentage: number;
@@ -17,11 +21,29 @@
             ? $_("proposal.youVotedAdopt")
             : $_("proposal.youVotedReject")
         : "";
+
+    function click(ev: MouseEvent) {
+        if (!isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
+
+    function touchstart(ev: TouchEvent) {
+        if (isTouchDevice) {
+            dispatch("click", ev);
+        }
+    }
 </script>
 
 <div class="vote-button" {title}>
     <div class="label">{label}</div>
-    <div on:click class:voting class:voted class:disabled class={`icon ${mode}`}>
+    <div
+        on:click|stopPropagation={click}
+        on:touchstart|stopPropagation={touchstart}
+        class:voting
+        class:voted
+        class:disabled
+        class={`icon ${mode}`}>
         {#if !voting}
             {#if mode === "yes"}
                 <ThumbUp size={$iconSize} color={iconColor} />


### PR DESCRIPTION
in iOS in safari if a parent element has a :hover pseudo selector and a descendent is clicked, the click handler does not fire first time. The first tap will trigger the parent hover state and only a second tap will activate the button. 

To prevent this weird behaviour I'm converting touchstart to click for certain elements where we know this is a problem. 

This is not a great solution. A better solution would be to replace all hover interactions with explicit taps or long presses on touch devices. But that will need a bit more testing so this seems a safer short term hacklet. 