### PR TITLE
some small bugs

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -89,6 +89,7 @@
             addHotGroupExclusion,
             deleteFrozenGroup,
             deleteMessage,
+            deleteChannelMessage,
             freezeGroup,
             removeHotGroupExclusion,
             setCommunityModerationFlags,
@@ -159,6 +160,40 @@
                 console.log("Failed to unfreeze group", chatId);
             }
         });
+    }
+
+    function deleteChannelMessage(
+        communityId: string,
+        channelId: string,
+        messageId: bigint,
+        threadRootMessageIndex?: number | undefined
+    ): void {
+        client
+            .deleteMessage(
+                { kind: "channel", communityId, channelId },
+                threadRootMessageIndex,
+                messageId,
+                true
+            )
+            .then((success) => {
+                if (success) {
+                    console.log(
+                        "Message deleted",
+                        communityId,
+                        channelId,
+                        messageId,
+                        threadRootMessageIndex
+                    );
+                } else {
+                    console.log(
+                        "Failed to delete message",
+                        communityId,
+                        channelId,
+                        messageId,
+                        threadRootMessageIndex
+                    );
+                }
+            });
     }
 
     function deleteMessage(

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -30,6 +30,7 @@
     import { toastStore } from "stores/toast";
     import ImportToCommunity from "./communities/Import.svelte";
     import { randomSentence } from "../../utils/randomMsg";
+    import { rightPanelHistory } from "../../stores/rightPanel";
 
     export let joining: MultiUserChat | undefined;
     export let chat: ChatSummary;
@@ -105,6 +106,8 @@
         if (importToCommunities.size === 0) {
             toastStore.showFailureToast("communities.noOwned");
             importToCommunities = undefined;
+        } else {
+            rightPanelHistory.set([]);
         }
     }
 

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -878,6 +878,7 @@
     }
 
     function convertGroupToCommunity(ev: CustomEvent<GroupChatSummary>) {
+        rightPanelHistory.set([]);
         convertGroup = ev.detail;
     }
 

--- a/frontend/openchat-agent/src/utils/caching.ts
+++ b/frontend/openchat-agent/src/utils/caching.ts
@@ -26,7 +26,7 @@ import {
 import type { Principal } from "@dfinity/principal";
 import { toRecord } from "./list";
 
-const CACHE_VERSION = 73;
+const CACHE_VERSION = 74;
 
 export type Database = Promise<IDBPDatabase<ChatSchema>>;
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -374,6 +374,7 @@ import {
     unreadFavouriteChats,
     unreadCommunityChannels,
     globalUnreadCount,
+    getAllChats,
 } from "./stores/global";
 import { localCommunitySummaryUpdates } from "./stores/localCommunitySummaryUpdates";
 import { hasFlag, moderationFlags } from "./stores/flagStore";
@@ -4082,7 +4083,7 @@ export class OpenChat extends OpenChatAgentWorker {
                     .concat(chatsResponse.state.communities.flatMap((c) => c.channels));
 
                 this.updateReadUpToStore(updatedChats);
-                const chats = this._liveState.myServerChatSummaries.values();
+                const chats = getAllChats(this._liveState.globalState).values();
 
                 this._cachePrimer?.processChatUpdates(chats, updatedChats);
 


### PR DESCRIPTION
support delete channel message for platform operator
close right panel when importing or converting a community
ensure that cache primer operates on _all_ chats rather than just the chats for the selected scope
bump cache since some people will probably have got into a weird state