### PR TITLE
Add score to CommunityMatch

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove random factor in `explore_communities` ([#4102](https://github.com/open-chat-labs/open-chat/pull/4102))
-- Add an `UNDER_REVIEW` moderation flag  ([#4104](https://github.com/open-chat-labs/open-chat/pull/4104))
+- Add an `UNDER_REVIEW` moderation flag ([#4104](https://github.com/open-chat-labs/open-chat/pull/4104))
+- Add `score` to `CommunityMatch` ([#4106](https://github.com/open-chat-labs/open-chat/pull/4106))
 
 ## [[2.0.769](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.769-group_index)] - 2023-07-31
 

--- a/backend/canisters/group_index/impl/src/model/public_communities.rs
+++ b/backend/canisters/group_index/impl/src/model/public_communities.rs
@@ -89,7 +89,7 @@ impl PublicCommunities {
         let matches = matches
             .into_iter()
             .rev()
-            .map(|(_, c)| c.into())
+            .map(|(s, c)| c.to_match(s))
             .skip(page_index as usize * page_size as usize)
             .take(page_size as usize)
             .collect();
@@ -239,21 +239,20 @@ impl PublicCommunityInfo {
     pub fn set_moderation_flags(&mut self, flags: ModerationFlags) {
         self.moderation_flags = flags;
     }
-}
 
-impl From<&PublicCommunityInfo> for CommunityMatch {
-    fn from(community: &PublicCommunityInfo) -> Self {
+    pub fn to_match(&self, score: u32) -> CommunityMatch {
         CommunityMatch {
-            id: community.id,
-            name: community.name.clone(),
-            description: community.description.clone(),
-            avatar_id: community.avatar_id,
-            banner_id: community.banner_id,
-            member_count: community.activity.member_count,
-            channel_count: community.activity.channel_count,
-            gate: community.gate.clone(),
-            moderation_flags: community.moderation_flags.bits(),
-            primary_language: community.primary_language.clone(),
+            id: self.id,
+            score,
+            name: self.name.clone(),
+            description: self.description.clone(),
+            avatar_id: self.avatar_id,
+            banner_id: self.banner_id,
+            member_count: self.activity.member_count,
+            channel_count: self.activity.channel_count,
+            gate: self.gate.clone(),
+            moderation_flags: self.moderation_flags.bits(),
+            primary_language: self.primary_language.clone(),
         }
     }
 }

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -932,7 +932,7 @@ type Cryptocurrency = variant {
     CKBTC;
     CHAT;
     KINIC;
-    Other: text;
+    Other : text;
 };
 
 type CryptoTransaction = variant {
@@ -1329,7 +1329,7 @@ type UsersInvited = record {
 };
 
 type MembersAddedToDefaultChannel = record {
-    count: nat32;
+    count : nat32;
 };
 
 type ReportedMessage = record {
@@ -1348,6 +1348,7 @@ type EmptyArgs = record {};
 
 type CommunityMatch = record {
     id : CommunityId;
+    score : nat32;
     name : text;
     description : text;
     avatar_id : opt nat;

--- a/backend/libraries/types/src/group_match.rs
+++ b/backend/libraries/types/src/group_match.rs
@@ -17,6 +17,7 @@ pub struct GroupMatch {
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct CommunityMatch {
     pub id: CommunityId,
+    pub score: u32,
     pub name: String,
     pub description: String,
     pub avatar_id: Option<u128>,


### PR DESCRIPTION
There's something odd about the explore communities ordering but (local) unit tests seem fine so want to see the scores with prod data.