### PR TITLE
Revert "Discard old serialized state for the OpenChat group (#4093)"

### DIFF
--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Serialize chat state more efficiently ([#4092](https://github.com/open-chat-labs/open-chat/pull/4092))
-- Discard old serialized state for the OpenChat group ([#4093](https://github.com/open-chat-labs/open-chat/pull/4093))
 
 ## [[2.0.774](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.774-group)] - 2023-07-31
 

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -283,9 +283,7 @@ struct Data {
     pub activity_notification_state: ActivityNotificationState,
     pub instruction_counts_log: InstructionCountsLog,
     pub test_mode: bool,
-    #[serde(skip_deserializing)]
     pub community_being_imported_into: Option<CommunityBeingImportedInto>,
-    #[serde(skip_deserializing)]
     pub serialized_chat_state: Option<ByteBuf>,
 }
 


### PR DESCRIPTION
This reverts commit 8ab4d3be3c948ca23b592a8646f9f61e0e604b13.