### PR TITLE
Switch from using `svelte-qr` to `svelte-qrcode-image`

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -101,7 +101,7 @@
         "svelte-easy-crop": "^2.0.1",
         "svelte-i18n": "^3.4.0",
         "svelte-material-icons": "^1.0.3",
-        "svelte-qr": "^1.0.0",
+        "svelte-qrcode-image": "^1.0.0-rc.2",
         "usergeek-ic-js": "git+https://github.com/hpeebles/usergeek-ic-js.git#d00643807272a657cf546d34f5a983c593fc38f5",
         "uuid": "^9.0.0"
     }

--- a/frontend/app/src/components/QRCode.svelte
+++ b/frontend/app/src/components/QRCode.svelte
@@ -10,7 +10,7 @@
 
 <div class="qr-wrapper" class:border>
     <div class="qr" class:smaller={size === "smaller"} class:larger={size === "larger"} class:full-width-on-mobile={fullWidthOnMobile}>
-        <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayHeight="100%" displayWidth="100%" />
+        <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
         {#if logo !== undefined}
             <img class="icon" src={logo} />
         {/if}
@@ -48,6 +48,11 @@
             height: 35px;
             width: 35px;
             border-radius: 4px;
+        }
+
+        :global(.qr-code-image) {
+            width: 100%;
+            height: 100%;
         }
 
         &.smaller {

--- a/frontend/app/src/components/QRCode.svelte
+++ b/frontend/app/src/components/QRCode.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { QRCodeImage } from "svelte-qrcode-image";
+
+    export let text: string;
+    export let size: "default" | "smaller" | "larger" = "default";
+    export let border: boolean = false;
+    export let logo: string | undefined = undefined;
+    export let fullWidthOnMobile: boolean = false;
+</script>
+
+<div class="qr-wrapper" class:border>
+    <div class="qr" class:smaller={size === "smaller"} class:larger={size === "larger"} class:full-width-on-mobile={fullWidthOnMobile}>
+        <QRCodeImage {text} errorCorrectionLevel="Q" margin=2 displayHeight="100%" displayWidth="100%" />
+        {#if logo !== undefined}
+            <img class="icon" src={logo} />
+        {/if}
+    </div>
+</div>
+
+
+<style lang="scss">
+    .qr-wrapper {
+        padding: $sp5;
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        position: relative;
+
+        &.border {
+            border: 1px solid var(--bd);
+        }
+    }
+
+    .qr {
+        width: 200px;
+        height: 200px;
+        border-radius: 4px;
+        overflow: hidden;
+
+        .icon {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background-color: #fff;
+            padding: 4px;
+            height: 35px;
+            width: 35px;
+            border-radius: 4px;
+        }
+
+        &.smaller {
+            width: 150px;
+            height: 150px;
+            .icon {
+                height: 30px;
+                width: 30px;
+            }
+        }
+
+        &.larger {
+            width: 250px;
+            height: 250px;
+            .icon {
+                height: 45px;
+                width: 45px;
+            }
+        }
+
+        &.full-width-on-mobile {
+            @include mobile() {
+                width: 100%;
+                height: auto;
+                margin: 0;
+            }
+        }
+    }
+</style>

--- a/frontend/app/src/components/QRCode.svelte
+++ b/frontend/app/src/components/QRCode.svelte
@@ -10,7 +10,7 @@
 
 <div class="qr-wrapper" class:border>
     <div class="qr" class:smaller={size === "smaller"} class:larger={size === "larger"} class:full-width-on-mobile={fullWidthOnMobile}>
-        <QRCodeImage {text} errorCorrectionLevel="Q" margin=2 displayHeight="100%" displayWidth="100%" />
+        <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayHeight="100%" displayWidth="100%" />
         {#if logo !== undefined}
             <img class="icon" src={logo} />
         {/if}

--- a/frontend/app/src/components/home/AccountInfo.svelte
+++ b/frontend/app/src/components/home/AccountInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { _ } from "svelte-i18n";
-    import QR from "svelte-qr";
+    import { QRCodeImage } from "svelte-qrcode-image";
     import { toastStore } from "../../stores/toast";
     import ContentCopy from "svelte-material-icons/ContentCopy.svelte";
     import { iconSize } from "../../stores/iconSize";
@@ -45,7 +45,7 @@
 <div class="account-info">
     <div class="qr-wrapper" class:border>
         <div class="qr" class:smaller={qrSize === "smaller"} class:larger={qrSize === "larger"}>
-            <QR text={account} level="Q" />
+            <QRCodeImage text={account} errorCorrectionLevel="Q" />
             <img class="icon" src={tokenDetails.logo} />
         </div>
     </div>

--- a/frontend/app/src/components/home/AccountInfo.svelte
+++ b/frontend/app/src/components/home/AccountInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { _ } from "svelte-i18n";
-    import { QRCodeImage } from "svelte-qrcode-image";
+    import QRCode from "../QRCode.svelte";
     import { toastStore } from "../../stores/toast";
     import ContentCopy from "svelte-material-icons/ContentCopy.svelte";
     import { iconSize } from "../../stores/iconSize";
@@ -43,12 +43,7 @@
 </script>
 
 <div class="account-info">
-    <div class="qr-wrapper" class:border>
-        <div class="qr" class:smaller={qrSize === "smaller"} class:larger={qrSize === "larger"}>
-            <QRCodeImage text={account} errorCorrectionLevel="Q" />
-            <img class="icon" src={tokenDetails.logo} />
-        </div>
-    </div>
+    <QRCode text={account} size={qrSize} logo={tokenDetails.logo} {border} />
     <p class:centered>{$_("tokenTransfer.yourAccount", { values: { token: symbol } })}</p>
     <div class="receiver" class:centered>
         <div class="account">
@@ -61,56 +56,6 @@
 </div>
 
 <style lang="scss">
-    .qr-wrapper {
-        padding: $sp5;
-        display: flex;
-        justify-content: center;
-        width: 100%;
-        margin-bottom: $sp4;
-        position: relative;
-
-        &.border {
-            border: 1px solid var(--bd);
-        }
-    }
-
-    .qr {
-        background-color: #fff;
-        width: 140px;
-        height: 140px;
-
-        .icon {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            background-size: contain;
-            height: 35px;
-            width: 35px;
-            border-radius: 50%;
-            background-repeat: no-repeat;
-            background-position: top;
-        }
-
-        &.smaller {
-            width: 120px;
-            height: 120px;
-            .icon {
-                height: 30px;
-                width: 30px;
-            }
-        }
-
-        &.larger {
-            width: 180px;
-            height: 180px;
-            .icon {
-                height: 45px;
-                width: 45px;
-            }
-        }
-    }
-
     .centered {
         text-align: center;
     }

--- a/frontend/app/src/components/home/InviteUsersWithLink.svelte
+++ b/frontend/app/src/components/home/InviteUsersWithLink.svelte
@@ -2,7 +2,7 @@
     import { onMount, getContext } from "svelte";
     import RefreshIcon from "svelte-material-icons/Refresh.svelte";
     import ShareIcon from "svelte-material-icons/ShareVariant.svelte";
-    import { QRCodeImage } from "svelte-qrcode-image";
+    import QRCode from "../QRCode.svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
     import { _ } from "svelte-i18n";
     import ErrorMessage from "../ErrorMessage.svelte";
@@ -189,11 +189,7 @@
     {#if container.public || (code !== undefined && checked)}
         <div class="link-enabled">
             <div class="link">{link}</div>
-            <div class="qr-wrapper">
-                <div class="qr">
-                    <QRCodeImage text={link} errorCorrectionLevel="Q" />
-                </div>
-            </div>
+            <QRCode text={link} border=true fullWidthOnMobile=true />
             <div class="message">
                 <Markdown
                     text={interpolateLevel("invite.shareMessage", container.level, true) +
@@ -239,19 +235,6 @@
 {/if}
 
 <style lang="scss">
-    .qr-wrapper {
-        border: 1px solid var(--bd);
-        .qr {
-            background-color: #fff;
-            margin: $sp5 auto;
-            width: 200px;
-
-            @include mobile() {
-                width: 100%;
-                margin: 0;
-            }
-        }
-    }
     .toggle-row {
         display: flex;
         justify-content: space-between;

--- a/frontend/app/src/components/home/InviteUsersWithLink.svelte
+++ b/frontend/app/src/components/home/InviteUsersWithLink.svelte
@@ -2,7 +2,7 @@
     import { onMount, getContext } from "svelte";
     import RefreshIcon from "svelte-material-icons/Refresh.svelte";
     import ShareIcon from "svelte-material-icons/ShareVariant.svelte";
-    import QR from "svelte-qr";
+    import { QRCodeImage } from "svelte-qrcode-image";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
     import { _ } from "svelte-i18n";
     import ErrorMessage from "../ErrorMessage.svelte";
@@ -191,7 +191,7 @@
             <div class="link">{link}</div>
             <div class="qr-wrapper">
                 <div class="qr">
-                    <QR text={link} />
+                    <QRCodeImage text={link} errorCorrectionLevel="Q" />
                 </div>
             </div>
             <div class="message">

--- a/frontend/app/src/components/home/InviteUsersWithLink.svelte
+++ b/frontend/app/src/components/home/InviteUsersWithLink.svelte
@@ -189,7 +189,7 @@
     {#if container.public || (code !== undefined && checked)}
         <div class="link-enabled">
             <div class="link">{link}</div>
-            <QRCode text={link} border=true fullWidthOnMobile=true />
+            <QRCode text={link} border={true} fullWidthOnMobile={true} />
             <div class="message">
                 <Markdown
                     text={interpolateLevel("invite.shareMessage", container.level, true) +

--- a/frontend/app/src/components/home/UserReferralCardContent.svelte
+++ b/frontend/app/src/components/home/UserReferralCardContent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { getContext } from "svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
-    import { QRCodeImage } from "svelte-qrcode-image";
+    import QRCode from "../QRCode.svelte";
     import type { OpenChat } from "openchat-client";
     import { _ } from "svelte-i18n";
     import { toastStore } from "../../stores/toast";
@@ -24,22 +24,10 @@
         <div>{$_("tapForReferralLink")}</div>
         <CopyIcon size={"1em"} color={"var(--icon-txt)"} />
     </div>
-    <div class="qr">
-        <QRCodeImage text={link} errorCorrectionLevel="Q" />
-    </div>
+    <QRCode text={link} size="larger" fullWidthOnMobile=true />
 </div>
 
 <style lang="scss">
-    .qr {
-        background-color: #fff;
-        width: 250px;
-
-        @include mobile() {
-            width: 100%;
-            margin: 0;
-        }
-    }
-
     .link {
         display: flex;
         gap: $sp2;

--- a/frontend/app/src/components/home/UserReferralCardContent.svelte
+++ b/frontend/app/src/components/home/UserReferralCardContent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { getContext } from "svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
-    import QR from "svelte-qr";
+    import { QRCodeImage } from "svelte-qrcode-image";
     import type { OpenChat } from "openchat-client";
     import { _ } from "svelte-i18n";
     import { toastStore } from "../../stores/toast";
@@ -25,7 +25,7 @@
         <CopyIcon size={"1em"} color={"var(--icon-txt)"} />
     </div>
     <div class="qr">
-        <QR text={link} />
+        <QRCodeImage text={link} errorCorrectionLevel="Q" />
     </div>
 </div>
 

--- a/frontend/app/src/components/home/UserReferralCardContent.svelte
+++ b/frontend/app/src/components/home/UserReferralCardContent.svelte
@@ -24,7 +24,7 @@
         <div>{$_("tapForReferralLink")}</div>
         <CopyIcon size={"1em"} color={"var(--icon-txt)"} />
     </div>
-    <QRCode text={link} size="larger" fullWidthOnMobile=true />
+    <QRCode text={link} size="larger" fullWidthOnMobile={true} />
 </div>
 
 <style lang="scss">

--- a/frontend/app/src/components/home/profile/ReferUsers.svelte
+++ b/frontend/app/src/components/home/profile/ReferUsers.svelte
@@ -3,7 +3,7 @@
     import type { OpenChat } from "openchat-client";
     import ShareIcon from "svelte-material-icons/ShareVariant.svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
-    import QR from "svelte-qr";
+    import { QRCodeImage } from "svelte-qrcode-image";
     import { _ } from "svelte-i18n";
     import Link from "../../Link.svelte";
     import { iconSize } from "../../../stores/iconSize";
@@ -59,7 +59,7 @@
     <div class="link">{link}</div>
     <div class="qr-wrapper">
         <div class="qr">
-            <QR text={link} />
+            <QRCodeImage text={link} errorCorrectionLevel="Q" />
         </div>
     </div>
     <div class="message">

--- a/frontend/app/src/components/home/profile/ReferUsers.svelte
+++ b/frontend/app/src/components/home/profile/ReferUsers.svelte
@@ -57,7 +57,7 @@
 
 <div class="container">
     <div class="link">{link}</div>
-    <QRCode text={link} border=true fullWidthOnMobile=true />
+    <QRCode text={link} border={true} fullWidthOnMobile={true} />
     <div class="message">
         {$_("userReferralMessage")}
     </div>

--- a/frontend/app/src/components/home/profile/ReferUsers.svelte
+++ b/frontend/app/src/components/home/profile/ReferUsers.svelte
@@ -3,7 +3,7 @@
     import type { OpenChat } from "openchat-client";
     import ShareIcon from "svelte-material-icons/ShareVariant.svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
-    import { QRCodeImage } from "svelte-qrcode-image";
+    import QRCode from "../../QRCode.svelte";
     import { _ } from "svelte-i18n";
     import Link from "../../Link.svelte";
     import { iconSize } from "../../../stores/iconSize";
@@ -57,11 +57,7 @@
 
 <div class="container">
     <div class="link">{link}</div>
-    <div class="qr-wrapper">
-        <div class="qr">
-            <QRCodeImage text={link} errorCorrectionLevel="Q" />
-        </div>
-    </div>
+    <QRCode text={link} border=true fullWidthOnMobile=true />
     <div class="message">
         {$_("userReferralMessage")}
     </div>
@@ -106,20 +102,6 @@
 {/if}
 
 <style lang="scss">
-    .qr-wrapper {
-        border: 1px solid var(--bd);
-        .qr {
-            background-color: #fff;
-            margin: $sp5 auto;
-            width: 200px;
-
-            @include mobile() {
-                width: 100%;
-                margin: 0;
-            }
-        }
-    }
-
     .link,
     .message {
         @include font(book, normal, fs-80);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "svelte-easy-crop": "^2.0.1",
         "svelte-i18n": "^3.4.0",
         "svelte-material-icons": "^1.0.3",
-        "svelte-qr": "^1.0.0",
+        "svelte-qrcode-image": "^1.0.0-rc.2",
         "usergeek-ic-js": "git+https://github.com/hpeebles/usergeek-ic-js.git#d00643807272a657cf546d34f5a983c593fc38f5",
         "uuid": "^9.0.0"
       },
@@ -4542,7 +4542,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5509,7 +5508,6 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6128,6 +6126,14 @@
         "find": "^0.2.4"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.4.2",
       "dev": true,
@@ -6234,6 +6240,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -6442,7 +6453,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -6452,6 +6462,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -7438,7 +7453,6 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -7785,7 +7799,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -8613,7 +8626,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11109,7 +11121,6 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -12014,7 +12025,6 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -12025,7 +12035,6 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -12079,7 +12088,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12183,7 +12191,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12323,6 +12330,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -13049,6 +13064,114 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.5.3",
       "dev": true,
@@ -13349,7 +13472,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13362,6 +13484,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/require-relative": {
       "version": "0.8.7",
@@ -14206,7 +14333,6 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
@@ -14627,7 +14753,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14666,7 +14791,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14911,9 +15035,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/svelte-qr": {
-      "version": "1.0.0",
-      "license": "MIT"
+    "node_modules/svelte-qrcode-image": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/svelte-qrcode-image/-/svelte-qrcode-image-1.0.0-rc.2.tgz",
+      "integrity": "sha512-1rV14JOOWyyOAVVXxGlbBwgFvJK6aOUIqB1MvI7fQrGgBn+vb425BlVCvvEwfgMju0lCXVRPU22i5TpbD/NN2A==",
+      "dependencies": {
+        "qrcode": "^1.5.1"
+      }
     },
     "node_modules/svgo": {
       "version": "2.8.0",
@@ -16251,6 +16379,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.8",
@@ -20260,8 +20393,7 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -20877,8 +21009,7 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "dev": true
+      "version": "5.3.1"
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -21270,6 +21401,11 @@
         "find": "^0.2.4"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "decimal.js": {
       "version": "10.4.2",
       "dev": true
@@ -21332,6 +21468,11 @@
     "diff-sequences": {
       "version": "29.2.0",
       "dev": true
+    },
+    "dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -21473,12 +21614,16 @@
       "from": "emoji-picker-element@git+https://github.com/hpeebles/emoji-picker-element.git#716e3a30a87e7f7e471f90bebe1af93d90d866ff"
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "dev": true
+      "version": "8.0.0"
     },
     "emojis-list": {
       "version": "3.0.0",
       "dev": true
+    },
+    "encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -22122,7 +22267,6 @@
     },
     "find-up": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -22345,8 +22489,7 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "get-intrinsic": {
       "version": "1.1.3",
@@ -22856,8 +22999,7 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -24467,7 +24609,6 @@
     },
     "locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
@@ -25080,7 +25221,7 @@
         "svelte-i18n": "^3.4.0",
         "svelte-material-icons": "^1.0.3",
         "svelte-preprocess": "^5.0.4",
-        "svelte-qr": "^1.0.0",
+        "svelte-qrcode-image": "^1.0.0-rc.2",
         "tslib": "^2.3.1",
         "typescript": "^4.8.2",
         "usergeek-ic-js": "git+https://github.com/hpeebles/usergeek-ic-js.git#d00643807272a657cf546d34f5a983c593fc38f5",
@@ -25708,14 +25849,12 @@
     },
     "p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       },
       "dependencies": {
         "p-limit": {
           "version": "2.3.0",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -25745,8 +25884,7 @@
       }
     },
     "p-try": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
     },
     "pacote": {
       "version": "11.3.5",
@@ -25817,8 +25955,7 @@
       }
     },
     "path-exists": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -25906,6 +26043,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "postcss": {
       "version": "8.4.18",
@@ -26310,6 +26452,92 @@
       "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
       "peer": true
     },
+    "qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "requires": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "qs": {
       "version": "6.5.3",
       "dev": true
@@ -26512,12 +26740,16 @@
       "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "require-directory": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "require-from-string": {
       "version": "2.0.2",
       "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "require-relative": {
       "version": "0.8.7",
@@ -27110,8 +27342,7 @@
       }
     },
     "set-blocking": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "set-cookie-parser": {
       "version": "2.5.1",
@@ -27404,7 +27635,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -27431,7 +27661,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -27558,8 +27787,13 @@
         }
       }
     },
-    "svelte-qr": {
-      "version": "1.0.0"
+    "svelte-qrcode-image": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/svelte-qrcode-image/-/svelte-qrcode-image-1.0.0-rc.2.tgz",
+      "integrity": "sha512-1rV14JOOWyyOAVVXxGlbBwgFvJK6aOUIqB1MvI7fQrGgBn+vb425BlVCvvEwfgMju0lCXVRPU22i5TpbD/NN2A==",
+      "requires": {
+        "qrcode": "^1.5.1"
+      }
     },
     "svgo": {
       "version": "2.8.0",
@@ -28388,6 +28622,11 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "which-typed-array": {
       "version": "1.1.8",


### PR DESCRIPTION
Also, token QR codes now have a clear background around the token symbol.

<img width="360" alt="Screenshot 2023-08-16 at 09 29 29" src="https://github.com/open-chat-labs/open-chat/assets/4965315/7ffd017c-8342-4bbf-9c68-47a0a4adc28a">
