### PR TITLE
Longpresss

### DIFF
--- a/frontend/app/src/actions/longpress.ts
+++ b/frontend/app/src/actions/longpress.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { isTouchDevice } from "../utils/devices";
+import { eventListLastScrolled } from "../stores/scrollPos";
+import { get } from "svelte/store";
+
+const SCROLL_PROXIMITY = 1000;
 
 export function longpress(node: HTMLElement, onlongpress: () => void) {
     let longPressTimer: number | undefined;
@@ -16,7 +20,11 @@ export function longpress(node: HTMLElement, onlongpress: () => void) {
         startY = t.clientY;
         clearLongPressTimer();
         longPressTimer = window.setTimeout(() => {
-            onlongpress();
+            const lastScroll = get(eventListLastScrolled);
+            const diff = Date.now() - lastScroll;
+            if (diff > SCROLL_PROXIMITY) {
+                onlongpress();
+            }
         }, 500);
     }
 

--- a/frontend/app/src/actions/longpress.ts
+++ b/frontend/app/src/actions/longpress.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { isTouchDevice } from "../utils/devices";
+import { isTouchDevice, mobileOperatingSystem } from "../utils/devices";
 import { eventListLastScrolled } from "../stores/scrollPos";
 import { get } from "svelte/store";
 
-const SCROLL_PROXIMITY = 1000;
+const SCROLL_PROXIMITY = 750;
 
 export function longpress(node: HTMLElement, onlongpress: () => void) {
     let longPressTimer: number | undefined;
@@ -22,7 +22,7 @@ export function longpress(node: HTMLElement, onlongpress: () => void) {
         longPressTimer = window.setTimeout(() => {
             const lastScroll = get(eventListLastScrolled);
             const diff = Date.now() - lastScroll;
-            if (diff > SCROLL_PROXIMITY) {
+            if (mobileOperatingSystem === "iOS" || diff > SCROLL_PROXIMITY) {
                 onlongpress();
             }
         }, 500);

--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -24,7 +24,7 @@
         SentMessage,
         SentThreadMessage,
         ThreadReactionSelected,
-        chatIdentifiersEqual
+        chatIdentifiersEqual,
     } from "openchat-client";
     import { menuStore } from "../../stores/menu";
     import { tooltipStore } from "../../stores/tooltip";
@@ -36,7 +36,7 @@
     import { _ } from "svelte-i18n";
     import { pop } from "../../utils/transition";
     import { iconSize } from "../../stores/iconSize";
-    import { eventListScrollTop } from "../../stores/scrollPos";
+    import { eventListLastScrolled, eventListScrollTop } from "../../stores/scrollPos";
 
     const FROM_BOTTOM_THRESHOLD = 600;
     const LOADING_THRESHOLD = 400;
@@ -460,6 +460,7 @@
         }
         menuStore.hideMenu();
         tooltipStore.hide();
+        eventListLastScrolled.set(Date.now());
 
         if (!initialised || interrupt || loadingFromUserScroll) return;
 

--- a/frontend/app/src/stores/scrollPos.ts
+++ b/frontend/app/src/stores/scrollPos.ts
@@ -3,3 +3,5 @@ import { writable } from "svelte/store";
 export const chatListScroll = writable<number>(0);
 
 export const eventListScrollTop = writable<number | undefined>(undefined);
+
+export const eventListLastScrolled = writable<number>(0);


### PR DESCRIPTION
only activate the long press if we are more than 750ms away from the last scroll. This _feels_ about the right duration to avoid accidental activation without compromising deliberate activation. Only enabling this behaviour for Android since iOS seems to behave fine already. 