### PR TITLE
assume valid rather than invalid

### DIFF
--- a/frontend/app/src/components/home/profile/UserProfile.svelte
+++ b/frontend/app/src/components/home/profile/UserProfile.svelte
@@ -62,9 +62,9 @@
     let bioError: string | undefined = undefined;
     let saving = false;
     let username = "";
-    let usernameValid = false;
+    let usernameValid = true;
     let displayName: string | undefined = undefined;
-    let displayNameValid = false;
+    let displayNameValid = true;
     let checkingUsername: boolean;
     let readonly = client.isReadOnly();
     let view: "global" | "communities" = "global";


### PR DESCRIPTION
This gets immediately set to the correct value inside the relevant child component anyway it's just a different default that prevents the transient flicker of the invalid state. 