### PR TITLE
Accept calls to set_community_upgrade_concurrency

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed 
+
+- Accept calls to `set_community_upgrade_concurrency` ([#4418](https://github.com/open-chat-labs/open-chat/pull/4418))
+
 ## [[2.0.857](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.857-group_index)] - 2023-09-21
 
 ### Added

--- a/backend/canisters/group_index/impl/src/lifecycle/inspect_message.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/inspect_message.rs
@@ -29,6 +29,7 @@ fn accept_if_valid(state: &RuntimeState) {
         | "freeze_group"
         | "remove_hot_group_exclusion"
         | "set_community_moderation_flags"
+        | "set_community_upgrade_concurrency"
         | "set_group_upgrade_concurrency"
         | "unfreeze_group" => true,
         _ => false,


### PR DESCRIPTION
Previously I had added `set_max_concurrent_community_canister_upgrades` to inspect message but not `set_community_upgrade_concurrency`!