### PR TITLE
Only allow users to be selected for crypto message

### DIFF
--- a/frontend/app/src/components/home/MentionPicker.svelte
+++ b/frontend/app/src/components/home/MentionPicker.svelte
@@ -20,6 +20,7 @@
     export let border = false;
     export let mentionSelf = false;
     export let supportsUserGroups = false;
+    export let usersOnly = false;
 
     let index = 0;
     let usersAndGroups: UserOrUserGroup[] = [];
@@ -37,11 +38,16 @@
         switch (userOrGroup.kind) {
             case "user_group":
                 return (
-                    prefixLower === undefined ||
-                    (supportsUserGroups && userOrGroup.name.toLowerCase().startsWith(prefixLower))
+                    !usersOnly &&
+                    (prefixLower === undefined ||
+                        (supportsUserGroups &&
+                            userOrGroup.name.toLowerCase().startsWith(prefixLower)))
                 );
             case "everyone": {
-                return prefixLower === undefined || userOrGroup.kind.startsWith(prefixLower);
+                return (
+                    !usersOnly &&
+                    (prefixLower === undefined || userOrGroup.kind.startsWith(prefixLower))
+                );
             }
             default:
                 return (

--- a/frontend/app/src/components/home/SingleUserSelector.svelte
+++ b/frontend/app/src/components/home/SingleUserSelector.svelte
@@ -52,7 +52,8 @@
             on:close={() => (showMentionPicker = false)}
             on:mention={selectReceiver}
             border
-            prefix={textValue} />
+            usersOnly
+            prefix={textValue.startsWith("@") ? textValue.substring(1) : textValue} />
     {/if}
     {#if selectedReceiver !== undefined}
         <UserPill on:deleteUser={removeReceiver} userOrGroup={selectedReceiver} />


### PR DESCRIPTION
1. This fixes an issue where you can select @everyone or @usergroup as recipient of a crypto transfer
2. When selecting a recipient for a crypto transfer I was typing @ and expecting to see a list of users (and started debugging) before I realised that you don't start with @ at all. I have changed it so you now *can* start with @