### PR TITLE
allow winner messages to wrap where necessary

### DIFF
--- a/frontend/app/src/components/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components/home/PrizeWinnerContent.svelte
@@ -52,9 +52,7 @@
                 <Markdown
                     text={$_("prizes.winner", {
                         values: { recipient: winner, amount, token: symbol },
-                    })}
-                    oneLine
-                    suppressLinks />
+                    })} />
             </div>
             {#if transactionLinkText !== undefined}
                 <div class="link">
@@ -69,6 +67,7 @@
     .msg {
         cursor: pointer;
         text-align: center;
+        padding-top: $sp2;
     }
 
     .wrapper.other {
@@ -82,7 +81,7 @@
     }
 
     .label {
-        @include font(book, normal, fs-100, 28);
+        @include font(book, normal, fs-100);
     }
 
     .link {

--- a/frontend/app/src/components/home/profile/AccountsModal.svelte
+++ b/frontend/app/src/components/home/profile/AccountsModal.svelte
@@ -24,8 +24,8 @@
     </div>
     <div slot="footer">
         <div class="footer">
-            {#if zeroCount > 0}
-                <div class="show-more">
+            <div class="show-more">
+                {#if zeroCount > 0}
                     <LinkButton
                         light
                         underline={"hover"}
@@ -35,8 +35,8 @@
                                 ? "cryptoAccount.hideZeroBalance"
                                 : "cryptoAccount.showZeroBalance"
                         )}</LinkButton>
-                </div>
-            {/if}
+                {/if}
+            </div>
             <Button on:click={() => dispatch("close")} small={!$mobileWidth} tiny={$mobileWidth}>
                 {$_("close")}
             </Button>


### PR DESCRIPTION
+ unbreak the wallet modal footer. 