### PR TITLE
set max-scale for iOS

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -30,6 +30,7 @@
     import { framed, broadcastLoggedInUser } from "../stores/xframe";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import Witch from "./Witch.svelte";
+    import { mobileOperatingSystem } from "../utils/devices";
     overrideItemIdKeyNameBeforeInitialisingDndZones("_id");
 
     let viewPortContent = "width=device-width, initial-scale=1";
@@ -86,6 +87,10 @@
             page.replace(removeQueryStringParam("ref"));
         }
         calculateHeight();
+
+        if (mobileOperatingSystem === "iOS") {
+            viewPortContent += ", maximum-scale=1";
+        }
 
         window.addEventListener("orientationchange", calculateHeight);
         window.addEventListener("unhandledrejection", unhandledError);


### PR DESCRIPTION
Turns out that this is the lesser of two evils. Without this safari will auto zoom when we focus text boxes and then stay zoomed which is terrible. 