### PR TITLE
add a key to the chat list #each

### DIFF
--- a/frontend/app/src/components/home/ChatList.svelte
+++ b/frontend/app/src/components/home/ChatList.svelte
@@ -238,7 +238,7 @@
                 {#if searchResultsAvailable && chats.length > 0}
                     <h3 class="search-subtitle">{$_("yourChats")}</h3>
                 {/if}
-                {#each chats as chatSummary}
+                {#each chats as chatSummary (chatSummary.id)}
                     <ChatSummary
                         {chatSummary}
                         selected={chatIdentifiersEqual($selectedChatId, chatSummary.id)}


### PR DESCRIPTION
This stops us getting the wrong avatar transiently on the chat avatar when you change community. 

On the downside, you now get a blank avatar transiently sometimes which is also a bit puzzling. But having a key on the each is probably a good idea anyway. 