### PR TITLE
deal with placeholder text

### DIFF
--- a/frontend/app/src/actions/closeMenu.ts
+++ b/frontend/app/src/actions/closeMenu.ts
@@ -6,7 +6,7 @@ function hideMenu() {
 }
 
 export function menuCloser(node: HTMLElement) {
-    menuStore.subscribe((menu) => {
+    const unsub = menuStore.subscribe((menu) => {
         if (menu !== undefined) {
             node.addEventListener("scroll", hideMenu);
         } else {
@@ -17,6 +17,7 @@ export function menuCloser(node: HTMLElement) {
     return {
         destroy() {
             node.removeEventListener("scroll", hideMenu);
+            unsub();
         },
     };
 }

--- a/frontend/app/src/actions/translatable.ts
+++ b/frontend/app/src/actions/translatable.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { _, locale, dictionary } from "svelte-i18n";
+import { editmode, editingLabel, type ResourceKey } from "../i18n/i18n";
+import { derived, get } from "svelte/store";
+import { currentTheme } from "../theme/themes";
+import type { Theme } from "../theme/types";
+
+interface LocaleDictionary {
+    [key: string]: LocaleDictionary | string | Array<string | LocaleDictionary> | null;
+}
+type LocalesDictionary = {
+    [key: string]: LocaleDictionary | null;
+};
+
+function getSvg(theme: Theme) {
+    return `
+        <?xml version="1.0" encoding="utf-8"?>
+        <svg width="16px" height="16px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <g transform="matrix(0.909091, 0, 0, 1, 1, 0)" style="transform-origin: 1px 2px;">
+            <path fill="${theme.accent}" d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/>
+        </g>
+        </svg>
+    `;
+}
+
+function isTranslatable(
+    dictionary: LocalesDictionary,
+    locale: string | null | undefined,
+    { key }: ResourceKey,
+): boolean {
+    if (!locale) return false;
+    const localeValues = dictionary[locale];
+
+    if (!localeValues) return false;
+
+    if (key in localeValues) return true;
+
+    const keys = key.split(".");
+    let result: any = localeValues;
+
+    for (const key of keys) {
+        const val = result[key];
+        if (val == null) {
+            return false;
+        } else {
+            result = val;
+        }
+    }
+    return result !== undefined;
+}
+
+type Param = {
+    key: ResourceKey | undefined;
+    position?: "relative" | "absolute";
+    top?: number;
+    right?: number;
+};
+
+export function translatable(node: HTMLElement, param: Param) {
+    if (param.key === undefined) return;
+    const resourceKey = param.key;
+    const position = param.position ?? "relative";
+    const top = param.top ?? 4;
+    const right = param.right;
+
+    const editable = derived(
+        [locale, dictionary, editmode],
+        ([$locale, $dictionary, $editmode]) => {
+            return (
+                $editmode &&
+                !$locale?.startsWith("en") &&
+                isTranslatable($dictionary, $locale, resourceKey)
+            );
+        },
+    );
+    let span: HTMLSpanElement | undefined = undefined;
+    const unsub = editable.subscribe((canEdit) => {
+        if (canEdit) {
+            span = document.createElement("span");
+            span.classList.add("is-translatable");
+            span.style.position = position;
+            span.style.top = `${top}px`;
+            if (right !== undefined) {
+                span.style.right = `${right}px`;
+            }
+            span.innerHTML = getSvg(get(currentTheme));
+            node.parentNode?.insertBefore(span, node.nextSibling);
+            span.addEventListener("click", (ev) => {
+                ev.stopPropagation();
+                editingLabel.set(resourceKey);
+            });
+        } else {
+            if (span) {
+                node.parentNode?.removeChild(span);
+            }
+        }
+    });
+
+    return {
+        destroy() {
+            unsub();
+        },
+    };
+}

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -664,6 +664,11 @@
             left: -1000px;
             @include z-index("dollar");
         }
+
+        .is-translatable {
+            position: relative;
+            top: 4px;
+        }
     }
 
     .burst-wrapper {

--- a/frontend/app/src/components/DisplayNameInput.svelte
+++ b/frontend/app/src/components/DisplayNameInput.svelte
@@ -47,7 +47,7 @@
         minlength={MIN_DISPLAY_NAME_LENGTH}
         maxlength={MAX_DISPLAY_NAME_LENGTH}
         countdown
-        placeholder={$_("register.enterDisplayName")}>
+        placeholder={i18nKey("register.enterDisplayName")}>
         <slot />
     </Input>
 {:else}

--- a/frontend/app/src/components/EditLabel.svelte
+++ b/frontend/app/src/components/EditLabel.svelte
@@ -71,7 +71,7 @@
                     maxlength={1000}
                     disabled={busy}
                     bind:value={suggestion}
-                    placeholder={"Enter your suggestion"} />
+                    placeholder={i18nKey("Enter your suggestion")} />
             </div>
             <div slot="footer">
                 <ButtonGroup>

--- a/frontend/app/src/components/FindUser.svelte
+++ b/frontend/app/src/components/FindUser.svelte
@@ -13,6 +13,7 @@
     import FilteredUsername from "./FilteredUsername.svelte";
     import Diamond from "./icons/Diamond.svelte";
     import { i18nKey } from "../i18n/i18n";
+    import { translatable } from "../actions/translatable";
 
     const client = getContext<OpenChat>("client");
 
@@ -80,6 +81,7 @@
         disabled={!enabled}
         type="text"
         on:input={onInput}
+        use:translatable={{ key: i18nKey("searchForUsername") }}
         placeholder={$_("searchForUsername")} />
     {#if searching}
         <span class="loading" />

--- a/frontend/app/src/components/Input.svelte
+++ b/frontend/app/src/components/Input.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+    import { _ } from "svelte-i18n";
     import { createEventDispatcher } from "svelte";
     import { onMount } from "svelte";
+    import { translatable } from "../actions/translatable";
+    import { interpolate, type ResourceKey } from "../i18n/i18n";
 
     export let disabled: boolean = false;
     export let invalid: boolean = false;
     export let value: string | number = "";
     export let autofocus: boolean = false;
-    export let placeholder: string = "";
+    export let placeholder: ResourceKey | undefined = undefined;
     export let type: "text" | "number" = "text";
     export let minlength: number = 0;
     export let maxlength: number = Number.MAX_VALUE;
@@ -60,7 +63,8 @@
         {type}
         {minlength}
         {maxlength}
-        {placeholder}
+        placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
+        use:translatable={{ key: placeholder, position: "absolute", right: 30, top: 12 }}
         on:input={handleInput}
         on:keydown={keyDown}
         on:blur

--- a/frontend/app/src/components/Search.svelte
+++ b/frontend/app/src/components/Search.svelte
@@ -4,11 +4,13 @@
     import { _ } from "svelte-i18n";
     import { createEventDispatcher } from "svelte";
     import { iconSize } from "../stores/iconSize";
+    import { translatable } from "../actions/translatable";
+    import { i18nKey, interpolate, type ResourceKey } from "../i18n/i18n";
 
     const dispatch = createEventDispatcher();
     export let searchTerm = "";
     export let searching: boolean;
-    export let placeholder: string = "searchPlaceholder";
+    export let placeholder: ResourceKey = i18nKey("searchPlaceholder");
     export let fill = false;
 
     let timer: number | undefined;
@@ -44,7 +46,8 @@
         spellcheck="false"
         bind:value={searchTerm}
         type="text"
-        placeholder={$_(placeholder)} />
+        use:translatable={{ key: placeholder }}
+        placeholder={interpolate($_, placeholder)} />
     {#if searchTerm !== ""}
         <span on:click={clearSearch} class="icon close"
             ><Close size={$iconSize} color={"var(--icon-txt)"} /></span>

--- a/frontend/app/src/components/SelectChatModal.svelte
+++ b/frontend/app/src/components/SelectChatModal.svelte
@@ -269,7 +269,7 @@
         </span>
     </SectionHeader>
     <div class="search">
-        <Search searching={false} bind:searchTerm placeholder={"search"} />
+        <Search searching={false} bind:searchTerm placeholder={i18nKey("search")} />
     </div>
     {#if noTargets}
         <div class="no-chats"><Translatable resourceKey={i18nKey("noChatsAvailable")} /></div>

--- a/frontend/app/src/components/TextArea.svelte
+++ b/frontend/app/src/components/TextArea.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
     import { onMount } from "svelte";
+    import { _ } from "svelte-i18n";
+    import { interpolate, type ResourceKey } from "../i18n/i18n";
+    import { translatable } from "../actions/translatable";
     let inp: HTMLTextAreaElement;
     export let disabled: boolean = false;
     export let invalid: boolean = false;
     export let value: string = "";
     export let autofocus: boolean = false;
-    export let placeholder: string = "";
+    export let placeholder: ResourceKey | undefined = undefined;
     export let minlength: number = 0;
     export let maxlength: number = Number.MAX_VALUE;
     export let rows: number = 4;
@@ -37,7 +40,8 @@
             {disabled}
             {minlength}
             {maxlength}
-            {placeholder}
+            placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
+            use:translatable={{ key: placeholder, position: "absolute", right: 12, top: 12 }}
             bind:value
             class="textbox"
             class:scroll />

--- a/frontend/app/src/components/Translatable.svelte
+++ b/frontend/app/src/components/Translatable.svelte
@@ -1,68 +1,11 @@
 <script lang="ts">
-    import Translate from "svelte-material-icons/Translate.svelte";
-
-    import { _, locale, dictionary } from "svelte-i18n";
-    import { editmode, editingLabel, type ResourceKey, interpolate } from "../i18n/i18n";
-
-    interface LocaleDictionary {
-        [key: string]: LocaleDictionary | string | Array<string | LocaleDictionary> | null;
-    }
-    type LocalesDictionary = {
-        [key: string]: LocaleDictionary | null;
-    };
+    import { _ } from "svelte-i18n";
+    import { type ResourceKey, interpolate } from "../i18n/i18n";
+    import { translatable } from "../actions/translatable";
 
     export let resourceKey: ResourceKey;
-
-    $: editable =
-        $editmode && !$locale?.startsWith("en") && translatable($dictionary, $locale, resourceKey);
-
-    /**
-     * We need to make sure that only keys that actually exist in the dictionary are considered translatable
-     * - this is a bit horrible but it will *only* run if we are in edit mode && the locale is not english
-     */
-    function translatable(
-        dictionary: LocalesDictionary,
-        locale: string | null | undefined,
-        { key }: ResourceKey,
-    ): boolean {
-        if (!locale) return false;
-        const localeValues = dictionary[locale];
-
-        if (!localeValues) return false;
-
-        if (key in localeValues) return true;
-
-        const keys = key.split(".");
-        let result: any = localeValues;
-
-        for (const key of keys) {
-            const val = result[key];
-            if (val == null) {
-                return false;
-            } else {
-                result = val;
-            }
-        }
-        return result !== undefined;
-    }
-
-    function editLabel() {
-        editingLabel.set(resourceKey);
-    }
 </script>
 
-<span>
+<span use:translatable={{ key: resourceKey }}>
     {interpolate($_, resourceKey)}
 </span>
-
-{#if editable}
-    <span role="button" tabindex="0" class="edit" on:click|stopPropagation={editLabel}>
-        <Translate color={"var(--accent)"} size={"0.8em"} />
-    </span>
-{/if}
-
-<style lang="scss">
-    .edit {
-        cursor: pointer;
-    }
-</style>

--- a/frontend/app/src/components/UsernameInput.svelte
+++ b/frontend/app/src/components/UsernameInput.svelte
@@ -3,6 +3,7 @@
     import Input from "./Input.svelte";
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
+    import { i18nKey } from "../i18n/i18n";
 
     const MIN_EXTANT_USERNAME_LENGTH = 3;
     const MAX_USERNAME_LENGTH = 15;
@@ -80,6 +81,6 @@
     minlength={MIN_EXTANT_USERNAME_LENGTH}
     maxlength={MAX_USERNAME_LENGTH}
     countdown
-    placeholder={$_("register.enterUsername")}>
+    placeholder={i18nKey("register.enterUsername")}>
     <slot />
 </Input>

--- a/frontend/app/src/components/home/AccessGateControl.svelte
+++ b/frontend/app/src/components/home/AccessGateControl.svelte
@@ -215,14 +215,14 @@
             <Legend label={i18nKey("access.minDissolveDelay")} />
             <Input
                 maxlength={100}
-                placeholder={$_("access.optional")}
+                placeholder={i18nKey("access.optional")}
                 invalid={invalidDissolveDelay}
                 bind:value={minDissolveDelay} />
 
             <Legend label={i18nKey("access.minStake")} />
             <Input
                 maxlength={100}
-                placeholder={$_("access.optional")}
+                placeholder={i18nKey("access.optional")}
                 invalid={invalidMinStake}
                 bind:value={minStake} />
         {:else if selectedGateKey === "payment_gate_folder"}

--- a/frontend/app/src/components/home/ChatListSearch.svelte
+++ b/frontend/app/src/components/home/ChatListSearch.svelte
@@ -7,6 +7,7 @@
         OpenChat,
         UserSummary,
     } from "openchat-client";
+    import { i18nKey, type ResourceKey } from "../../i18n/i18n";
 
     const client = getContext<OpenChat>("client");
 
@@ -33,18 +34,18 @@
         }
     }
 
-    function getPlaceholder(scope: ChatListScope["kind"]): string {
+    function getPlaceholder(scope: ChatListScope["kind"]): ResourceKey {
         switch (scope) {
             case "community":
-                return "searchChannelsPlaceholder";
+                return i18nKey("searchChannelsPlaceholder");
             case "group_chat":
-                return "searchGroupsPlaceholder";
+                return i18nKey("searchGroupsPlaceholder");
             case "direct_chat":
-                return "searchUsersPlaceholder";
+                return i18nKey("searchUsersPlaceholder");
             case "favourite":
-                return "searchFavouritesPlaceholder";
+                return i18nKey("searchFavouritesPlaceholder");
             case "none":
-                return "searchPlaceholder";
+                return i18nKey("searchPlaceholder");
         }
     }
 

--- a/frontend/app/src/components/home/CryptoTransferBuilder.svelte
+++ b/frontend/app/src/components/home/CryptoTransferBuilder.svelte
@@ -189,7 +189,7 @@
                             maxlength={200}
                             rows={3}
                             autofocus={false}
-                            placeholder={$_("tokenTransfer.messagePlaceholder")}
+                            placeholder={i18nKey("tokenTransfer.messagePlaceholder")}
                             bind:value={message} />
                     </div>
                     {#if error}

--- a/frontend/app/src/components/home/GiphySelector.svelte
+++ b/frontend/app/src/components/home/GiphySelector.svelte
@@ -214,7 +214,7 @@
                         type={"text"}
                         autofocus
                         countdown
-                        placeholder={$_("search")}
+                        placeholder={i18nKey("search")}
                         on:change={onChange}
                         value={searchTerm} />
                 </div>
@@ -252,7 +252,7 @@
                         type={"text"}
                         autofocus={false}
                         countdown
-                        placeholder={$_("tokenTransfer.messagePlaceholder")}
+                        placeholder={i18nKey("tokenTransfer.messagePlaceholder")}
                         bind:value={message} />
                 </div>
             </form>

--- a/frontend/app/src/components/home/MakeProposalModal.svelte
+++ b/frontend/app/src/components/home/MakeProposalModal.svelte
@@ -284,7 +284,7 @@
                         minlength={MIN_TITLE_LENGTH}
                         maxlength={MAX_TITLE_LENGTH}
                         countdown
-                        placeholder={$_("proposal.maker.enterTitle")} />
+                        placeholder={i18nKey("proposal.maker.enterTitle")} />
                 </section>
                 <section>
                     <Legend
@@ -296,7 +296,7 @@
                         bind:value={url}
                         maxlength={MAX_URL_LENGTH}
                         countdown
-                        placeholder={$_("proposal.maker.enterUrl")} />
+                        placeholder={i18nKey("proposal.maker.enterUrl")} />
                 </section>
                 <section>
                     <div class="summary-heading">
@@ -340,7 +340,7 @@
                                 scroll
                                 minlength={MIN_SUMMARY_LENGTH}
                                 maxlength={MAX_SUMMARY_LENGTH}
-                                placeholder={$_("proposal.maker.enterSummary")} />
+                                placeholder={i18nKey("proposal.maker.enterSummary")} />
                         {/if}
                     </div>
                 </section>
@@ -374,7 +374,7 @@
                                 invalid={recipientOwner.length > 0 && !recipientOwnerValid}
                                 maxlength={63}
                                 bind:value={recipientOwner}
-                                placeholder={$_("proposal.maker.enterRecipientOwner")} />
+                                placeholder={i18nKey("proposal.maker.enterRecipientOwner")} />
                         </section>
                         <section>
                             <Legend
@@ -385,7 +385,7 @@
                                 invalid={!recipientSubaccountValid}
                                 maxlength={64}
                                 bind:value={recipientSubaccount}
-                                placeholder={$_("proposal.maker.enterRecipientSubaccount")} />
+                                placeholder={i18nKey("proposal.maker.enterRecipientSubaccount")} />
                         </section>
                         <section>
                             <Legend
@@ -398,8 +398,8 @@
                                 minlength={1}
                                 maxlength={20}
                                 bind:value={amountText}
-                                placeholder={$_("proposal.maker.enterAmount", {
-                                    values: { token },
+                                placeholder={i18nKey("proposal.maker.enterAmount", {
+                                    token,
                                 })} />
                         </section>
                     </div>
@@ -416,7 +416,7 @@
                                 minlength={CANISTER_ID_LENGTH}
                                 maxlength={CANISTER_ID_LENGTH}
                                 countdown
-                                placeholder="2ouva-viaaa-aaaaq-aaamq-cai" />
+                                placeholder={i18nKey("2ouva-viaaa-aaaaq-aaamq-cai")} />
                         </section>
                         <section>
                             <Legend label={i18nKey("proposal.maker.tokenInfoUrl")} required />
@@ -425,7 +425,7 @@
                                 minlength={1}
                                 maxlength={100}
                                 bind:value={addTokenInfoUrl}
-                                placeholder="https://token.com/info" />
+                                placeholder={i18nKey("https://token.com/info")} />
                         </section>
                         <section>
                             <Legend label={i18nKey("proposal.maker.howToBuyUrl")} required />
@@ -434,7 +434,7 @@
                                 minlength={1}
                                 maxlength={100}
                                 bind:value={addTokenHowToBuyUrl}
-                                placeholder="https://token.com/how-to-buy" />
+                                placeholder={i18nKey("https://token.com/how-to-buy")} />
                         </section>
                         <section>
                             <Legend
@@ -445,7 +445,9 @@
                                 minlength={1}
                                 maxlength={100}
                                 bind:value={addTokenTransactionUrlFormat}
-                                placeholder={`https://token.com/transactions/{transaction_index}`} />
+                                placeholder={i18nKey(
+                                    `https://token.com/transactions/{transaction_index}`,
+                                )} />
                         </section>
                         <section>
                             <Legend label={i18nKey("proposal.maker.tokenLogo")} />
@@ -455,7 +457,7 @@
                                 minlength={0}
                                 maxlength={10000}
                                 bind:value={addTokenLogo}
-                                placeholder="data:image/svg+xml;base64,PHN2ZyB3aW..." />
+                                placeholder={i18nKey("data:image/svg+xml;base64,PHN2ZyB3aW...")} />
                         </section>
                     </div>
                 {/if}

--- a/frontend/app/src/components/home/MessageEntry.svelte
+++ b/frontend/app/src/components/home/MessageEntry.svelte
@@ -33,7 +33,8 @@
     import { scream } from "../../utils/scream";
     import { snowing } from "../../stores/snow";
     import Translatable from "../Translatable.svelte";
-    import { i18nKey } from "../../i18n/i18n";
+    import { i18nKey, interpolate } from "../../i18n/i18n";
+    import { translatable } from "../../actions/translatable";
 
     const client = getContext<OpenChat>("client");
 
@@ -148,12 +149,12 @@
     }
 
     $: placeholder = !canEnterText
-        ? $_("sendTextDisabled")
+        ? i18nKey("sendTextDisabled")
         : attachment !== undefined
-          ? $_("enterCaption")
+          ? i18nKey("enterCaption")
           : dragging
-            ? $_("dropFile")
-            : $_("enterMessage");
+            ? i18nKey("dropFile")
+            : i18nKey("enterMessage");
 
     export function replaceSelection(text: string) {
         restoreSelection();
@@ -556,7 +557,13 @@
                         class:dragging
                         contenteditable
                         on:paste
-                        {placeholder}
+                        placeholder={interpolate($_, placeholder)}
+                        use:translatable={{
+                            key: placeholder,
+                            position: "absolute",
+                            right: 12,
+                            top: 12,
+                        }}
                         spellcheck
                         on:dragover={() => (dragging = true)}
                         on:dragenter={() => (dragging = true)}
@@ -649,6 +656,7 @@
     .container {
         margin: 0 $sp3;
         flex: 1;
+        position: relative;
     }
 
     .textbox {

--- a/frontend/app/src/components/home/PollBuilder.svelte
+++ b/frontend/app/src/components/home/PollBuilder.svelte
@@ -178,7 +178,7 @@
                                 minlength={0}
                                 maxlength={MAX_QUESTION_LENGTH}
                                 countdown
-                                placeholder={$_("poll.optionalQuestion")} />
+                                placeholder={i18nKey("poll.optionalQuestion")} />
                         </div>
 
                         <div class="section">
@@ -205,7 +205,7 @@
                                             maxlength={MAX_ANSWER_LENGTH}
                                             countdown
                                             on:enter={addAnswer}
-                                            placeholder={$_(
+                                            placeholder={i18nKey(
                                                 poll.pollAnswers.size === MAX_ANSWERS
                                                     ? "poll.maxReached"
                                                     : "poll.answerText",

--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -264,7 +264,7 @@
                             maxlength={200}
                             rows={3}
                             autofocus={false}
-                            placeholder={$_("tokenTransfer.messagePlaceholder")}
+                            placeholder={i18nKey("tokenTransfer.messagePlaceholder")}
                             bind:value={message} />
                     </div>
                     <div class="winners">

--- a/frontend/app/src/components/home/ReminderBuilder.svelte
+++ b/frontend/app/src/components/home/ReminderBuilder.svelte
@@ -126,7 +126,7 @@
                 <TextArea
                     maxlength={1000}
                     rows={4}
-                    placeholder={$_("reminders.notePlaceholder")}
+                    placeholder={i18nKey("reminders.notePlaceholder")}
                     bind:value={note} />
             </div>
 

--- a/frontend/app/src/components/home/RulesEditor.svelte
+++ b/frontend/app/src/components/home/RulesEditor.svelte
@@ -5,7 +5,7 @@
     import Toggle from "../Toggle.svelte";
     import type { UpdatedRules, Level } from "openchat-client";
     import { afterUpdate } from "svelte";
-    import { i18nKey, interpolate, type ResourceKey } from "../../i18n/i18n";
+    import { i18nKey, type ResourceKey } from "../../i18n/i18n";
     import Translatable from "../Translatable.svelte";
 
     const MAX_RULES_LENGTH = 1024;

--- a/frontend/app/src/components/home/RulesEditor.svelte
+++ b/frontend/app/src/components/home/RulesEditor.svelte
@@ -63,7 +63,7 @@
         minlength={0}
         maxlength={MAX_RULES_LENGTH}
         rows={8}
-        placeholder={interpolate($_, i18nKey("rules.placeholder", undefined, level, true))} />
+        placeholder={i18nKey("rules.placeholder", undefined, level, true)} />
     {#if editing && rules.enabled}
         <Toggle
             id="new-version"

--- a/frontend/app/src/components/home/SuspendModal.svelte
+++ b/frontend/app/src/components/home/SuspendModal.svelte
@@ -43,7 +43,7 @@
                 autofocus
                 minlength={3}
                 maxlength={512}
-                placeholder={$_("reasonForSuspension")}>
+                placeholder={i18nKey("reasonForSuspension")}>
                 {#if showError}
                     <ErrorMessage
                         ><Translatable

--- a/frontend/app/src/components/home/addgroup/GroupDetails.svelte
+++ b/frontend/app/src/components/home/addgroup/GroupDetails.svelte
@@ -46,10 +46,7 @@
         minlength={MIN_LENGTH}
         maxlength={MAX_LENGTH}
         countdown
-        placeholder={interpolate(
-            $_,
-            i18nKey("newGroupName", undefined, candidateGroup.level, true),
-        )} />
+        placeholder={i18nKey("newGroupName", undefined, candidateGroup.level, true)} />
 </section>
 
 <section>
@@ -59,10 +56,7 @@
         disabled={busy}
         bind:value={candidateGroup.description}
         maxlength={MAX_DESC_LENGTH}
-        placeholder={interpolate(
-            $_,
-            i18nKey("newGroupDesc", undefined, candidateGroup.level, true),
-        )} />
+        placeholder={i18nKey("newGroupDesc", undefined, candidateGroup.level, true)} />
 </section>
 
 <style lang="scss">

--- a/frontend/app/src/components/home/addgroup/GroupDetails.svelte
+++ b/frontend/app/src/components/home/addgroup/GroupDetails.svelte
@@ -5,7 +5,7 @@
     import Input from "../../Input.svelte";
     import TextArea from "../../TextArea.svelte";
     import Legend from "../../Legend.svelte";
-    import { i18nKey, interpolate } from "../../../i18n/i18n";
+    import { i18nKey } from "../../../i18n/i18n";
 
     const MIN_LENGTH = 3;
     const MAX_LENGTH = 25;

--- a/frontend/app/src/components/home/communities/details/UserGroup.svelte
+++ b/frontend/app/src/components/home/communities/details/UserGroup.svelte
@@ -148,7 +148,7 @@
                 countdown
                 invalid={nameDirty && !nameValid}
                 on:blur={autoCorrect}
-                placeholder={$_("communities.enterUserGroupName")} />
+                placeholder={i18nKey("communities.enterUserGroupName")} />
         </div>
         <div class="search">
             <Search
@@ -156,7 +156,7 @@
                 fill
                 searching={false}
                 bind:searchTerm
-                placeholder={"searchUsersPlaceholder"} />
+                placeholder={i18nKey("searchUsersPlaceholder")} />
         </div>
         {#if matchedUsers.length > 0}
             <div style={`height: ${matchedUsers.length * 80}px`} class="searched-users">

--- a/frontend/app/src/components/home/communities/details/UserGroups.svelte
+++ b/frontend/app/src/components/home/communities/details/UserGroups.svelte
@@ -143,7 +143,7 @@
                     fill
                     searching={false}
                     bind:searchTerm
-                    placeholder={"communities.searchUserGroups"} />
+                    placeholder={i18nKey("communities.searchUserGroups")} />
             </div>
             {#if canManageUserGroups}
                 <div class="add">

--- a/frontend/app/src/components/home/communities/edit/ChooseChannels.svelte
+++ b/frontend/app/src/components/home/communities/edit/ChooseChannels.svelte
@@ -85,7 +85,7 @@
             maxlength={MAX_CHANNEL_LENGTH}
             countdown
             on:enter={addChannel}
-            placeholder={$_("communities.channelPlaceholder")} />
+            placeholder={i18nKey("communities.channelPlaceholder")} />
     </div>
     <div class="add-btn" on:click={addChannel}>
         <PlusCircleOutline size={$iconSize} color={"var(--icon-txt)"} />

--- a/frontend/app/src/components/home/communities/edit/Details.svelte
+++ b/frontend/app/src/components/home/communities/edit/Details.svelte
@@ -67,7 +67,7 @@
         minlength={MIN_LENGTH}
         maxlength={MAX_LENGTH}
         countdown
-        placeholder={$_("communities.namePlaceholder")} />
+        placeholder={i18nKey("communities.namePlaceholder")} />
 </section>
 <section>
     <Legend label={i18nKey("communities.primaryLanguage")} />
@@ -87,7 +87,7 @@
         disabled={busy}
         bind:value={candidate.description}
         maxlength={MAX_DESC_LENGTH}
-        placeholder={$_("communities.descriptionPlaceholder")} />
+        placeholder={i18nKey("communities.descriptionPlaceholder")} />
 </section>
 
 <style lang="scss">

--- a/frontend/app/src/components/home/communities/edit/EditableChannel.svelte
+++ b/frontend/app/src/components/home/communities/edit/EditableChannel.svelte
@@ -7,6 +7,7 @@
     import { iconSize } from "../../../../stores/iconSize";
     import { _ } from "svelte-i18n";
     import { createEventDispatcher, onMount } from "svelte";
+    import { i18nKey } from "../../../../i18n/i18n";
 
     const dispatch = createEventDispatcher();
 
@@ -39,7 +40,7 @@
             invalid={editingChannel.name.length < min || editingChannel.name.length > max}
             on:blur={stopEditing}
             on:enter={stopEditing}
-            placeholder={$_("communities.updateChannelPlaceholder")}>
+            placeholder={i18nKey("communities.updateChannelPlaceholder")}>
             <div class="hash">
                 <Pound size={$iconSize} color={"var(--icon-txt)"} />
             </div>

--- a/frontend/app/src/components/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components/home/communities/explore/Explore.svelte
@@ -130,7 +130,7 @@
                         bind:searchTerm
                         searching={false}
                         on:searchEntered={() => search(true)}
-                        placeholder={$_("communities.search")} />
+                        placeholder={i18nKey("communities.search")} />
                 </div>
                 <div class="create">
                     <Button on:click={createCommunity} hollow
@@ -157,7 +157,7 @@
                         fill
                         bind:searchTerm
                         on:searchEntered={() => search(true)}
-                        placeholder={$_("communities.search")} />
+                        placeholder={i18nKey("communities.search")} />
                 </div>
             {/if}
         </div>

--- a/frontend/app/src/components/home/groupdetails/Members.svelte
+++ b/frontend/app/src/components/home/groupdetails/Members.svelte
@@ -170,7 +170,7 @@
             on:searchEntered={() => membersList.reset()}
             searching={false}
             bind:searchTerm
-            placeholder={"search"} />
+            placeholder={i18nKey("search")} />
     </div>
 
     {#if showBlocked || showInvited}

--- a/frontend/app/src/components/home/profile/SaveAccount.svelte
+++ b/frontend/app/src/components/home/profile/SaveAccount.svelte
@@ -38,7 +38,7 @@
     autofocus
     countdown={false}
     maxlength={100}
-    placeholder={$_("tokenTransfer.enterAccountName")} />
+    placeholder={i18nKey("tokenTransfer.enterAccountName")} />
 
 <style lang="scss">
     .account {

--- a/frontend/app/src/components/home/profile/SendCrypto.svelte
+++ b/frontend/app/src/components/home/profile/SendCrypto.svelte
@@ -187,7 +187,7 @@
                     countdown={false}
                     maxlength={100}
                     invalid={targetAccount.length > 0 && !targetAccountValid}
-                    placeholder={$_("cryptoAccount.sendTarget")} />
+                    placeholder={i18nKey("cryptoAccount.sendTarget")} />
 
                 <div class="qr" on:click={scan}>
                     <QrcodeScan size={$iconSize} color={"var(--icon-selected)"} />

--- a/frontend/app/src/components/home/profile/UserProfile.svelte
+++ b/frontend/app/src/components/home/profile/UserProfile.svelte
@@ -325,7 +325,7 @@
                         invalid={false}
                         disabled={readonly}
                         maxlength={MAX_BIO_LENGTH}
-                        placeholder={$_("enterBio")}>
+                        placeholder={i18nKey("enterBio")}>
                         {#if bioError !== undefined}
                             <ErrorMessage
                                 ><Translatable resourceKey={i18nKey(bioError)} /></ErrorMessage>


### PR DESCRIPTION
Annotate translatable elements using a svelte action rather than the `Translatable` component. 

This allows us to annotate existing elements _without_ wrapping in a span which makes it easier to deal with things like placeholder attribute translation.  