### PR TITLE
Add `is_from_identity_canister` to `UserRegistered` events

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `access_token` endpoint + sync secret key ([#5398](https://github.com/open-chat-labs/open-chat/pull/5398))
 
+### Changed
+
+- Add `is_from_identity_canister` to `UserRegistered` events ([#5402](https://github.com/open-chat-labs/open-chat/pull/5402))
+
 ## [[2.0.1046](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1046-local_user_index)] - 2024-02-05
 
 ### Added

--- a/backend/canisters/local_user_index/api/src/updates/register_user.rs
+++ b/backend/canisters/local_user_index/api/src/updates/register_user.rs
@@ -1,13 +1,14 @@
 use candid::CandidType;
 use ic_ledger_types::AccountIdentifier;
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 use types::UserId;
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
     pub username: String,
     pub referral_code: Option<String>,
-    pub public_key: Vec<u8>,
+    pub public_key: ByteBuf,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Propagate video call operators ids for guarding ([#5374](https://github.com/open-chat-labs/open-chat/pull/5374))
 - Generate and store an OpenChat public/private key pair ([#5383](https://github.com/open-chat-labs/open-chat/pull/5383))
 - Sync secret key with local_user_indexes ([#5398](https://github.com/open-chat-labs/open-chat/pull/5398))
+- Add `is_from_identity_canister` to `UserRegistered` events ([#5402](https://github.com/open-chat-labs/open-chat/pull/5402))
 
 ## [[2.0.1061](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1061-user_index)] - 2024-02-14
 

--- a/backend/canisters/user_index/api/src/lib.rs
+++ b/backend/canisters/user_index/api/src/lib.rs
@@ -25,6 +25,8 @@ pub struct UserRegistered {
     pub user_id: UserId,
     pub username: String,
     pub referred_by: Option<UserId>,
+    #[serde(default)]
+    pub is_from_identity_canister: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/backend/integration_tests/src/client/identity.rs
+++ b/backend/integration_tests/src/client/identity.rs
@@ -14,7 +14,6 @@ pub mod happy_path {
     use candid::Principal;
     use identity_canister::SignedDelegation;
     use pocket_ic::PocketIc;
-    use serde_bytes::ByteBuf;
     use types::{CanisterId, TimestampMillis};
 
     pub fn prepare_delegation(
@@ -27,7 +26,7 @@ pub mod happy_path {
             user.principal,
             identity_canister_id,
             &identity_canister::prepare_delegation::Args {
-                session_key: ByteBuf::from(user.public_key.clone()),
+                session_key: user.public_key.clone(),
                 max_time_to_live: None,
             },
         );
@@ -49,7 +48,7 @@ pub mod happy_path {
             user.principal,
             identity_canister_id,
             &identity_canister::get_delegation::Args {
-                session_key: ByteBuf::from(user.public_key.clone()),
+                session_key: user.public_key.clone(),
                 expiration,
             },
         );

--- a/backend/integration_tests/src/lib.rs
+++ b/backend/integration_tests/src/lib.rs
@@ -3,6 +3,7 @@
 use crate::utils::principal_to_username;
 use candid::Principal;
 use pocket_ic::PocketIc;
+use serde_bytes::ByteBuf;
 use types::{CanisterId, Cycles, UserId};
 
 mod batched_summary_and_event_tests;
@@ -56,7 +57,7 @@ pub struct TestEnv {
 pub struct User {
     pub principal: Principal,
     pub user_id: UserId,
-    pub public_key: Vec<u8>,
+    pub public_key: ByteBuf,
 }
 
 impl User {

--- a/backend/integration_tests/src/rng.rs
+++ b/backend/integration_tests/src/rng.rs
@@ -1,6 +1,7 @@
 use crate::NNS_INTERNET_IDENTITY_CANISTER_ID;
 use candid::Principal;
 use rand::{random, RngCore};
+use serde_bytes::ByteBuf;
 use types::MessageId;
 
 pub fn random_principal() -> Principal {
@@ -9,7 +10,7 @@ pub fn random_principal() -> Principal {
     Principal::from_slice(&random_bytes)
 }
 
-pub fn random_user_principal() -> (Principal, Vec<u8>) {
+pub fn random_user_principal() -> (Principal, ByteBuf) {
     let algorithm_bytes = [48u8, 60, 48, 12, 6, 10, 43, 6, 1, 4, 1, 131, 184, 67, 1, 2, 3, 44, 0];
     let random_bytes: [u8; 32] = random();
 
@@ -18,7 +19,7 @@ pub fn random_user_principal() -> (Principal, Vec<u8>) {
     public_key.extend_from_slice(NNS_INTERNET_IDENTITY_CANISTER_ID.as_slice());
     public_key.extend_from_slice(&random_bytes);
 
-    (Principal::self_authenticating(&public_key), public_key)
+    (Principal::self_authenticating(&public_key), ByteBuf::from(public_key))
 }
 
 pub fn random_string() -> String {


### PR DESCRIPTION
This allows us to differentiate between the old principals which are derived from II and the new principals which are derived from the new Identity canister.