### PR TITLE
persist community search results

### DIFF
--- a/frontend/app/src/stores/search.ts
+++ b/frontend/app/src/stores/search.ts
@@ -1,0 +1,24 @@
+import type { CommunityMatch } from "openchat-client";
+import { writable } from "svelte/store";
+
+type CommunitySearch = {
+    results: CommunityMatch[];
+    total: number;
+    index: number;
+};
+
+const store = writable<CommunitySearch>({
+    results: [],
+    total: 0,
+    index: 0,
+});
+
+export const communitySearchStore = {
+    subscribe: store.subscribe,
+    reset: () => store.update((val) => ({ ...val, index: 0 })),
+    nextPage: () => store.update((val) => ({ ...val, index: val.index + 1 })),
+    setResults: (results: CommunityMatch[]) => store.update((val) => ({ ...val, results })),
+    setTotal: (total: number) => store.update((val) => ({ ...val, total })),
+    appendResults: (results: CommunityMatch[]) =>
+        store.update((val) => ({ ...val, results: [...val.results, ...results] })),
+};

--- a/frontend/app/src/stores/search.ts
+++ b/frontend/app/src/stores/search.ts
@@ -13,6 +13,8 @@ const store = writable<CommunitySearch>({
     index: 0,
 });
 
+export const communitySearchTerm = writable<string>("");
+
 export const communitySearchStore = {
     subscribe: store.subscribe,
     reset: () => store.update((val) => ({ ...val, index: 0 })),
@@ -22,3 +24,5 @@ export const communitySearchStore = {
     appendResults: (results: CommunityMatch[]) =>
         store.update((val) => ({ ...val, results: [...val.results, ...results] })),
 };
+
+export const communitySearchScrollPos = writable<number>(0);


### PR DESCRIPTION
It's really annoying if you scroll down the list of communities and click on one and then go back and you have lost your place and have to start again. 

This keeps the results in a store and also preserves your scroll position. 

fixes #5184 