### PR TITLE
Change the way scroll position is managed when adding dynamic content

### DIFF
--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -335,7 +335,6 @@
 
     async function clientEvent(ev: Event): Promise<void> {
         await tick();
-        console.debug("SCROLL: onClientEvent: ", ev);
         if (ev instanceof LoadedNewMessages && !scrollingToMessage) {
             onLoadedNewMessages(ev.detail);
         }

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -548,6 +548,8 @@
                         on:startVideoCall
                         on:expandMessage />
 
+                    <pre>{msg.messageIndex}</pre>
+
                     {#if !inert && !isPrize}
                         <TimeAndTicks
                             {pinned}

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -548,8 +548,6 @@
                         on:startVideoCall
                         on:expandMessage />
 
-                    <pre>{msg.messageIndex}</pre>
-
                     {#if !inert && !isPrize}
                         <TimeAndTicks
                             {pinned}


### PR DESCRIPTION
When the size of the scrollable container changes due to the addition of more content (when loading new messages in either scroll direction), we sometimes need to intervene to maintain a consistent perceived scroll position. Finding precisely the right point in time to make this adjustment has always been problematic and previously we have tried to use the svelte lifecycle to pick the right moment. 

This is a new approach that uses a mutation observer that will fire if changes in the target (or its subtree) cause the target's scrollHeight to change. 

This _appears_ to result in more reliable adjustments and fewer (if any) unexpected leaps in scroll position when loading dynamic content. 