### PR TITLE
Ignore leading @ symbol when searching for users

### DIFF
--- a/frontend/app/src/components/FindUser.svelte
+++ b/frontend/app/src/components/FindUser.svelte
@@ -11,6 +11,7 @@
     import { translatable } from "../actions/translatable";
     import MatchingUser from "./MatchingUser.svelte";
     import Translatable from "./Translatable.svelte";
+    import { trimLeadingAtSymbol } from "../utils/user";
 
     export let mode: "add" | "edit";
     export let enabled = true;
@@ -61,7 +62,7 @@
     }
 
     function onInput() {
-        debounce(inp.value);
+        debounce(trimLeadingAtSymbol(inp.value));
     }
 
     function clearFilter() {

--- a/frontend/app/src/components/home/ChatListSearch.svelte
+++ b/frontend/app/src/components/home/ChatListSearch.svelte
@@ -8,6 +8,7 @@
         UserSummary,
     } from "openchat-client";
     import { i18nKey, type ResourceKey } from "../../i18n/i18n";
+    import { trimLeadingAtSymbol } from "../../utils/user";
 
     const client = getContext<OpenChat>("client");
 
@@ -56,6 +57,10 @@
     async function performSearch(ev: CustomEvent<string>) {
         searchResultsAvailable = false;
         searchTerm = ev.detail;
+
+        if ($chatListScope.kind === "direct_chat") {
+            searchTerm = trimLeadingAtSymbol(searchTerm);
+        }
 
         if (searchTerm !== "") {
             try {

--- a/frontend/app/src/components/home/communities/details/UserGroup.svelte
+++ b/frontend/app/src/components/home/communities/details/UserGroup.svelte
@@ -20,6 +20,7 @@
     import Legend from "../../../Legend.svelte";
     import { i18nKey } from "../../../../i18n/i18n";
     import Translatable from "../../../Translatable.svelte";
+    import { trimLeadingAtSymbol } from "../../../../utils/user";
 
     const dispatch = createEventDispatcher();
     const client = getContext<OpenChat>("client");
@@ -34,7 +35,11 @@
     let added: Set<string> = new Set();
     let removed: Set<string> = new Set();
     let searchVirtualList: VirtualList;
+    let searchTermEntered = "";
+    let usersDirty = false;
+    let saving = false;
 
+    $: searchTerm = trimLeadingAtSymbol(searchTermEntered);
     $: searchTermLower = searchTerm.toLowerCase();
     $: groupUsers = [...userGroup.members]
         .map((m) => communityUsers[m])
@@ -48,10 +53,6 @@
         trimmedName.length <= MAX_LENGTH &&
         trimmedName.indexOf(" ") < 0;
     $: valid = nameValid && userGroup.members.size > 0;
-
-    let searchTerm = "";
-    let usersDirty = false;
-    let saving = false;
 
     const MIN_LENGTH = 3;
     const MAX_LENGTH = 25;
@@ -115,7 +116,7 @@
     }
 
     function addUserToGroup(user: UserSummary) {
-        searchTerm = "";
+        searchTermEntered = "";
         added.add(user.userId);
         removed.delete(user.userId);
         changeUsers(() => userGroup.members.add(user.userId));
@@ -155,7 +156,7 @@
                 on:searchEntered={() => searchVirtualList?.reset()}
                 fill
                 searching={false}
-                bind:searchTerm
+                bind:searchTerm={searchTermEntered}
                 placeholder={i18nKey("searchUsersPlaceholder")} />
         </div>
         {#if matchedUsers.length > 0}

--- a/frontend/app/src/components/home/groupdetails/Members.svelte
+++ b/frontend/app/src/components/home/groupdetails/Members.svelte
@@ -24,6 +24,7 @@
     import UserGroups from "../communities/details/UserGroups.svelte";
     import Translatable from "../../Translatable.svelte";
     import { i18nKey } from "../../../i18n/i18n";
+    import { trimLeadingAtSymbol } from "../../../utils/user";
 
     const client = getContext<OpenChat>("client");
 
@@ -58,12 +59,13 @@
     //$: canPromoteMyselfToOwner = me !== undefined && me.role !== "owner" && $platformModerator;
     $: canPromoteMyselfToOwner = false;
 
-    let searchTerm = "";
+    let searchTermEntered = "";
     let id = collection.id;
     let membersList: VirtualList;
     let memberView: "members" | "blocked" | "invited" = "members";
     let selectedTab: "users" | "groups" = "users";
 
+    $: searchTerm = trimLeadingAtSymbol(searchTermEntered);
     $: searchTermLower = searchTerm.toLowerCase();
 
     $: {
@@ -107,7 +109,7 @@
     }
 
     function matchesSearch(searchTermLower: string, user: UserSummary): boolean {
-        if (searchTerm === "") return true;
+        if (searchTermLower === "") return true;
         if (user.username === undefined) return true;
         return (
             user.username.toLowerCase().includes(searchTermLower) ||
@@ -186,7 +188,7 @@
         <Search
             on:searchEntered={() => membersList.reset()}
             searching={false}
-            bind:searchTerm
+            bind:searchTerm={searchTermEntered}
             placeholder={i18nKey("search")} />
     </div>
 

--- a/frontend/app/src/utils/user.ts
+++ b/frontend/app/src/utils/user.ts
@@ -7,3 +7,8 @@ export function buildDisplayName(users: UserLookup, userId: string, me: boolean,
     const name = me ? get(_)("you") : summary?.displayName ?? summary?.username ?? get(_)("unknownUser");
     return bold ? `**${name}**` : name;
 }
+
+export function trimLeadingAtSymbol(term: string): string {
+    return term.length > 0 && term[0] === "@" ? term.substring(1) : term;
+}
+


### PR DESCRIPTION
Some people (myself included) have tried to search for users by starting with the @ symbol but the only time that works, and is in fact necessary, is when searching for messages by username. This PR disregards a leading @ when searching for users.

This is on webtest