### PR TITLE
add footer tray for mobile view

### DIFF
--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -1128,11 +1128,13 @@
             on:askToSpeak
             on:hangup />
     {/if}
+
     {#if $layoutStore.showMiddle}
         <MiddlePanel
             {joining}
             bind:currentChatMessages
             on:startVideoCall
+            on:profile={showProfile}
             on:successfulImport={successfulImport}
             on:clearSelection={() => page(routeForScope($chatListScope))}
             on:leaveGroup={triggerConfirm}

--- a/frontend/app/src/components/home/LeftPanel.svelte
+++ b/frontend/app/src/components/home/LeftPanel.svelte
@@ -3,6 +3,7 @@
     import { rtlStore } from "../../stores/rtl";
     import { currentTheme } from "../../theme/themes";
     import { layoutStore } from "../../stores/layout";
+    import BottomNav from "./nav/BottomNav.svelte";
 </script>
 
 <section
@@ -28,6 +29,10 @@
             on:askToSpeak
             on:hangup
             on:newChannel />
+
+        {#if $layoutStore.showBottomNav}
+            <BottomNav on:profile />
+        {/if}
     </div>
 </section>
 

--- a/frontend/app/src/components/home/MiddlePanel.svelte
+++ b/frontend/app/src/components/home/MiddlePanel.svelte
@@ -92,7 +92,7 @@
     {#if $pathParams.kind === "explore_groups_route"}
         <RecommendedGroups {joining} on:joinGroup on:leaveGroup on:upgrade />
     {:else if $pathParams.kind === "communities_route"}
-        <ExploreCommunities on:upgrade on:createCommunity />
+        <ExploreCommunities on:profile on:upgrade on:createCommunity />
     {:else if $pathParams.kind === "admin_route"}
         {#await import("./admin/Admin.svelte")}
             <div class="loading">

--- a/frontend/app/src/components/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components/home/communities/explore/Explore.svelte
@@ -30,6 +30,8 @@
         communitySearchTerm,
     } from "../../../../stores/search";
     import Fab from "../../../Fab.svelte";
+    import { layoutStore } from "../../../../stores/layout";
+    import BottomNav from "../../nav/BottomNav.svelte";
 
     const client = getContext<OpenChat>("client");
     const dispatch = createEventDispatcher();
@@ -247,6 +249,9 @@
             <ArrowUp size={$iconSize} color={"#fff"} />
         </Fab>
     </div>
+    {#if $layoutStore.showBottomNav}
+        <BottomNav on:profile />
+    {/if}
 </div>
 
 <style lang="scss">
@@ -260,12 +265,16 @@
         position: relative;
 
         @include mobile() {
-            padding: $sp3;
+            padding: 0;
             gap: $sp3;
         }
     }
 
     .header {
+        @include mobile() {
+            padding: $sp3 $sp3 0 $sp3;
+        }
+
         .title-row {
             display: flex;
             align-items: center;
@@ -318,6 +327,10 @@
         @include nice-scrollbar();
         flex: auto;
         height: 3000px;
+
+        @include mobile() {
+            padding: 0 $sp3 0 $sp3;
+        }
     }
 
     .communities {
@@ -354,7 +367,7 @@
         text-align: center;
     }
 
-    $size: 200px;
+    $size: 150px;
 
     .loading {
         width: $size;

--- a/frontend/app/src/components/home/nav/BottomNav.svelte
+++ b/frontend/app/src/components/home/nav/BottomNav.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import CommonNavElements from "./CommonNavElements.svelte";
+</script>
+
+<div class="bottom-nav">
+    <CommonNavElements
+        menuAlignment={"end"}
+        menuPosition={"top"}
+        menuGutter={0}
+        orientation={"horizontal"}
+        on:profile />
+</div>
+
+<style lang="scss">
+    .bottom-nav {
+        display: flex;
+        justify-content: space-evenly;
+        align-items: center;
+        border-top: var(--bw) solid var(--bd);
+        height: toRem(60);
+        flex: 0 0 toRem(60);
+    }
+</style>

--- a/frontend/app/src/components/home/nav/CommonNavElements.svelte
+++ b/frontend/app/src/components/home/nav/CommonNavElements.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+    import Hamburger from "svelte-material-icons/Menu.svelte";
+    import MessageOutline from "svelte-material-icons/MessageOutline.svelte";
+    import ForumOutline from "svelte-material-icons/ForumOutline.svelte";
+    import HeartOutline from "svelte-material-icons/HeartOutline.svelte";
+    import HoverIcon from "../../HoverIcon.svelte";
+    import MenuIcon from "../../MenuIcon.svelte";
+    import NavItem from "./NavItem.svelte";
+    import { i18nKey } from "../../../i18n/i18n";
+    import { mobileWidth } from "../../../stores/screenDimensions";
+    import MainMenu from "./MainMenu.svelte";
+    import { createEventDispatcher, getContext } from "svelte";
+    import { AvatarSize, type OpenChat, type UserSummary } from "openchat-client";
+    import Avatar from "../../Avatar.svelte";
+    import { pathParams } from "../../../routes";
+    import page from "page";
+    import type { Alignment, Position } from "../../../utils/alignment";
+
+    const client = getContext<OpenChat>("client");
+    const dispatch = createEventDispatcher();
+
+    export let menuPosition: Position = "right";
+    export let menuAlignment: Alignment = "start";
+    export let menuGutter: number = 20;
+    export let orientation: "vertical" | "horizontal" = "vertical";
+
+    let iconSize = $mobileWidth ? "1.2em" : "1.4em"; // in this case we don't want to use the standard store
+
+    $: createdUser = client.user;
+    $: userStore = client.userStore;
+    $: user = $userStore[$createdUser.userId] as UserSummary | undefined; // annoying that this annotation is necessary
+    $: chatListScope = client.chatListScope;
+    $: avatarSize = $mobileWidth ? AvatarSize.Small : AvatarSize.Default;
+    $: anonUser = client.anonUser;
+    $: communityExplorer = $pathParams.kind === "communities_route";
+    $: unreadDirectCounts = client.unreadDirectCounts;
+    $: directVideoCallCounts = client.directVideoCallCounts;
+    $: groupVideoCallCounts = client.groupVideoCallCounts;
+    $: unreadGroupCounts = client.unreadGroupCounts;
+    $: unreadFavouriteCounts = client.unreadFavouriteCounts;
+    $: favouritesVideoCallCounts = client.favouritesVideoCallCounts;
+</script>
+
+{#if orientation === "vertical"}
+    <NavItem separator {orientation} label={i18nKey("communities.mainMenu")}>
+        <div class="hover logo">
+            <MenuIcon position={menuPosition} align={menuAlignment} gutter={menuGutter}>
+                <span slot="icon">
+                    <HoverIcon>
+                        <Hamburger size={iconSize} color={"var(--icon-txt)"} />
+                    </HoverIcon>
+                </span>
+                <span slot="menu">
+                    <MainMenu on:wallet on:halloffame on:upgrade on:profile />
+                </span>
+            </MenuIcon>
+        </div>
+    </NavItem>
+{/if}
+
+{#if user !== undefined}
+    <NavItem {orientation} label={i18nKey("profile.title")} on:click={() => dispatch("profile")}>
+        <Avatar url={client.userAvatarUrl(user)} userId={user.userId} size={avatarSize} />
+    </NavItem>
+{/if}
+
+<NavItem
+    {orientation}
+    selected={$chatListScope.kind === "direct_chat" && !communityExplorer}
+    label={i18nKey("communities.directChats")}
+    disabled={$anonUser}
+    unread={$unreadDirectCounts.chats}
+    video={$directVideoCallCounts}
+    on:click={() => page("/user")}>
+    <div class="hover direct">
+        <MessageOutline size={iconSize} color={"var(--icon-txt)"} />
+    </div>
+</NavItem>
+
+<NavItem
+    {orientation}
+    selected={$chatListScope.kind === "group_chat" && !communityExplorer}
+    label={i18nKey("communities.groupChats")}
+    unread={client.mergeCombinedUnreadCounts($unreadGroupCounts)}
+    video={$groupVideoCallCounts}
+    on:click={() => page("/group")}>
+    <div class="hover direct">
+        <ForumOutline size={iconSize} color={"var(--icon-txt)"} />
+    </div>
+</NavItem>
+
+<NavItem
+    {orientation}
+    separator={orientation === "vertical"}
+    selected={$chatListScope.kind === "favourite" && !communityExplorer}
+    disabled={$anonUser}
+    label={i18nKey("communities.favourites")}
+    unread={client.mergeCombinedUnreadCounts($unreadFavouriteCounts)}
+    video={$favouritesVideoCallCounts}
+    on:click={() => page("/favourite")}>
+    <div class="hover favs">
+        <HeartOutline size={iconSize} color={"var(--icon-txt)"} />
+    </div>
+</NavItem>
+
+<style lang="scss">
+    :global(.hover svg path) {
+        transition: fill 250ms ease-in-out;
+    }
+
+    @media (hover: hover) {
+        :global(.nav-item .avatar:not(.selected):hover) {
+            box-shadow: 0 0 0 1px var(--icon-selected);
+        }
+
+        :global(.nav-item:hover .hover svg path) {
+            fill: var(--icon-selected);
+        }
+
+        :global(.nav-item:hover .hover) {
+            border-color: var(--icon-selected);
+        }
+    }
+
+    :global(.nav-item.selected svg path) {
+        fill: var(--icon-selected);
+    }
+
+    $size: toRem(48);
+    $mobile-size: toRem(40);
+
+    .logo {
+        width: $size;
+        height: $size;
+        margin: auto;
+
+        @include mobile() {
+            width: $mobile-size;
+            height: $mobile-size;
+        }
+    }
+
+    .hover {
+        width: $size;
+        height: $size;
+        border: 1px solid transparent;
+        border-radius: var(--nav-icon-rd);
+        background: var(--icon-hv);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: border-color 250ms ease-in-out;
+
+        @include mobile() {
+            width: $mobile-size;
+            height: $mobile-size;
+        }
+    }
+</style>

--- a/frontend/app/src/components/home/nav/LeftNav.svelte
+++ b/frontend/app/src/components/home/nav/LeftNav.svelte
@@ -1,55 +1,41 @@
 <script lang="ts">
     import Avatar from "../../Avatar.svelte";
-    import MenuIcon from "../../MenuIcon.svelte";
-    import HoverIcon from "../../HoverIcon.svelte";
-    import HeartOutline from "svelte-material-icons/HeartOutline.svelte";
-    import Compass from "svelte-material-icons/CompassOutline.svelte";
     import Hamburger from "svelte-material-icons/Menu.svelte";
+    import Compass from "svelte-material-icons/CompassOutline.svelte";
     import ArrowRight from "svelte-material-icons/ArrowExpandRight.svelte";
-    import MessageOutline from "svelte-material-icons/MessageOutline.svelte";
-    import ForumOutline from "svelte-material-icons/ForumOutline.svelte";
     import {
         AvatarSize,
         type CommunitySummary,
         type OpenChat,
-        type UserSummary,
         emptyCombinedUnreadCounts,
     } from "openchat-client";
     import { mobileWidth } from "../../../stores/screenDimensions";
     import { communityListScrollTop } from "../../../stores/scrollPos";
     import { pathParams } from "../../../routes";
     import page from "page";
-    import { createEventDispatcher, getContext, onDestroy, onMount, tick } from "svelte";
-    import LeftNavItem from "./LeftNavItem.svelte";
-    import MainMenu from "./MainMenu.svelte";
-    import { navOpen } from "../../../stores/layout";
+    import { getContext, onDestroy, onMount, tick } from "svelte";
+    import NavItem from "./NavItem.svelte";
+    import { layoutStore, navOpen } from "../../../stores/layout";
     import { flip } from "svelte/animate";
     import { type DndEvent, dndzone } from "svelte-dnd-action";
     import { isTouchDevice } from "../../../utils/devices";
     import { rtlStore } from "../../../stores/rtl";
     import { i18nKey } from "../../../i18n/i18n";
+    import CommonNavElements from "./CommonNavElements.svelte";
+    import MenuIcon from "../../MenuIcon.svelte";
+    import HoverIcon from "../../HoverIcon.svelte";
+    import MainMenu from "./MainMenu.svelte";
 
     const client = getContext<OpenChat>("client");
-    const dispatch = createEventDispatcher();
     const flipDurationMs = 300;
 
-    $: createdUser = client.user;
-    $: userStore = client.userStore;
-    $: user = $userStore[$createdUser.userId] as UserSummary | undefined; // annoying that this annotation is necessary
     $: avatarSize = $mobileWidth ? AvatarSize.Small : AvatarSize.Default;
     $: communities = client.communitiesList;
     $: selectedCommunity = client.selectedCommunity;
     $: chatListScope = client.chatListScope;
-    $: unreadDirectCounts = client.unreadDirectCounts;
-    $: directVideoCallCounts = client.directVideoCallCounts;
-    $: groupVideoCallCounts = client.groupVideoCallCounts;
-    $: favouritesVideoCallCounts = client.favouritesVideoCallCounts;
-    $: unreadGroupCounts = client.unreadGroupCounts;
-    $: unreadFavouriteCounts = client.unreadFavouriteCounts;
     $: unreadCommunityChannelCounts = client.unreadCommunityChannelCounts;
     $: communityChannelVideoCallCounts = client.communityChannelVideoCallCounts;
     $: communityExplorer = $pathParams.kind === "communities_route";
-    $: anonUser = client.anonUser;
     $: selectedCommunityId = $selectedCommunity?.id.communityId;
 
     let iconSize = $mobileWidth ? "1.2em" : "1.4em"; // in this case we don't want to use the standard store
@@ -109,24 +95,8 @@
         }
     }
 
-    function viewProfile() {
-        dispatch("profile");
-    }
-
     function exploreCommunities() {
         page("/communities");
-    }
-
-    function directChats() {
-        page("/user");
-    }
-
-    function groupChats() {
-        page("/group");
-    }
-
-    function favouriteChats() {
-        page("/favourite");
     }
 
     function selectCommunity(community: CommunitySummary) {
@@ -143,64 +113,19 @@
 <svelte:body on:click={closeIfOpen} />
 
 <section class="nav" class:open={$navOpen} class:rtl={$rtlStore}>
-    <div class="top">
-        <LeftNavItem separator label={i18nKey("communities.mainMenu")}>
-            <div class="hover logo">
-                <MenuIcon position="right" align="start" gutter={20}>
-                    <span slot="icon">
-                        <HoverIcon>
-                            <Hamburger size={iconSize} color={"var(--icon-txt)"} />
-                        </HoverIcon>
-                    </span>
-                    <span slot="menu">
-                        <MainMenu on:wallet on:halloffame on:upgrade on:profile />
-                    </span>
-                </MenuIcon>
-            </div>
-        </LeftNavItem>
-
-        {#if user !== undefined}
-            <LeftNavItem label={i18nKey("profile.title")} on:click={viewProfile}>
-                <Avatar url={client.userAvatarUrl(user)} userId={user.userId} size={avatarSize} />
-            </LeftNavItem>
-        {/if}
-
-        <LeftNavItem
-            selected={$chatListScope.kind === "direct_chat" && !communityExplorer}
-            label={i18nKey("communities.directChats")}
-            disabled={$anonUser}
-            unread={$unreadDirectCounts.chats}
-            video={$directVideoCallCounts}
-            on:click={directChats}>
-            <div class="hover direct">
-                <MessageOutline size={iconSize} color={"var(--icon-txt)"} />
-            </div>
-        </LeftNavItem>
-
-        <LeftNavItem
-            selected={$chatListScope.kind === "group_chat" && !communityExplorer}
-            label={i18nKey("communities.groupChats")}
-            unread={client.mergeCombinedUnreadCounts($unreadGroupCounts)}
-            video={$groupVideoCallCounts}
-            on:click={groupChats}>
-            <div class="hover direct">
-                <ForumOutline size={iconSize} color={"var(--icon-txt)"} />
-            </div>
-        </LeftNavItem>
-
-        <LeftNavItem
-            selected={$chatListScope.kind === "favourite" && !communityExplorer}
-            separator
-            disabled={$anonUser}
-            label={i18nKey("communities.favourites")}
-            unread={client.mergeCombinedUnreadCounts($unreadFavouriteCounts)}
-            video={$favouritesVideoCallCounts}
-            on:click={favouriteChats}>
-            <div class="hover favs">
-                <HeartOutline size={iconSize} color={"var(--icon-txt)"} />
-            </div>
-        </LeftNavItem>
-    </div>
+    {#if !$layoutStore.showBottomNav}
+        <div class="top">
+            <CommonNavElements
+                menuAlignment={"start"}
+                menuPosition={"right"}
+                menuGutter={20}
+                orientation={"horizontal"}
+                on:profile
+                on:wallet
+                on:halloffame
+                on:upgrade />
+        </div>
+    {/if}
 
     <div
         use:dndzone={{
@@ -215,7 +140,7 @@
         class="middle">
         {#each communityItems as community (community._id)}
             <div animate:flip={{ duration: flipDurationMs }}>
-                <LeftNavItem
+                <NavItem
                     selected={community.id.communityId === selectedCommunityId &&
                         $chatListScope.kind !== "favourite" &&
                         !communityExplorer}
@@ -235,26 +160,44 @@
                             !communityExplorer}
                         url={client.communityAvatarUrl(community.id.communityId, community.avatar)}
                         size={avatarSize} />
-                </LeftNavItem>
+                </NavItem>
             </div>
         {/each}
     </div>
 
     <div class="bottom">
-        <LeftNavItem
+        <NavItem
             selected={communityExplorer}
             label={i18nKey("communities.explore")}
             on:click={exploreCommunities}>
             <div class="explore hover">
                 <Compass size={iconSize} color={"var(--icon-txt)"} />
             </div>
-        </LeftNavItem>
-        <LeftNavItem label={$navOpen ? i18nKey("collapse") : i18nKey("expand")}>
+        </NavItem>
+        <NavItem label={$navOpen ? i18nKey("collapse") : i18nKey("expand")}>
             <div class:open={$navOpen} on:click|stopPropagation={toggleNav} class="expand hover">
                 <ArrowRight size={iconSize} color={"var(--icon-txt)"} />
             </div>
-        </LeftNavItem>
+        </NavItem>
     </div>
+    {#if $layoutStore.showBottomNav}
+        <div class="corner">
+            <NavItem orientation={"vertical"} label={i18nKey("communities.mainMenu")}>
+                <div class="hover logo">
+                    <MenuIcon position={"right"} align={"start"} gutter={20}>
+                        <span slot="icon">
+                            <HoverIcon>
+                                <Hamburger size={iconSize} color={"var(--icon-txt)"} />
+                            </HoverIcon>
+                        </span>
+                        <span slot="menu">
+                            <MainMenu on:wallet on:halloffame on:upgrade on:profile />
+                        </span>
+                    </MenuIcon>
+                </div>
+            </NavItem>
+        </div>
+    {/if}
 </section>
 
 <style lang="scss">
@@ -263,24 +206,24 @@
     }
 
     @media (hover: hover) {
-        :global(.left-nav-item .avatar:not(.selected):hover) {
+        :global(.nav-item .avatar:not(.selected):hover) {
             box-shadow: 0 0 0 1px var(--icon-selected);
         }
 
-        :global(.left-nav-item:hover .hover svg path) {
+        :global(.nav-item:hover .hover svg path) {
             fill: var(--icon-selected);
         }
 
-        :global(.left-nav-item:hover .hover) {
+        :global(.nav-item:hover .hover) {
             border-color: var(--icon-selected);
         }
     }
 
-    :global(.left-nav-item.selected svg path) {
+    :global(.nav-item.selected svg path) {
         fill: var(--icon-selected);
     }
 
-    :global(.left-nav-item.selected) {
+    :global(.nav-item.selected) {
         .explore {
             border: 1px solid var(--icon-selected);
         }
@@ -298,7 +241,7 @@
         overflow-x: hidden;
         height: 100%;
         background: var(--panel-nav-bg);
-        padding: $sp2 0;
+        padding: $sp2 0 0 0;
         border-right: var(--bw) solid var(--bd);
         @include z-index("left-nav");
         transition: width 250ms ease-in-out;
@@ -312,7 +255,7 @@
 
         @include mobile() {
             width: toRem(60);
-            padding: $sp1 0;
+            padding: $sp1 0 0 0;
         }
 
         &.open {
@@ -331,15 +274,15 @@
         display: flex;
         flex-direction: column;
     }
-    .logo {
-        width: $size;
-        height: $size;
-        margin: auto;
 
-        @include mobile() {
-            width: $mobile-size;
-            height: $mobile-size;
-        }
+    .bottom {
+        padding-bottom: $sp1;
+    }
+
+    .corner {
+        display: flex;
+        flex: 0 0 toRem(60);
+        border-top: var(--bw) solid var(--bd);
     }
 
     .middle {

--- a/frontend/app/src/components/home/nav/NavItem.svelte
+++ b/frontend/app/src/components/home/nav/NavItem.svelte
@@ -12,20 +12,29 @@
     export let unread = emptyUnreadCounts();
     export let video = { muted: 0, unmuted: 0 };
     export let disabled = false;
+    export let orientation: "vertical" | "horizontal" = "vertical";
 </script>
 
-<div role="button" tabindex="0" class:separator class:selected class="left-nav-item" on:click>
+<div
+    role="button"
+    tabindex="0"
+    class:separator
+    class:selected
+    class:horizontal={orientation === "horizontal"}
+    class="nav-item"
+    on:click>
     <div class="icon" title={$_(label.key, label.params)}>
         <slot />
         <UnreadCount {unread} />
         <VideoCallIcon {video} />
     </div>
-    <div class="label"><Translatable resourceKey={label} /></div>
-    <div class="menu"><slot name="menu" /></div>
+    {#if orientation === "vertical"}
+        <div class="label"><Translatable resourceKey={label} /></div>
+    {/if}
 </div>
 
 <style lang="scss">
-    :global(.left-nav-item .unread-count) {
+    :global(.nav-item .unread-count) {
         right: toRem(-9);
         top: 85%;
         @include mobile() {
@@ -36,7 +45,7 @@
     $size: toRem(48);
     $mobile-size: toRem(40);
 
-    .left-nav-item {
+    .nav-item {
         display: flex;
         align-items: center;
         gap: toRem(16);
@@ -61,6 +70,15 @@
             border-bottom: 1px solid var(--bd);
         }
 
+        &.horizontal {
+            flex-direction: column;
+            gap: $sp2;
+
+            &.selected {
+                background-color: transparent;
+            }
+        }
+
         .icon {
             flex: 0 0 $size;
             width: $size;
@@ -80,6 +98,11 @@
         .label {
             flex: auto;
             white-space: nowrap;
+        }
+
+        &.vertical .label {
+            text-transform: uppercase;
+            @include font(light, normal, fs-60);
         }
 
         .menu {

--- a/frontend/app/src/stores/layout.ts
+++ b/frontend/app/src/stores/layout.ts
@@ -16,6 +16,7 @@ type RightPanelState = "hidden" | "floating" | "inline";
 
 export type Layout = {
     showNav: boolean;
+    showBottomNav: boolean;
     showMiddle: boolean;
     showLeft: boolean;
     rightPanel: RightPanelState;
@@ -44,6 +45,7 @@ export const layoutStore: Readable<Layout> = derived(
                         $pathParams.kind === "admin_route") &&
                         !showRight));
             return {
+                showBottomNav: showNav,
                 showNav,
                 showMiddle,
                 showLeft,
@@ -57,6 +59,7 @@ export const layoutStore: Readable<Layout> = derived(
                 $pathParams.kind !== "communities_route" && $pathParams.kind !== "admin_route";
 
             return {
+                showBottomNav: false,
                 showNav: !$disableLeftNav,
                 showMiddle: true,
                 showLeft,


### PR DESCRIPTION
This is more consistent with other similar mobile apps and makes important navigations easier to reach with the thumb. 

This will also free up some space in the left nav on mobile for streak / chit related CTA. 

<img width="403" alt="image" src="https://github.com/open-chat-labs/open-chat/assets/86620/9458a603-d67c-4ca4-8a52-feb0bf418a60">
