### PR TITLE
Fix geo location

### DIFF
--- a/frontend/app/src/components/home/profile/Accounts.svelte
+++ b/frontend/app/src/components/home/profile/Accounts.svelte
@@ -98,11 +98,13 @@
 
     function showSwap(ledger: string) {
         selectedLedger = ledger;
-        if (client.swapRestricted()) {
-            manageMode = "restricted";
-        } else {
-            manageMode = "swap";
-        }
+        client.swapRestricted().then((restricted) => {
+            if (restricted) {
+                manageMode = "restricted";
+            } else {
+                manageMode = "swap";
+            }
+        });
     }
 
     function showTransactions(token: { ledger: string; urlFormat: string }) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -560,15 +560,6 @@ export class OpenChat extends OpenChatAgentWorker {
         localStorage.removeItem("ic-identity");
         initialiseTracking(config);
 
-        getUserCountryCode()
-            .then((country) => {
-                this._userLocation = country;
-                console.debug("GEO: derived user's location: ", country);
-            })
-            .catch((err) => {
-                console.warn("GEO: Unable to determine user's country location", err);
-            });
-
         this._ocIdentityStorage = new IdentityStorage();
         this._authClient = AuthClient.create({
             idleOptions: {
@@ -6633,10 +6624,24 @@ export class OpenChat extends OpenChatAgentWorker {
         return { kind: "direct_chat" };
     }
 
+    getUserLocation(): Promise<string | undefined> {
+        if (this._userLocation !== undefined) return Promise.resolve(this._userLocation);
+        return getUserCountryCode()
+            .then((country) => {
+                this._userLocation = country;
+                console.debug("GEO: derived user's location: ", country);
+                return country;
+            })
+            .catch((err) => {
+                console.warn("GEO: Unable to determine user's country location", err);
+                return undefined;
+            });
+    }
+
     // **** End of Communities stuff
     diamondDurationToMs = diamondDurationToMs;
-    swapRestricted(): boolean {
-        return featureRestricted(this._userLocation, "swap");
+    swapRestricted(): Promise<boolean> {
+        return this.getUserLocation().then((location) => featureRestricted(location, "swap"));
     }
 
     /**

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -6625,7 +6625,9 @@ export class OpenChat extends OpenChatAgentWorker {
     }
 
     getUserLocation(): Promise<string | undefined> {
-        if (this._userLocation !== undefined) return Promise.resolve(this._userLocation);
+        if (this._userLocation !== undefined) {
+            return Promise.resolve(this._userLocation);
+        }
         return getUserCountryCode()
             .then((country) => {
                 this._userLocation = country;

--- a/frontend/openchat-client/src/utils/location.ts
+++ b/frontend/openchat-client/src/utils/location.ts
@@ -1,7 +1,23 @@
 /** For various reasons, we need to (attempt to) figure out roughly where the user is
  */
 
-export function getUserCountryCode(): Promise<string> {
+const MAX_RETRIES = 5;
+
+function primaryApi(): Promise<string> {
+    return fetch("https://api.ip.sb/geoip")
+        .then((resp) => {
+            if (!resp.ok) {
+                console.debug("GEO: error getting ip from ip location");
+                throw new Error(
+                    `Failed to get location data from the preferred service: ${resp.status}, ${resp.statusText}`,
+                );
+            }
+            return resp.json();
+        })
+        .then((json) => json.country_code);
+}
+
+function secondaryApi(): Promise<string> {
     const BASE_URL = "https://api.iplocation.net";
 
     return fetch(`${BASE_URL}/?cmd=get-ip`)
@@ -21,4 +37,23 @@ export function getUserCountryCode(): Promise<string> {
             return resp.json();
         })
         .then((json) => json.country_code2);
+}
+
+export function getUserCountryCode(retries: number = 0, delay: number = 50): Promise<string> {
+    return primaryApi().catch((primaryErr) => {
+        return secondaryApi().catch((secondaryErr) => {
+            // this means that *both* apis have failed
+            if (retries >= MAX_RETRIES) {
+                throw new Error(
+                    `Unable to determine the user's country code: ${primaryErr}, ${secondaryErr}`,
+                );
+            }
+
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    getUserCountryCode(retries + 1, delay * 2).then(resolve);
+                }, delay);
+            });
+        });
+    });
 }


### PR DESCRIPTION
This does a few things: 

* introduces a new api to try _before_ we try the existing api
* adds a retry mechanism for the overall process
* requests country code only on demand when the user attempts to use the swap feature (in case we have some sort of rate limiting problem). 