### PR TITLE
Retry unfinished ICPSwaps + some extra logging

### DIFF
--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added optional `to` arg to `chit_events` ([#5929](https://github.com/open-chat-labs/open-chat/pull/5929))
 
+### Changed
+
+- Retry unfinished ICPSwaps + some extra logging ([#5946](https://github.com/open-chat-labs/open-chat/pull/5946))
+
 ## [[2.0.1197](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1197-user)] - 2024-06-06
 
 ### Added

--- a/backend/canisters/user/impl/src/timer_job_types.rs
+++ b/backend/canisters/user/impl/src/timer_job_types.rs
@@ -62,6 +62,8 @@ pub struct RemoveExpiredEventsJob;
 pub struct ProcessTokenSwapJob {
     pub token_swap: TokenSwap,
     pub attempt: u32,
+    #[serde(default)]
+    pub debug: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -241,7 +243,7 @@ impl Job for RemoveExpiredEventsJob {
 impl Job for ProcessTokenSwapJob {
     fn execute(self) {
         ic_cdk::spawn(async move {
-            process_token_swap(self.token_swap, self.attempt).await;
+            process_token_swap(self.token_swap, self.attempt, self.debug).await;
         });
     }
 }


### PR DESCRIPTION
During the NNS subnet incident on Friday 14th the ICP ledger was unavailable for some of the time. There is some evidence that if a user was swapping to ICP during this time, ICPSwap might see their balance as zero and fail to deposit or withdraw the funds.

For an example see this user's canister logs at timestamp 1718396682164:
https://2enzf-kyaaa-aaaaf-avdva-cai.raw.icp0.io/logs

Also see the transaction history of ICP transferred into their account shows no record on the Friday so the withdrawal definitely failed:
https://dashboard.internetcomputer.org/transactions?p=7&m=12439383&t=259&to=550b8e0b7f5291b84cdd8c196f90c0756a2eb66f2ed79be378e5d550ea9380b3


