### PR TITLE
move source map declaration to its own line

### DIFF
--- a/frontend/app/rollup.config.mjs
+++ b/frontend/app/rollup.config.mjs
@@ -23,6 +23,7 @@ import fs from "fs-extra";
 import path from "path";
 import rimraf from "rimraf";
 import { fileURLToPath } from "url";
+import { sourcemapNewline } from "../sourcemapNewline.mjs";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -403,6 +404,7 @@ export default {
             ],
             hook: "generateBundle",
         }),
+        sourcemapNewline(),
     ],
     watch: {
         clearScreen: false,

--- a/frontend/openchat-service-worker/rollup.config.mjs
+++ b/frontend/openchat-service-worker/rollup.config.mjs
@@ -5,6 +5,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import del from "rollup-plugin-delete";
+import { sourcemapNewline } from "../sourcemapNewline.mjs";
 
 export default {
     input: `./src/service_worker.ts`,
@@ -27,5 +28,6 @@ export default {
             dedupe: ["@dfinity/candid"],
         }),
         terser(),
+        sourcemapNewline(),
     ],
 };

--- a/frontend/openchat-worker/rollup.config.mjs
+++ b/frontend/openchat-worker/rollup.config.mjs
@@ -5,6 +5,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import del from "rollup-plugin-delete";
+import { sourcemapNewline } from "../sourcemapNewline.mjs";
 
 export default {
     input: `./src/worker.ts`,
@@ -26,5 +27,6 @@ export default {
             preferBuiltins: false,
         }),
         terser(),
+        sourcemapNewline(),
     ],
 };

--- a/frontend/sourcemapNewline.mjs
+++ b/frontend/sourcemapNewline.mjs
@@ -1,0 +1,18 @@
+export function sourcemapNewline() {
+    return {
+        name: "sourcemap-newline",
+        generateBundle(_, bundle) {
+            for (const fileName in bundle) {
+                const chunk = bundle[fileName];
+                if (chunk.type === "chunk") {
+                    const sourceMappingRegex = /(\/\/[@#] sourceMappingURL=.+)(\r?\n)?$/;
+                    const match = chunk.code.match(sourceMappingRegex);
+
+                    if (match) {
+                        chunk.code = chunk.code.replace(sourceMappingRegex, "\n$1\n");
+                    }
+                }
+            }
+        },
+    };
+}


### PR DESCRIPTION
Rollbar support have speculated that their failure to parse our source maps might be because our sourcemap declarations are on the same line as the rest of the code. While this _seems_ like a) their problem and b) horseshit, it's probably worth a try to get more meaningful logging. 