### PR TITLE
capture userID in the registerUser tracking

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -4484,7 +4484,7 @@ export class OpenChat extends OpenChatAgentWorker {
             .then((res) => {
                 console.log("register user response: ", res);
                 if (res.kind === "success") {
-                    gaTrack("registered_user", "registration");
+                    gaTrack("registered_user", "registration", res.userId);
                     if (this._referralCode !== undefined) {
                         gaTrack("registered_user_with_referral_code", "registration");
                     }


### PR DESCRIPTION
CLS wanted (hashed) email and wallet, but we don't always have that and the underlying requirement is something unique to the user so this should do. 