### PR TITLE
make sure that history is preserved consistently

### DIFF
--- a/frontend/app/src/components/home/thread/ThreadPreview.svelte
+++ b/frontend/app/src/components/home/thread/ThreadPreview.svelte
@@ -6,6 +6,7 @@
         OpenChat,
         routeForChatIdentifier,
         type MultiUserChat,
+        routeForMessageContext,
     } from "openchat-client";
     import { pop } from "../../../utils/transition";
     import { _ } from "svelte-i18n";
@@ -87,6 +88,12 @@
     });
 
     function selectThread() {
+        // we want to preserve the right history so we will insert a history entry to represent the URL for the message context
+        const url = routeForMessageContext($chatListScope.kind, {
+            chatId: thread.chatId,
+            threadRootMessageIndex: thread.rootMessage.event.messageIndex,
+        });
+        window.history.pushState(null, "", url);
         page(
             `${routeForChatIdentifier($chatListScope.kind, thread.chatId)}/${
                 thread.rootMessage.event.messageIndex


### PR DESCRIPTION
Add an intermediate history entry when we open thread from the chat list so that the back button does the same as the app level button (and this also avoids the blank screen issue we were seeing before I _think_).