### PR TITLE
Activity improvements

### DIFF
--- a/frontend/app/src/components/home/DailyChitModal.svelte
+++ b/frontend/app/src/components/home/DailyChitModal.svelte
@@ -212,11 +212,11 @@
 <style lang="scss">
     :root {
         --offset: -20px;
-        --margin-top: -28px;
+        --margin-top: -24px;
         --scale: 2.5;
         @include mobile() {
             --offset: -18px;
-            --margin-top: -25px;
+            --margin-top: -22px;
             --scale: 2;
         }
     }

--- a/frontend/app/src/components/home/activity/ActivityFeed.svelte
+++ b/frontend/app/src/components/home/activity/ActivityFeed.svelte
@@ -38,9 +38,9 @@
     }
 
     function loadActivity() {
-        client.messageActivityFeed().then((resp) => {
+        client.messageActivityFeed().subscribe((resp, final) => {
             activityEvents.set(resp.events);
-            if ($activityEvents.length > 0) {
+            if ($activityEvents.length > 0 && final) {
                 client.markActivityFeedRead($activityEvents[0].timestamp);
             }
         });

--- a/frontend/app/src/stores/activity.ts
+++ b/frontend/app/src/stores/activity.ts
@@ -1,3 +1,6 @@
+import { type MessageActivityEvent } from "openchat-shared";
 import { writable } from "svelte/store";
 
 export const activityFeedShowing = writable<boolean>(false);
+
+export const activityEvents = writable<MessageActivityEvent[]>([]);

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -1825,7 +1825,7 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
                 break;
 
             case "messageActivityFeed":
-                executeThenReply(payload, correlationId, agent.messageActivityFeed());
+                streamReplies(payload, correlationId, agent.messageActivityFeed());
                 break;
 
             case "markActivityFeedRead":


### PR DESCRIPTION
Store the activity feed in an in memory store so that we don't keep reloading it when we navigate back and forth (particularly affects mobile). 

Convert the feed to a stream so that the hydrated message can be filled in _after_ the feed has rendered. This paves the way for relatively easily rehydrating in batches as and when it seems necessary. 