### PR TITLE
Revert "Remove events from heap + remove code to migrate events to st…

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Consolidate `summary` and `c2c_summary` args ([#6723](https://github.com/open-chat-labs/open-chat/pull/6723))
-- Remove events from heap ([#6729](https://github.com/open-chat-labs/open-chat/pull/6729))
 - Fix case where some thread messages were not updated in stable memory ([#6736](https://github.com/open-chat-labs/open-chat/pull/6736))
 
 ## [[2.0.1423](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1423-community)] - 2024-11-05

--- a/backend/canisters/community/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/community/impl/src/lifecycle/post_upgrade.rs
@@ -18,16 +18,8 @@ fn post_upgrade(args: Args) {
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);
 
-    let (mut data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
+    let (data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
         msgpack::deserialize(reader).unwrap();
-
-    assert!(data.stable_memory_event_migration_complete);
-
-    for channel in data.channels.iter_mut() {
-        if channel.chat.events.thread_messages_to_update_in_stable_memory_len() > 0 {
-            data.stable_memory_event_migration_complete = false;
-        }
-    }
 
     canister_logger::init_with_logs(data.test_mode, errors, logs, traces);
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Consolidate `summary` and `c2c_summary` args ([#6723](https://github.com/open-chat-labs/open-chat/pull/6723))
-- Remove events from heap ([#6729](https://github.com/open-chat-labs/open-chat/pull/6729))
 - Fix case where some thread messages were not updated in stable memory ([#6736](https://github.com/open-chat-labs/open-chat/pull/6736))
 
 ## [[2.0.1424](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1424-group)] - 2024-11-05

--- a/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -17,14 +17,8 @@ fn post_upgrade(args: Args) {
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);
 
-    let (mut data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
+    let (data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
         msgpack::deserialize(reader).unwrap();
-
-    assert!(data.stable_memory_event_migration_complete);
-
-    if data.chat.events.thread_messages_to_update_in_stable_memory_len() > 0 {
-        data.stable_memory_event_migration_complete = false;
-    }
 
     canister_logger::init_with_logs(data.test_mode, errors, logs, traces);
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Avoid extra key lookup when iterating over events ([#6680](https://github.com/open-chat-labs/open-chat/pull/6680))
 - Read events in batches when performing stable memory garbage collection ([#6682](https://github.com/open-chat-labs/open-chat/pull/6682))
 - Read events from stable memory once migration is complete ([#6722](https://github.com/open-chat-labs/open-chat/pull/6722))
-- Remove events from heap ([#6729](https://github.com/open-chat-labs/open-chat/pull/6729))
 
 ## [[2.0.1412](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1414-user)] - 2024-10-24
 

--- a/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -19,8 +19,6 @@ fn post_upgrade(args: Args) {
     let (data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
         msgpack::deserialize(reader).unwrap();
 
-    assert!(data.stable_memory_event_migration_complete);
-
     canister_logger::init_with_logs(data.test_mode, errors, logs, traces);
 
     let env = init_env(data.rng_seed);

--- a/backend/canisters/user/impl/src/regular_jobs.rs
+++ b/backend/canisters/user/impl/src/regular_jobs.rs
@@ -1,3 +1,4 @@
+use crate::updates::c2c_migrate_events_to_stable_memory::migrate_events_to_stable_memory_impl;
 use crate::Data;
 use utils::env::Environment;
 use utils::regular_jobs::{RegularJob, RegularJobs};
@@ -11,11 +12,13 @@ pub(crate) fn build() -> RegularJobs<Data> {
         5 * MINUTE_IN_MS,
     );
     let retry_deleting_files = RegularJob::new("Retry deleting files", retry_deleting_files, MINUTE_IN_MS);
+    let migrate_chat_events_to_stable_memory = RegularJob::new("Migrate chat events", migrate_chat_events_to_stable_memory, 0);
 
     RegularJobs::new(vec![
         check_cycles_balance,
         aggregate_direct_chat_metrics,
         retry_deleting_files,
+        migrate_chat_events_to_stable_memory,
     ])
 }
 
@@ -29,4 +32,8 @@ fn aggregate_direct_chat_metrics(_: &dyn Environment, data: &mut Data) {
 
 fn retry_deleting_files(_: &dyn Environment, _: &mut Data) {
     storage_bucket_client::retry_failed();
+}
+
+fn migrate_chat_events_to_stable_memory(_: &dyn Environment, data: &mut Data) {
+    migrate_events_to_stable_memory_impl(data, true);
 }

--- a/backend/canisters/user/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
@@ -1,0 +1,39 @@
+use crate::guards::caller_is_local_user_index;
+use crate::{mutate_state, Data};
+use canister_api_macros::update;
+use canister_tracing_macros::trace;
+use types::{CanisterId, Empty};
+use user_canister::c2c_migrate_events_to_stable_memory::*;
+
+#[update(guard = "caller_is_local_user_index", msgpack = true)]
+#[trace]
+fn c2c_migrate_events_to_stable_memory(_args: Args) -> Response {
+    mutate_state(|state| migrate_events_to_stable_memory_impl(&mut state.data, false))
+}
+
+pub(crate) fn migrate_events_to_stable_memory_impl(data: &mut Data, notify: bool) -> bool {
+    if data.stable_memory_event_migration_complete {
+        return true;
+    }
+    for chat in data.direct_chats.iter_mut() {
+        let finished = chat.events.migrate_next_batch_of_events_to_stable_storage();
+        if !finished {
+            return false;
+        }
+    }
+    if notify {
+        ic_cdk::spawn(notify_migration_to_stable_memory_complete(data.local_user_index_canister_id));
+    } else {
+        data.stable_memory_event_migration_complete = true;
+    }
+    true
+}
+
+async fn notify_migration_to_stable_memory_complete(local_group_index: CanisterId) {
+    if local_user_index_canister_c2c_client::c2c_mark_events_migrated_to_stable_memory(local_group_index, &Empty {})
+        .await
+        .is_ok()
+    {
+        mutate_state(|state| state.data.stable_memory_event_migration_complete = true);
+    }
+}

--- a/backend/canisters/user/impl/src/updates/mod.rs
+++ b/backend/canisters/user/impl/src/updates/mod.rs
@@ -10,6 +10,7 @@ pub mod c2c_charge_user_account;
 pub mod c2c_grant_super_admin;
 pub mod c2c_mark_community_updated_for_user;
 pub mod c2c_mark_group_updated_for_user;
+pub mod c2c_migrate_events_to_stable_memory;
 pub mod c2c_notify_achievement;
 pub mod c2c_notify_community_canister_events;
 pub mod c2c_notify_community_deleted;

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -48,14 +48,17 @@ pub struct ChatEvents {
     video_call_in_progress: Timestamped<Option<VideoCall>>,
     anonymized_id: String,
     search_index: SearchIndex,
+    #[serde(default = "default_next_event_to_migrate_to_stable_memory")]
+    next_event_to_migrate_to_stable_memory: Option<EventContext>,
+    #[serde(default)]
     thread_messages_to_update_in_stable_memory: Vec<MessageIndex>,
 }
 
-impl ChatEvents {
-    pub fn thread_messages_to_update_in_stable_memory_len(&self) -> usize {
-        self.thread_messages_to_update_in_stable_memory.len()
-    }
+fn default_next_event_to_migrate_to_stable_memory() -> Option<EventContext> {
+    Some(EventContext::default())
+}
 
+impl ChatEvents {
     pub fn update_event_in_stable_memory(&mut self, event_key: EventKey) {
         self.main.update_event_in_stable_memory(event_key);
     }
@@ -80,6 +83,7 @@ impl ChatEvents {
     }
 
     pub fn migrate_next_batch_of_events_to_stable_storage(&mut self) -> bool {
+        let mut total_count = 0;
         while !self.thread_messages_to_update_in_stable_memory.is_empty() {
             if ic_cdk::api::instruction_counter() > 1_000_000_000 {
                 return false;
@@ -95,9 +99,58 @@ impl ChatEvents {
                 self.update_event_in_stable_memory(message_index.into());
             }
             info!(chat = ?self.chat, count, "Updated threads in stable memory");
+            total_count += count;
         }
 
-        true
+        if self.next_event_to_migrate_to_stable_memory.is_none() {
+            return true;
+        };
+
+        while ic_cdk::api::instruction_counter() < 1_000_000_000 {
+            let EventContext {
+                thread_root_message_index: next_thread_root_message_index,
+                event_index: next_event_index,
+            } = self.next_event_to_migrate_to_stable_memory.clone().unwrap();
+
+            let (thread_root_message_index, events_list) = if let Some(message_index) = next_thread_root_message_index {
+                if let Some((index, next)) = self.threads.range_mut(message_index..).next() {
+                    (Some(*index), next)
+                } else {
+                    self.next_event_to_migrate_to_stable_memory = None;
+                    self.main.set_read_events_from_stable_memory(true);
+                    for events_list in self.threads.values_mut() {
+                        events_list.set_read_events_from_stable_memory(true);
+                    }
+                    info!(chat = ?self.chat, total_count, "Finished migrating events to stable memory");
+                    return true;
+                }
+            } else {
+                (None, &mut self.main)
+            };
+
+            let (count, next_event_index) = events_list.migrate_events_to_stable_memory(next_event_index, 100);
+            if let Some(event_index) = next_event_index {
+                self.next_event_to_migrate_to_stable_memory = Some(EventContext {
+                    thread_root_message_index,
+                    event_index,
+                });
+            } else {
+                self.next_event_to_migrate_to_stable_memory = Some(EventContext {
+                    thread_root_message_index: Some(thread_root_message_index.map_or(MessageIndex::default(), |m| m.incr())),
+                    event_index: EventIndex::default(),
+                });
+            }
+            total_count += count;
+        }
+        if total_count > 0 {
+            info!(
+                chat = ?self.chat,
+                count = total_count,
+                next = ?self.next_event_to_migrate_to_stable_memory,
+                "Migrated batch of events to stable memory"
+            );
+        }
+        false
     }
 
     pub fn new_direct_chat(
@@ -120,6 +173,7 @@ impl ChatEvents {
             video_call_in_progress: Timestamped::default(),
             anonymized_id: hex::encode(anonymized_id.to_be_bytes()),
             search_index: SearchIndex::default(),
+            next_event_to_migrate_to_stable_memory: None,
             thread_messages_to_update_in_stable_memory: Vec::new(),
         };
 
@@ -151,6 +205,7 @@ impl ChatEvents {
             video_call_in_progress: Timestamped::default(),
             anonymized_id: hex::encode(anonymized_id.to_be_bytes()),
             search_index: SearchIndex::default(),
+            next_event_to_migrate_to_stable_memory: None,
             thread_messages_to_update_in_stable_memory: Vec::new(),
         };
 

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -1,11 +1,13 @@
 use crate::last_updated_timestamps::LastUpdatedTimestamps;
 use crate::stable_storage::ChatEventsStableStorage;
-use crate::{ChatEventInternal, ChatInternal, EventKey, EventOrExpiredRangeInternal, EventsMap, MessageInternal};
+use crate::{
+    ChatEventInternal, ChatEventsMap, ChatInternal, EventKey, EventOrExpiredRangeInternal, EventsMap, MessageInternal,
+};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry::Vacant;
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, RangeBounds};
 use types::{
     Chat, ChatEvent, EventIndex, EventOrExpiredRange, EventWrapper, EventWrapperInternal, HydratedMention, Mention, Message,
     MessageId, MessageIndex, TimestampMillis, UserId,
@@ -13,17 +15,19 @@ use types::{
 
 #[derive(Serialize, Deserialize)]
 pub struct ChatEventsList {
+    events_map: ChatEventsMap,
     stable_events_map: ChatEventsStableStorage,
     message_id_map: HashMap<MessageId, EventIndex>,
     message_event_indexes: Vec<EventIndex>,
     latest_event_index: Option<EventIndex>,
     latest_event_timestamp: Option<TimestampMillis>,
+    read_events_from_stable_memory: bool,
 }
 
 impl ChatEventsList {
     pub fn update_event_in_stable_memory(&mut self, event_key: EventKey) {
         if let Some(event_index) = self.event_index(event_key) {
-            if let Some(event) = self.stable_events_map.get(event_index) {
+            if let Some(event) = self.events_map.get(event_index) {
                 self.stable_events_map.insert(event);
             }
         }
@@ -33,13 +37,34 @@ impl ChatEventsList {
         self.stable_events_map = ChatEventsStableStorage::new(chat, thread_root_message_index);
     }
 
+    pub fn set_read_events_from_stable_memory(&mut self, value: bool) {
+        self.read_events_from_stable_memory = value;
+    }
+
+    pub fn migrate_events_to_stable_memory(&mut self, start: EventIndex, max_events: usize) -> (usize, Option<EventIndex>) {
+        let mut count = 0;
+        let mut next_event_index = start;
+        for event in self.events_map.range(start..).take(max_events) {
+            count += 1;
+            next_event_index = event.index.incr();
+            self.stable_events_map.insert(event);
+        }
+        if Some(next_event_index) > self.latest_event_index {
+            (count, None)
+        } else {
+            (count, Some(next_event_index))
+        }
+    }
+
     pub fn new(chat: Chat, thread_root_message_index: Option<MessageIndex>) -> Self {
         ChatEventsList {
+            events_map: ChatEventsMap::default(),
             stable_events_map: ChatEventsStableStorage::new(chat, thread_root_message_index),
             message_id_map: HashMap::new(),
             message_event_indexes: Vec::new(),
             latest_event_index: None,
             latest_event_timestamp: None,
+            read_events_from_stable_memory: false,
         }
     }
 
@@ -67,7 +92,9 @@ impl ChatEventsList {
             expires_at,
             event,
         };
-        self.stable_events_map.insert(event_wrapper);
+        self.stable_events_map.insert(event_wrapper.clone());
+        self.events_map.insert(event_wrapper);
+
         self.latest_event_index = Some(event_index);
         self.latest_event_timestamp = Some(now);
 
@@ -106,7 +133,8 @@ impl ChatEventsList {
         if let Some(mut event) = self.get_event(event_key, EventIndex::default()) {
             update_event_fn(&mut event).map(|result| {
                 let event_index = event.index;
-                self.stable_events_map.insert(event);
+                self.stable_events_map.insert(event.clone());
+                self.events_map.insert(event);
                 (result, event_index)
             })
         } else {
@@ -138,7 +166,7 @@ impl ChatEventsList {
             (min_visible_event_index, self.latest_event_index.unwrap_or_default())
         };
 
-        let iter = self.stable_events_map.range(min..=max);
+        let iter = self.range_internal(min..=max);
 
         if ascending {
             Box::new(ChatEventsListIterator {
@@ -192,7 +220,7 @@ impl ChatEventsList {
 
     pub fn migrate_replies(&mut self, old: ChatInternal, new: ChatInternal) -> Vec<EventIndex> {
         let mut updated = Vec::new();
-        for mut event in self.stable_events_map.iter() {
+        for mut event in self.iter_internal() {
             if let Some(message) = event.event.as_message_mut() {
                 if let Some(r) = message.replies_to.as_mut() {
                     if let Some((chat, _)) = r.chat_if_other.as_mut() {
@@ -207,14 +235,14 @@ impl ChatEventsList {
 
         let updated_indexes = updated.iter().map(|e| e.index).collect();
         for event in updated {
-            self.stable_events_map.insert(event);
+            self.stable_events_map.insert(event.clone());
+            self.events_map.insert(event);
         }
         updated_indexes
     }
 
     pub(crate) fn event_count_since<F: Fn(&ChatEventInternal) -> bool>(&self, since: TimestampMillis, filter: &F) -> usize {
-        self.stable_events_map
-            .iter()
+        self.iter_internal()
             .rev()
             .take_while(|e| e.timestamp > since)
             .filter(|e| filter(&e.event))
@@ -222,7 +250,8 @@ impl ChatEventsList {
     }
 
     pub fn remove(&mut self, event_index: EventIndex) -> Option<EventWrapperInternal<ChatEventInternal>> {
-        self.stable_events_map.remove(event_index)
+        self.stable_events_map.remove(event_index);
+        self.events_map.remove(event_index)
     }
 
     pub fn latest_event_index(&self) -> Option<EventIndex> {
@@ -250,7 +279,7 @@ impl ChatEventsList {
     }
 
     pub fn last(&self) -> Option<EventWrapperInternal<ChatEventInternal>> {
-        self.stable_events_map.iter().next_back()
+        self.iter_internal().next_back()
     }
 
     pub fn contains_message_id(&self, message_id: MessageId) -> bool {
@@ -269,14 +298,33 @@ impl ChatEventsList {
         &self,
         event_index: EventIndex,
     ) -> Result<EventWrapperInternal<ChatEventInternal>, (Option<EventIndex>, Option<EventIndex>)> {
-        let next_key = match self.stable_events_map.range(event_index..).next() {
+        let next_key = match self.range_internal(event_index..).next() {
             Some(v) if v.index == event_index => return Ok(v),
             Some(v) => Some(v.index),
             None => None,
         };
-        let previous_key = self.stable_events_map.range(..event_index).next_back().map(|e| e.index);
+        let previous_key = self.range_internal(..event_index).next_back().map(|e| e.index);
 
         Err((previous_key, next_key))
+    }
+
+    fn iter_internal(&self) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_> {
+        if self.read_events_from_stable_memory {
+            self.stable_events_map.iter()
+        } else {
+            self.events_map.iter()
+        }
+    }
+
+    fn range_internal<R: RangeBounds<EventIndex>>(
+        &self,
+        range: R,
+    ) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_> {
+        if self.read_events_from_stable_memory {
+            self.stable_events_map.range(range)
+        } else {
+            self.events_map.range(range)
+        }
     }
 }
 

--- a/backend/libraries/chat_events/src/events_map.rs
+++ b/backend/libraries/chat_events/src/events_map.rs
@@ -1,4 +1,6 @@
 use crate::ChatEventInternal;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 use types::{EventIndex, EventWrapperInternal};
 
@@ -11,4 +13,32 @@ pub trait EventsMap {
         range: R,
     ) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_>;
     fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_>;
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct ChatEventsMap(BTreeMap<EventIndex, EventWrapperInternal<ChatEventInternal>>);
+
+impl EventsMap for ChatEventsMap {
+    fn get(&self, event_index: EventIndex) -> Option<EventWrapperInternal<ChatEventInternal>> {
+        self.0.get(&event_index).cloned()
+    }
+
+    fn insert(&mut self, event: EventWrapperInternal<ChatEventInternal>) {
+        self.0.insert(event.index, event);
+    }
+
+    fn remove(&mut self, event_index: EventIndex) -> Option<EventWrapperInternal<ChatEventInternal>> {
+        self.0.remove(&event_index)
+    }
+
+    fn range<R: RangeBounds<EventIndex>>(
+        &self,
+        range: R,
+    ) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_> {
+        Box::new(self.0.range(range).map(|(_, e)| e.clone()))
+    }
+
+    fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = EventWrapperInternal<ChatEventInternal>> + '_> {
+        Box::new(self.0.values().cloned())
+    }
 }

--- a/backend/libraries/chat_events/src/hybrid_map.rs
+++ b/backend/libraries/chat_events/src/hybrid_map.rs
@@ -200,9 +200,7 @@ impl<MSlow: EventsMap> DoubleEndedIterator for Iter<'_, MSlow> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stable_storage::{ChatEventsStableStorage, Memory};
-    use candid::Principal;
-    use types::Chat;
+    use crate::ChatEventsMap;
 
     #[test]
     fn get() {
@@ -339,12 +337,10 @@ mod tests {
         assert!(!LAST_READ_FROM_SLOW.get());
     }
 
-    fn setup_map() -> HybridMap<ChatEventsStableStorage> {
-        crate::stable_storage::init(Memory::default());
-
+    fn setup_map() -> HybridMap<ChatEventsMap> {
         let mut map = HybridMap {
             fast: BTreeMap::new(),
-            slow: ChatEventsStableStorage::new(Chat::Direct(Principal::anonymous().into()), None),
+            slow: ChatEventsMap::default(),
             latest_event_index: EventIndex::default(),
             max_events_in_fast_map: 10,
         };


### PR DESCRIPTION
…able memory (#6729)"

This reverts commit 787e7bf4cb4efbfe077672d8791408f0ac689fa5.

# Conflicts:
#	backend/canisters/local_user_index/impl/src/jobs/migrate_events_to_stable_memory.rs