### PR TITLE
Revert "Remove event migration job from communities (#6751)"

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
-### Removed
-
-- Remove code to migrate events to stable memory ([#6751](https://github.com/open-chat-labs/open-chat/pull/6751))
-
 ## [[2.0.1431](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1431-community)] - 2024-11-06
 
 ### Changed

--- a/backend/canisters/community/api/src/updates/mod.rs
+++ b/backend/canisters/community/api/src/updates/mod.rs
@@ -11,6 +11,7 @@ pub mod c2c_invite_users_to_channel;
 pub mod c2c_join_channel;
 pub mod c2c_join_community;
 pub mod c2c_leave_community;
+pub mod c2c_migrate_events_to_stable_memory;
 pub mod c2c_send_message;
 pub mod c2c_set_user_suspended;
 pub mod c2c_tip_message;

--- a/backend/canisters/community/impl/src/regular_jobs.rs
+++ b/backend/canisters/community/impl/src/regular_jobs.rs
@@ -1,3 +1,4 @@
+use crate::updates::c2c_migrate_events_to_stable_memory::migrate_events_to_stable_memory_impl;
 use crate::Data;
 use utils::env::Environment;
 use utils::regular_jobs::{RegularJob, RegularJobs};
@@ -7,8 +8,14 @@ pub(crate) fn build() -> RegularJobs<Data> {
     let check_cycles_balance = RegularJob::new("Check cycles balance", check_cycles_balance, 5 * MINUTE_IN_MS);
     let retry_deleting_files = RegularJob::new("Retry deleting files", retry_deleting_files, MINUTE_IN_MS);
     let build_chat_metrics = RegularJob::new("Build chat metrics", build_chat_metrics, 30 * MINUTE_IN_MS);
+    let migrate_chat_events_to_stable_memory = RegularJob::new("Migrate chat events", migrate_chat_events_to_stable_memory, 0);
 
-    RegularJobs::new(vec![check_cycles_balance, retry_deleting_files, build_chat_metrics])
+    RegularJobs::new(vec![
+        check_cycles_balance,
+        retry_deleting_files,
+        build_chat_metrics,
+        migrate_chat_events_to_stable_memory,
+    ])
 }
 
 fn check_cycles_balance(_: &dyn Environment, data: &mut Data) {
@@ -21,4 +28,8 @@ fn retry_deleting_files(_: &dyn Environment, _: &mut Data) {
 
 fn build_chat_metrics(env: &dyn Environment, data: &mut Data) {
     data.build_chat_metrics(env.now());
+}
+
+fn migrate_chat_events_to_stable_memory(_: &dyn Environment, data: &mut Data) {
+    migrate_events_to_stable_memory_impl(data, true);
 }

--- a/backend/canisters/community/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
@@ -1,11 +1,11 @@
-use crate::guards::caller_is_local_user_index;
+use crate::guards::caller_is_group_index_or_local_group_index;
 use crate::{mutate_state, Data};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
+use community_canister::c2c_migrate_events_to_stable_memory::*;
 use types::{CanisterId, Empty};
-use user_canister::c2c_migrate_events_to_stable_memory::*;
 
-#[update(guard = "caller_is_local_user_index", msgpack = true)]
+#[update(guard = "caller_is_group_index_or_local_group_index", msgpack = true)]
 #[trace]
 fn c2c_migrate_events_to_stable_memory(_args: Args) -> Response {
     mutate_state(|state| migrate_events_to_stable_memory_impl(&mut state.data, false))
@@ -15,14 +15,14 @@ pub(crate) fn migrate_events_to_stable_memory_impl(data: &mut Data, notify: bool
     if data.stable_memory_event_migration_complete {
         return true;
     }
-    for chat in data.direct_chats.iter_mut() {
-        let finished = chat.events.migrate_next_batch_of_events_to_stable_storage();
+    for channel in data.channels.iter_mut() {
+        let finished = channel.chat.events.migrate_next_batch_of_events_to_stable_storage();
         if !finished {
             return false;
         }
     }
     if notify {
-        ic_cdk::spawn(notify_migration_to_stable_memory_complete(data.local_user_index_canister_id));
+        ic_cdk::spawn(notify_migration_to_stable_memory_complete(data.local_group_index_canister_id));
     } else {
         data.stable_memory_event_migration_complete = true;
     }
@@ -30,7 +30,7 @@ pub(crate) fn migrate_events_to_stable_memory_impl(data: &mut Data, notify: bool
 }
 
 async fn notify_migration_to_stable_memory_complete(local_group_index: CanisterId) {
-    if local_user_index_canister_c2c_client::c2c_mark_events_migrated_to_stable_memory(local_group_index, &Empty {})
+    if local_group_index_canister_c2c_client::c2c_mark_events_migrated_to_stable_memory(local_group_index, &Empty {})
         .await
         .is_ok()
     {

--- a/backend/canisters/community/impl/src/updates/mod.rs
+++ b/backend/canisters/community/impl/src/updates/mod.rs
@@ -8,6 +8,7 @@ pub mod c2c_invite_users_to_channel;
 pub mod c2c_join_channel;
 pub mod c2c_join_community;
 pub mod c2c_leave_community;
+pub mod c2c_migrate_events_to_stable_memory;
 pub mod c2c_notify_p2p_swap_status_change;
 pub mod c2c_set_user_suspended;
 pub mod c2c_tip_message;

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Consolidate `summary` and `c2c_summary` args ([#6723](https://github.com/open-chat-labs/open-chat/pull/6723))
 - Fix case where some thread messages were not updated in stable memory ([#6736](https://github.com/open-chat-labs/open-chat/pull/6736))
-- Perform cycles check when migrating events to stable memory ([#6751](https://github.com/open-chat-labs/open-chat/pull/6751))
 
 ### Fixed
 

--- a/backend/canisters/group/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_migrate_events_to_stable_memory.rs
@@ -8,10 +8,7 @@ use types::{CanisterId, Empty};
 #[update(guard = "caller_is_group_index_or_local_group_index", msgpack = true)]
 #[trace]
 fn c2c_migrate_events_to_stable_memory(_args: Args) -> Response {
-    mutate_state(|state| {
-        utils::cycles::check_cycles_balance(state.data.local_user_index_canister_id);
-        migrate_events_to_stable_memory_impl(&mut state.data, false)
-    })
+    mutate_state(|state| migrate_events_to_stable_memory_impl(&mut state.data, false))
 }
 
 pub(crate) fn migrate_events_to_stable_memory_impl(data: &mut Data, notify: bool) -> bool {

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Avoid extra key lookup when iterating over events ([#6680](https://github.com/open-chat-labs/open-chat/pull/6680))
 - Read events in batches when performing stable memory garbage collection ([#6682](https://github.com/open-chat-labs/open-chat/pull/6682))
 - Read events from stable memory once migration is complete ([#6722](https://github.com/open-chat-labs/open-chat/pull/6722))
-- Perform cycles check when migrating events to stable memory ([#6751](https://github.com/open-chat-labs/open-chat/pull/6751))
 
 ## [[2.0.1412](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1414-user)] - 2024-10-24
 


### PR DESCRIPTION
This reverts commit ce452a958955d20da860d229d416fef10d6dbada.