### PR TITLE
Rehydrate prize winner users

### DIFF
--- a/frontend/openchat-shared/src/utils/chat.ts
+++ b/frontend/openchat-shared/src/utils/chat.ts
@@ -56,6 +56,8 @@ export function userIdsFromEvents(events: EventWrapper<ChatEvent>[]): Set<string
                     userIds.add(e.event.content.transfer.recipient);
                 } else if (e.event.content.kind === "reported_message_content") {
                     e.event.content.reports.forEach((r) => userIds.add(r.reportedBy));
+                } else if (e.event.content.kind === "prize_winner_content") {
+                    userIds.add(e.event.content.transaction.recipient);
                 }
                 e.event.reactions.forEach((r) => r.userIds.forEach((u) => userIds.add(u)));
                 extractUserIdsFromMentions(


### PR DESCRIPTION
Seeing multiple instances of "Unknown" user claiming prizes has caused a bit of confusion and caused some conspiracy theories - this should fix it. 