### PR TITLE
fix the way edit message works

### DIFF
--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -127,6 +127,28 @@ export function isAttachmentContent(content: MessageContent): content is Attachm
     }
 }
 
+export type EditableContent =
+    | FileContent
+    | TextContent
+    | ImageContent
+    | VideoContent
+    | AudioContent
+    | GiphyContent;
+
+export function isEditableContent(kind: MessageContent["kind"]): kind is EditableContent["kind"] {
+    switch (kind) {
+        case "file_content":
+        case "text_content":
+        case "image_content":
+        case "video_content":
+        case "audio_content":
+        case "giphy_content":
+            return true;
+        default:
+            return false;
+    }
+}
+
 export function isCaptionedContent(content: MessageContent): content is CaptionedContent {
     switch (content.kind) {
         case "image_content":

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
                 "dotenv-cli": "^7.2.1",
                 "eslint-config-prettier": "^9.0.0",
                 "eslint-plugin-prettier": "^5.0.0",
+                "prettier-plugin-svelte": "^3.3.2",
                 "rollup": "^4.22.4",
                 "rollup-plugin-analyzer": "^4.0.0",
                 "rollup-plugin-cleaner": "^1.0.0",
@@ -30399,6 +30400,17 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/prettier-plugin-svelte": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.2.tgz",
+            "integrity": "sha512-kRPjH8wSj2iu+dO+XaUv4vD8qr5mdDmlak3IT/7AOgGIMRG86z/EHOLauFcClKEnOUf4A4nOA7sre5KrJD4Raw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "prettier": "^3.0.0",
+                "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
             }
         },
         "node_modules/pretty-bytes": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
         "dotenv-cli": "^7.2.1",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "prettier-plugin-svelte": "^3.3.2",
         "rollup": "^4.22.4",
         "rollup-plugin-analyzer": "^4.0.0",
         "rollup-plugin-cleaner": "^1.0.0",


### PR DESCRIPTION
Allows us to edit anything editable and captioned without losing the main content. This only worked for attachment content types before. 