### PR TITLE
Revert "Temporarily comment out bot endpoints to reduce size below limit (#7100)"

### DIFF
--- a/backend/canisters/user_index/impl/src/model/user_map.rs
+++ b/backend/canisters/user_index/impl/src/model/user_map.rs
@@ -52,7 +52,6 @@ pub struct Bot {
 }
 
 impl Bot {
-    #[allow(dead_code)]
     pub fn to_match(&self, id: UserId, score: u32) -> BotMatch {
         BotMatch {
             id,
@@ -376,7 +375,6 @@ impl UserMap {
         self.users.values()
     }
 
-    #[allow(dead_code)]
     pub fn iter_bots(&self) -> impl Iterator<Item = (&UserId, &Bot)> {
         self.bots.iter()
     }
@@ -474,7 +472,6 @@ impl UserMap {
 
     // TODO - When a bot is added/removed to/from a community or group the user_index should be notified
     // so it can maintain a popularity score and use this for ordering results
-    #[allow(dead_code)]
     pub fn search_bots(&self, search_term: Option<String>, page_index: u32, page_size: u8) -> (Vec<BotMatch>, u32) {
         let query = search_term.map(Query::parse);
 

--- a/backend/canisters/user_index/impl/src/queries/mod.rs
+++ b/backend/canisters/user_index/impl/src/queries/mod.rs
@@ -1,10 +1,10 @@
-// pub mod bot_updates;
+pub mod bot_updates;
 pub mod c2c_lookup_user;
 pub mod check_username;
 pub mod chit_leaderboard;
 pub mod current_user;
 pub mod diamond_membership_fees;
-// pub mod explore_bots;
+pub mod explore_bots;
 pub mod external_achievements;
 pub mod http_request;
 pub mod platform_moderators;

--- a/backend/integration_tests/src/lib.rs
+++ b/backend/integration_tests/src/lib.rs
@@ -9,7 +9,7 @@ use types::{CanisterId, Cycles, UserId};
 
 mod airdrop_bot_tests;
 mod batched_summary_and_event_tests;
-// mod bot_tests;
+mod bot_tests;
 mod change_group_role_tests;
 mod chit_tests;
 mod client;


### PR DESCRIPTION
This reverts commit 36cae095ad062e38feab58f794e1f22ff0fd9179.