### PR TITLE
Break longer-than-message-bubble strings

### DIFF
--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -956,6 +956,7 @@
         border-radius: $radius;
         border: var(--currentChat-msg-bd);
         box-shadow: var(--currentChat-msg-sh);
+        word-break: break-word;
 
         .username {
             color: inherit;


### PR DESCRIPTION
Added rule to break strings that have many characters, when chat bubble is on the smaller size due to width constrictions.