### PR TITLE
Fix proposal bubble

### DIFF
--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -966,7 +966,10 @@
         border-radius: $radius;
         border: var(--currentChat-msg-bd);
         box-shadow: var(--currentChat-msg-sh);
-        word-break: break-word;
+
+        :global(.markdown-wrapper) {
+            word-break: break-word;
+        }
 
         .username {
             color: inherit;


### PR DESCRIPTION
Moved the word-break rule to the markdown wrapper, which should limit the effect, and fix the issue with the proposal bubble.