### PR TITLE
Move notification processing to single synchronous thread + more metrics

### DIFF
--- a/backend/notification_pusher/core/src/lib.rs
+++ b/backend/notification_pusher/core/src/lib.rs
@@ -1,20 +1,21 @@
 use crate::ic_agent::IcAgent;
-use crate::metrics::METRICS;
+use crate::metrics::{collect_metrics, Metrics};
+use crate::processor::Processor;
 use crate::pusher::Pusher;
 use crate::reader::Reader;
 use crate::subscription_remover::SubscriptionRemover;
-use async_channel::Sender;
 use index_store::IndexStore;
 use prometheus::{Encoder, TextEncoder};
 use std::io::Write;
 use std::sync::{Arc, RwLock};
-use tokio::time;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::info;
 use types::{CanisterId, TimestampMillis, UserId};
-use web_push::SubscriptionInfo;
+use web_push::{SubscriptionInfo, WebPushMessage};
 
 pub mod ic_agent;
 mod metrics;
+mod processor;
 mod pusher;
 mod reader;
 mod subscription_remover;
@@ -29,25 +30,41 @@ pub async fn run_notifications_pusher<I: IndexStore + 'static>(
 ) {
     info!("Notifications pusher starting");
 
-    let (sender, receiver) = async_channel::bounded::<Notification>(200_000);
+    let (to_process_sender, to_process_receiver) = async_channel::bounded::<Notification>(200_000);
+    let (to_push_sender, to_push_receiver) = async_channel::bounded::<NotificationToPush>(200_000);
     let (subscriptions_to_remove_sender, subscriptions_to_remove_receiver) = async_channel::bounded(20_000);
+
+    Metrics::init(
+        to_process_sender.clone(),
+        to_push_sender.clone(),
+        subscriptions_to_remove_sender.clone(),
+    );
 
     for notification_canister_id in notifications_canister_ids {
         let reader = Reader::new(
             ic_agent.clone(),
             notification_canister_id,
             index_store.clone(),
-            sender.clone(),
+            to_process_sender.clone(),
         );
         tokio::spawn(reader.run());
     }
 
     let invalid_subscriptions = Arc::new(RwLock::default());
     let throttled_subscriptions = Arc::new(RwLock::default());
+
+    let processor = Processor::new(
+        to_process_receiver.clone(),
+        to_push_sender.clone(),
+        &vapid_private_pem,
+        invalid_subscriptions.clone(),
+        throttled_subscriptions.clone(),
+    );
+    tokio::spawn(processor.run());
+
     for _ in 0..pusher_count {
         let pusher = Pusher::new(
-            receiver.clone(),
-            &vapid_private_pem,
+            to_push_receiver.clone(),
             subscriptions_to_remove_sender.clone(),
             invalid_subscriptions.clone(),
             throttled_subscriptions.clone(),
@@ -58,7 +75,6 @@ pub async fn run_notifications_pusher<I: IndexStore + 'static>(
     let subscription_remover = SubscriptionRemover::new(ic_agent, index_canister_id, subscriptions_to_remove_receiver);
 
     tokio::spawn(subscription_remover.run());
-    tokio::spawn(run_queue_monitor_thread(sender));
 
     info!("Notifications pusher started");
 
@@ -66,7 +82,7 @@ pub async fn run_notifications_pusher<I: IndexStore + 'static>(
 }
 
 pub fn write_metrics<W: Write>(w: &mut W) {
-    let metrics = METRICS.collect();
+    let metrics = collect_metrics();
     let encoder = TextEncoder::new();
 
     encoder.encode(&metrics, w).unwrap();
@@ -81,12 +97,11 @@ pub struct Notification {
     subscription_info: SubscriptionInfo,
 }
 
-async fn run_queue_monitor_thread(sender: Sender<Notification>) {
-    let mut interval = time::interval(time::Duration::from_secs(20));
+pub struct NotificationToPush {
+    notification: Notification,
+    message: WebPushMessage,
+}
 
-    loop {
-        interval.tick().await;
-
-        METRICS.set_notifications_in_queue(sender.len() as u64);
-    }
+fn timestamp() -> TimestampMillis {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
 }

--- a/backend/notification_pusher/core/src/processor.rs
+++ b/backend/notification_pusher/core/src/processor.rs
@@ -1,0 +1,134 @@
+use crate::metrics::write_metrics;
+use crate::{timestamp, Notification, NotificationToPush};
+use async_channel::{Receiver, Sender};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use tracing::info;
+use types::TimestampMillis;
+use web_push::{
+    ContentEncoding, PartialVapidSignatureBuilder, SubscriptionInfo, Urgency, VapidSignature, VapidSignatureBuilder,
+    WebPushError, WebPushMessage, WebPushMessageBuilder,
+};
+
+const MAX_PAYLOAD_LENGTH_BYTES: u32 = 3 * 1000; // Just under 3KB
+
+pub struct Processor {
+    receiver: Receiver<Notification>,
+    sender: Sender<NotificationToPush>,
+    sig_builder: PartialVapidSignatureBuilder,
+    invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
+    throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
+}
+
+impl Processor {
+    pub fn new(
+        receiver: Receiver<Notification>,
+        sender: Sender<NotificationToPush>,
+        vapid_private_pem: &str,
+        invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
+        throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
+    ) -> Self {
+        Self {
+            receiver,
+            sender,
+            sig_builder: VapidSignatureBuilder::from_pem_no_sub(vapid_private_pem.as_bytes()).unwrap(),
+            invalid_subscriptions,
+            throttled_subscriptions,
+        }
+    }
+
+    pub async fn run(self) {
+        while let Ok(notification) = self.receiver.recv().await {
+            let notifications_canister = notification.notifications_canister;
+            let index = notification.index;
+
+            match self.process_notification(&notification) {
+                Ok(message) => {
+                    self.sender.send(NotificationToPush { notification, message }).await.unwrap();
+                }
+                Err(_) => {
+                    // Record error in metrics
+                }
+            }
+            write_metrics(|m| m.set_latest_notification_index_processed(index, notifications_canister));
+        }
+    }
+
+    fn process_notification(&self, notification: &Notification) -> Result<WebPushMessage, ProcessNotificationError> {
+        if let Ok(map) = self.invalid_subscriptions.read() {
+            if map.contains_key(&notification.subscription_info.endpoint) {
+                return Err(ProcessNotificationError::SubscriptionInvalid);
+            }
+        }
+        if let Ok(map) = self.throttled_subscriptions.read() {
+            if let Some(until) = map.get(&notification.subscription_info.endpoint) {
+                let timestamp = timestamp();
+                if *until > timestamp {
+                    info!("Notification skipped due to subscription being throttled");
+                    return Err(ProcessNotificationError::SubscriptionThrottled);
+                }
+            }
+        }
+        let payload_bytes = notification.payload.as_ref();
+        let subscription = &notification.subscription_info;
+        let vapid_signature = self
+            .build_vapid_signature(subscription)
+            .map_err(ProcessNotificationError::FailedToBuildSignature)?;
+
+        let message = build_web_push_message(payload_bytes, subscription, vapid_signature.clone())
+            .map_err(ProcessNotificationError::FailedToBuildMessage)?;
+
+        let length = message.payload.as_ref().map_or(0, |p| p.content.len()) as u32;
+        if length <= MAX_PAYLOAD_LENGTH_BYTES {
+            Ok(message)
+        } else {
+            Err(ProcessNotificationError::PayloadTooLarge(length))
+        }
+    }
+
+    fn build_vapid_signature(&self, subscription: &SubscriptionInfo) -> Result<VapidSignature, WebPushError> {
+        let mut sig_builder = self.sig_builder.clone().add_sub_info(subscription);
+        sig_builder.add_claim("sub", "https://oc.app");
+        sig_builder.build()
+    }
+}
+
+#[allow(dead_code)]
+enum ProcessNotificationError {
+    SubscriptionInvalid,
+    SubscriptionThrottled,
+    PayloadTooLarge(u32),
+    FailedToBuildSignature(WebPushError),
+    FailedToBuildMessage(WebPushError),
+}
+
+fn build_web_push_message(
+    payload: &[u8],
+    subscription: &SubscriptionInfo,
+    vapid_signature: VapidSignature,
+) -> Result<WebPushMessage, WebPushError> {
+    let mut message_builder = WebPushMessageBuilder::new(subscription);
+    message_builder.set_payload(ContentEncoding::Aes128Gcm, payload);
+    message_builder.set_vapid_signature(vapid_signature);
+    message_builder.set_ttl(3600); // 1 hour
+    message_builder.set_urgency(Urgency::High);
+    message_builder.build()
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct SubscriptionInfoDebug<'a> {
+    endpoint: &'a str,
+    p256dh_len: usize,
+    auth_len: usize,
+}
+
+impl<'a> From<&'a SubscriptionInfo> for SubscriptionInfoDebug<'a> {
+    fn from(s: &'a SubscriptionInfo) -> Self {
+        SubscriptionInfoDebug {
+            endpoint: &s.endpoint,
+            p256dh_len: s.keys.p256dh.len(),
+            auth_len: s.keys.auth.len(),
+        }
+    }
+}

--- a/backend/notification_pusher/core/src/pusher.rs
+++ b/backend/notification_pusher/core/src/pusher.rs
@@ -1,23 +1,17 @@
-use crate::metrics::METRICS;
-use crate::Notification;
+use crate::metrics::write_metrics;
+use crate::{timestamp, NotificationToPush};
 use async_channel::{Receiver, Sender};
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::{error, info};
-use types::{Error, Milliseconds, TimestampMillis, UserId};
-use web_push::{
-    ContentEncoding, HyperWebPushClient, PartialVapidSignatureBuilder, SubscriptionInfo, Urgency, VapidSignature,
-    VapidSignatureBuilder, WebPushClient, WebPushError, WebPushMessage, WebPushMessageBuilder,
-};
+use tracing::info;
+use types::{Milliseconds, TimestampMillis, UserId};
+use web_push::{HyperWebPushClient, WebPushClient, WebPushError};
 
-const MAX_PAYLOAD_LENGTH_BYTES: usize = 3 * 1000; // Just under 3KB
 const ONE_MINUTE: Milliseconds = 60 * 1000;
 
 pub struct Pusher {
-    receiver: Receiver<Notification>,
+    receiver: Receiver<NotificationToPush>,
     web_push_client: HyperWebPushClient,
-    sig_builder: PartialVapidSignatureBuilder,
     subscriptions_to_remove_sender: Sender<(UserId, String)>,
     invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
     throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
@@ -25,8 +19,7 @@ pub struct Pusher {
 
 impl Pusher {
     pub fn new(
-        receiver: Receiver<Notification>,
-        vapid_private_pem: &str,
+        receiver: Receiver<NotificationToPush>,
         subscriptions_to_remove_sender: Sender<(UserId, String)>,
         invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
         throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
@@ -34,7 +27,6 @@ impl Pusher {
         Self {
             receiver,
             web_push_client: HyperWebPushClient::new(),
-            sig_builder: VapidSignatureBuilder::from_pem_no_sub(vapid_private_pem.as_bytes()).unwrap(),
             subscriptions_to_remove_sender,
             invalid_subscriptions,
             throttled_subscriptions,
@@ -42,109 +34,50 @@ impl Pusher {
     }
 
     pub async fn run(self) {
-        while let Ok(notification) = self.receiver.recv().await {
-            self.process_notification(&notification).await;
-
-            let latency_ms = timestamp().saturating_sub(notification.timestamp);
-            METRICS.set_latest_notification_index_processed(notification.index, notification.notifications_canister);
-            METRICS.set_notification_latency_ms(latency_ms, notification.notifications_canister);
-        }
-    }
-
-    async fn process_notification(&self, notification: &Notification) {
-        if let Ok(map) = self.invalid_subscriptions.read() {
-            if map.contains_key(&notification.subscription_info.endpoint) {
-                return;
-            }
-        }
-        if let Ok(map) = self.throttled_subscriptions.read() {
-            if let Some(until) = map.get(&notification.subscription_info.endpoint) {
-                let timestamp = timestamp();
-                if *until > timestamp {
-                    info!("Notification skipped due to subscription being throttled");
-                    return;
+        while let Ok(NotificationToPush { notification, message }) = self.receiver.recv().await {
+            let payload_bytes = message.payload.as_ref().map_or(0, |p| p.content.len()) as u64;
+            match self.web_push_client.send(message).await {
+                Ok(_) => {
+                    let latency_ms = timestamp().saturating_sub(notification.timestamp);
+                    write_metrics(|m| {
+                        m.incr_total_notifications_pushed();
+                        m.incr_total_notification_bytes_pushed(payload_bytes);
+                        m.set_latest_notification_index_pushed(notification.index, notification.notifications_canister);
+                        m.set_notification_latency_ms(latency_ms, notification.notifications_canister);
+                    });
                 }
-            }
-        }
-        if let Err(error) = self.push_notification(notification).await {
-            let bytes = notification.payload.len();
-            error!(
-                ?error,
-                bytes, notification.subscription_info.endpoint, "Failed to push notification"
-            );
-        } else {
-            METRICS.incr_user_notifications_pushed();
-        }
-    }
-
-    async fn push_notification(&self, notification: &Notification) -> Result<(), Error> {
-        let payload_bytes = notification.payload.as_ref();
-        let subscription = &notification.subscription_info;
-        let vapid_signature = self.build_vapid_signature(subscription)?;
-
-        let message = build_web_push_message(payload_bytes, subscription, vapid_signature.clone())?;
-        let length = message.payload.as_ref().map_or(0, |p| p.content.len());
-        if length <= MAX_PAYLOAD_LENGTH_BYTES {
-            if let Err(error) = self.web_push_client.send(message).await {
-                match error {
+                Err(error) => match error {
                     WebPushError::EndpointNotValid | WebPushError::InvalidUri | WebPushError::EndpointNotFound => {
                         let _ = self
                             .subscriptions_to_remove_sender
-                            .try_send((notification.recipient, subscription.keys.p256dh.clone()));
-
+                            .try_send((notification.recipient, notification.subscription_info.keys.p256dh.clone()));
                         if let Ok(mut map) = self.invalid_subscriptions.write() {
                             if map.len() > 10000 {
                                 prune_invalid_subscriptions(&mut map);
                             }
-                            map.insert(subscription.endpoint.clone(), timestamp());
+                            map.insert(notification.subscription_info.endpoint.clone(), timestamp());
                         }
 
                         info!(
                             ?error,
-                            subscription.endpoint, "Failed to push notification, subscription queued to be removed"
+                            notification.subscription_info.endpoint,
+                            "Failed to push notification, subscription queued to be removed"
                         );
-                        Ok(())
                     }
                     _ => {
                         if let Ok(mut map) = self.throttled_subscriptions.write() {
+                            let timestamp = timestamp();
                             if map.len() > 100 {
-                                let timestamp = timestamp();
                                 map.retain(|_, ts| *ts > timestamp);
                             }
-                            info!(subscription.endpoint, "Subscription throttled for 1 minute");
-                            map.insert(subscription.endpoint.clone(), timestamp() + ONE_MINUTE);
+                            info!(notification.subscription_info.endpoint, "Subscription throttled for 1 minute");
+                            map.insert(notification.subscription_info.endpoint.clone(), timestamp + ONE_MINUTE);
                         }
-                        Err(error.into())
                     }
-                }
-            } else {
-                METRICS.incr_total_notifications_pushed();
-                METRICS.incr_total_notification_bytes_pushed(length as u64);
-                Ok(())
+                },
             }
-        } else {
-            Err(format!("Max length exceeded. Length: {length}").into())
         }
     }
-
-    fn build_vapid_signature(&self, subscription: &SubscriptionInfo) -> Result<VapidSignature, WebPushError> {
-        let mut sig_builder = self.sig_builder.clone().add_sub_info(subscription);
-        sig_builder.add_claim("sub", "https://oc.app");
-        sig_builder.build()
-    }
-}
-
-fn build_web_push_message(
-    payload: &[u8],
-    subscription: &SubscriptionInfo,
-    vapid_signature: VapidSignature,
-) -> Result<WebPushMessage, WebPushError> {
-    let mut message_builder = WebPushMessageBuilder::new(subscription);
-    message_builder.set_payload(ContentEncoding::Aes128Gcm, payload);
-    message_builder.set_vapid_signature(vapid_signature);
-    message_builder.set_ttl(3600); // 1 hour
-    message_builder.set_urgency(Urgency::High);
-    message_builder.build()
 }
 
 // Prunes the oldest 1000 subscriptions
@@ -167,28 +100,6 @@ fn prune_invalid_subscriptions(map: &mut HashMap<String, TimestampMillis>) {
 
     for (_, subscription) in heap {
         map.remove(&subscription);
-    }
-}
-
-fn timestamp() -> TimestampMillis {
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
-}
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct SubscriptionInfoDebug<'a> {
-    endpoint: &'a str,
-    p256dh_len: usize,
-    auth_len: usize,
-}
-
-impl<'a> From<&'a SubscriptionInfo> for SubscriptionInfoDebug<'a> {
-    fn from(s: &'a SubscriptionInfo) -> Self {
-        SubscriptionInfoDebug {
-            endpoint: &s.endpoint,
-            p256dh_len: s.keys.p256dh.len(),
-            auth_len: s.keys.auth.len(),
-        }
     }
 }
 


### PR DESCRIPTION
We now have 1 `reader` thread per notifications canister which pulls in new notifications every second and puts them into a queue.
Then we have a `processor` thread which consumes that queue and synchronously builds the individual web push messages.
Then we have multiple `pusher` threads which pull notifications off the queue and push them.