### PR TITLE
Do not render previews if no LinkInfo is provided

### DIFF
--- a/frontend/app/src/components/home/GenericPreview.svelte
+++ b/frontend/app/src/components/home/GenericPreview.svelte
@@ -18,7 +18,7 @@
     export let rendered = false;
 
     let previewWrapper: HTMLElement;
-    let previewPromise: Promise<LinkInfo | null> | undefined = undefined;
+    let previewPromise: Promise<LinkInfo | undefined> | undefined = undefined;
 
     $: {
         if (intersecting && !$eventListScrolling && !rendered && !$offlineStore) {
@@ -33,19 +33,19 @@
         }
     }
 
-    async function loadPreview(url: string): Promise<LinkInfo | null> {
+    async function loadPreview(url: string): Promise<LinkInfo | undefined> {
         const response = await fetch(
             `${import.meta.env.OC_PREVIEW_PROXY_URL}/preview?url=${encodeURIComponent(url)}`,
         );
 
-        const check_if_meta_empty = (meta: Omit<LinkInfo, "url">) =>
+        const checkIfMetaEmpty = (meta: Omit<LinkInfo, "url">) =>
             !meta.title && !meta.description && !meta.image && !meta.imageAlt;
 
         if (response.ok) {
             const meta = await response.json();
-            const meta_is_empty = check_if_meta_empty(meta);
+            const metaIsEmpty = checkIfMetaEmpty(meta);
 
-            if (!meta_is_empty) {
+            if (!metaIsEmpty) {
                 return {
                     url,
                     title: meta.title,
@@ -55,8 +55,6 @@
                 };
             }
         }
-
-        return null;
     }
 
     function imageLoaded() {


### PR DESCRIPTION
In case of the image links relayed from discord, fetching their metadata returns incomplete data, with only `title = ""`. This in turn indicates to the component that preview should be rendered since at least one thing is there since `"" !== undefined`.

This PR adds a check to make sure that something is there for the `LinkInfo`, and if it is, then render the previews fully or partially.

Before
![2025-02-20_20-18](https://github.com/user-attachments/assets/fdd85cb1-1bdf-4b52-a385-b50b6bdd4141)
After
![2025-02-20_20-20](https://github.com/user-attachments/assets/afccabcf-3d76-4cb9-85ea-3025d9ce6205)
