### PR TITLE
Prevent copying sign in principals

### DIFF
--- a/frontend/app/src/components/home/TruncatedAccount.svelte
+++ b/frontend/app/src/components/home/TruncatedAccount.svelte
@@ -8,6 +8,7 @@
 
     export let account: string;
     export let centered = false;
+    export let disableCopy = false
 
     function collapseAccount(account: string) {
         if (account.length > 23) {
@@ -36,9 +37,11 @@
     <div class="principal">
         {collapseAccount(account)}
     </div>
-    <div class="copy" title={$_("copyToClipboard")} on:click={copy}>
-        <ContentCopy size={$iconSize} color={"var(--icon-txt)"} />
-    </div>
+    {#if !disableCopy}
+        <div class="copy" title={$_("copyToClipboard")} on:click={copy}>
+            <ContentCopy size={$iconSize} color={"var(--icon-txt)"} />
+        </div>
+    {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/app/src/components/home/profile/LinkedAuthAccounts.svelte
+++ b/frontend/app/src/components/home/profile/LinkedAuthAccounts.svelte
@@ -59,7 +59,7 @@
 
 {#each accounts as account}
     <div class="account">
-        <TruncatedAccount account={account.principal}>
+        <TruncatedAccount account={account.principal} disableCopy={true}>
             <AuthProviderLogo square provider={account.provider} />
         </TruncatedAccount>
         {#if account.isCurrentIdentity}


### PR DESCRIPTION
A few users have copied these principals and then sent funds to them.
There are no use cases where a user needs these principals in full so we should remove the ability to copy them.