### PR TITLE
Show higher badges when applicable on the daily claim modal

### DIFF
--- a/frontend/app/src/components/home/DailyChitModal.svelte
+++ b/frontend/app/src/components/home/DailyChitModal.svelte
@@ -38,7 +38,9 @@
 
     $: available = $chitState.nextDailyChitClaim < $now500;
     $: streak = $chitState.streakEnds < $now500 ? 0 : $chitState.streak;
-    $: percent = calculatePercentage(streak);
+    $: badgesVisible = calculateBadgesVisible(streak);
+    $: maxBadgeVisible = badgesVisible[badgesVisible.length - 1];
+    $: percent = calculatePercentage(maxBadgeVisible);
     $: remaining = client.formatTimeRemaining($now500, Number($chitState.nextDailyChitClaim), true);
 
     onMount(() => {
@@ -48,8 +50,18 @@
         }
     });
 
-    function calculatePercentage(streak: number): number {
-        const percent = (streak / 30) * 100;
+    function calculateBadgesVisible(streak: number): number[] {
+        if (streak < 30) {
+            return [3, 7, 14, 30];
+        } else if (streak < 100) {
+            return [14, 30, 100];
+        } else {
+            return [30, 100, 365];
+        }
+    }
+
+    function calculatePercentage(maxBadge: number): number {
+        const percent = (streak / maxBadge) * 100;
         return percent > 100 ? 100 : percent;
     }
 
@@ -169,18 +181,11 @@
                     <div class="line"></div>
                 </div>
                 <div class="badges">
-                    <div class="badge three">
-                        <Streak disabled={streak < 3} days={3} />
-                    </div>
-                    <div class="badge seven">
-                        <Streak disabled={streak < 7} days={7} />
-                    </div>
-                    <div class="badge fourteen">
-                        <Streak disabled={streak < 14} days={14} />
-                    </div>
-                    <div class="badge thirty">
-                        <Streak disabled={streak < 30} days={30} />
-                    </div>
+                    {#each badgesVisible as badge}
+                        <div class="badge" style="left: {badge * 100 / maxBadgeVisible}%">
+                            <Streak disabled={streak < badge} days={badge} />
+                        </div>
+                    {/each}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<img width="578" alt="Screenshot 2025-02-26 at 08 48 09" src="https://github.com/user-attachments/assets/176beeae-fec9-4056-92a4-16c99ee3418b" />

<img width="578" alt="Screenshot 2025-02-26 at 08 47 58" src="https://github.com/user-attachments/assets/02c7514e-e286-4ed8-8ba0-e3fc334d7f73" />

<img width="578" alt="Screenshot 2025-02-26 at 08 48 20" src="https://github.com/user-attachments/assets/c8490ca9-eaeb-4f1c-af74-31e837e6c8bb" />

<img width="578" alt="Screenshot 2025-02-26 at 08 48 30" src="https://github.com/user-attachments/assets/a5ea8780-ee84-42e2-a7fc-fafc782ebf6f" />
