### PR TITLE
Avoid infinite loop in cache primer if you leave community

### DIFF
--- a/frontend/openchat-client/src/utils/cachePrimer.ts
+++ b/frontend/openchat-client/src/utils/cachePrimer.ts
@@ -129,10 +129,10 @@ export class CachePrimer {
         }
         const sorted = this.pending.values().sort(compareChats);
         const next = sorted[0];
+        this.pending.delete(next.id);
+        
         const batch = this.getEventsArgs(next);
         const localUserIndex = this.localUserIndex(next);
-
-        this.pending.delete(next.id);
 
         for (let i = 1; i < sorted.length; i++) {
             const chat = sorted[i];


### PR DESCRIPTION
If a channel gets queued up in the cache primer, but then you leave the community before the channel is processed, then when the cache primer processes the channel the `const localUserIndex = this.localUserIndex(next);` throws an error, but the channel still remains as the next item to process.
So on the next iteration the channel is picked up again, and again it will fail, and so on.