### PR TITLE
Fix for multiline input not breaking lines

### DIFF
--- a/frontend/app/src/components/home/MultiLineInput.svelte
+++ b/frontend/app/src/components/home/MultiLineInput.svelte
@@ -156,15 +156,15 @@
     }
 
     .textbox {
+        @include input();
+
         max-height: calc(var(--vh, 1vh) * 50);
         min-height: toRem(30);
         overflow-x: hidden;
-        overflow-y: auto;
         user-select: text;
-        white-space: pre-wrap;
-        overflow-wrap: anywhere;
-
-        @include input();
+        overflow-y: auto;
+        text-overflow: unset;
+        white-space: normal;
 
         &.empty:before {
             content: attr(placeholder);


### PR DESCRIPTION
Updated CSS for the multiline input field to break into new lines.

![image](https://github.com/user-attachments/assets/a1698e82-4cfe-46df-bd32-0abecd3c7868)
![image](https://github.com/user-attachments/assets/5df79604-013c-4325-bac6-2c6a181b754a)
