### PR TITLE
Fix pushing diamond membership payment events

### DIFF
--- a/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
@@ -166,6 +166,7 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
                         timestamp: ev.timestamp,
                         expires_at: ev.expires_at,
                         ledger: ev.ledger,
+                        token: Some(ev.token_symbol.clone().into()),
                         token_symbol: ev.token_symbol,
                         amount_e8s: ev.amount_e8s,
                         block_index: ev.block_index,

--- a/backend/canisters/user/api/src/lib.rs
+++ b/backend/canisters/user/api/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use candid::CandidType;
 use chat_events::MessageContentInternal;
 use serde::{Deserialize, Serialize};
@@ -178,6 +179,7 @@ pub struct DiamondMembershipPaymentReceived {
     pub expires_at: TimestampMillis,
     pub ledger: CanisterId,
     pub token_symbol: String,
+    pub token: Option<types::Cryptocurrency>,
     pub amount_e8s: u64,
     pub block_index: u64,
     pub duration: DiamondMembershipPlanDuration,


### PR DESCRIPTION
The version of the User canisters which is live is still expecting the `token` field, so I have added it back in as optional so that it gets populated for now but can easily be removed after the next upgrade.