### PR TITLE
Loosen channel name restrictions

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow community owners to delete channels and explore private channels ([#7652](https://github.com/open-chat-labs/open-chat/pull/7652))
 - Filter trace level events globally so they are dropped earlier ([#7678](https://github.com/open-chat-labs/open-chat/pull/7678))
+- Loosen channel name restrictions ([#7683](https://github.com/open-chat-labs/open-chat/pull/7683))
 
 ## [[2.0.1657](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1657-community)] - 2025-03-17
 

--- a/backend/canisters/community/impl/src/updates/create_channel.rs
+++ b/backend/canisters/community/impl/src/updates/create_channel.rs
@@ -14,7 +14,7 @@ use types::{BotCaller, BotPermissions, Caller, CommunityPermission, MultiUserCha
 use url::Url;
 use utils::document::validate_avatar;
 use utils::text_validation::{
-    validate_description, validate_group_name, validate_rules, NameValidationError, RulesValidationError,
+    validate_channel_name, validate_description, validate_rules, RulesValidationError, StringLengthValidationError,
 };
 
 #[update(msgpack = true)]
@@ -131,11 +131,10 @@ fn create_channel_impl(
         return NotAuthorized;
     }
 
-    if let Err(error) = validate_group_name(&args.name, args.is_public, subtype.as_ref()) {
+    if let Err(error) = validate_channel_name(&args.name) {
         return match error {
-            NameValidationError::TooShort(s) => NameTooShort(s),
-            NameValidationError::TooLong(l) => NameTooLong(l),
-            NameValidationError::Reserved => NameReserved,
+            StringLengthValidationError::TooShort(s) => NameTooShort(s),
+            StringLengthValidationError::TooLong(l) => NameTooLong(l),
         };
     }
 

--- a/backend/canisters/user/impl/src/updates/create_community.rs
+++ b/backend/canisters/user/impl/src/updates/create_community.rs
@@ -9,7 +9,7 @@ use types::{CanisterId, CommunityId};
 use user_canister::create_community::{Response::*, *};
 use utils::document::{validate_avatar, validate_banner};
 use utils::text_validation::{
-    validate_community_name, validate_description, validate_group_name, validate_rules, NameValidationError,
+    validate_channel_name, validate_community_name, validate_description, validate_rules, NameValidationError,
     RulesValidationError,
 };
 
@@ -124,11 +124,7 @@ fn prepare(args: Args, state: &RuntimeState) -> Result<PrepareResult, Response> 
 }
 
 fn default_channels_valid(default_channels: &[String]) -> bool {
-    if default_channels.is_empty()
-        || default_channels
-            .iter()
-            .any(|channel| validate_group_name(channel, true, None).is_err())
-    {
+    if default_channels.is_empty() || default_channels.iter().any(|channel| validate_channel_name(channel).is_err()) {
         return false;
     }
 

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -121,6 +121,10 @@ impl ChatEvents {
         events
     }
 
+    pub fn chat(&self) -> Chat {
+        self.chat
+    }
+
     pub fn set_chat(&mut self, chat: Chat) {
         self.chat = chat;
         self.main.set_stable_memory_prefix(chat, None);

--- a/backend/libraries/group_chat_core/src/lib.rs
+++ b/backend/libraries/group_chat_core/src/lib.rs
@@ -1570,13 +1570,11 @@ impl GroupChatCore {
                         NameValidationError::Reserved => NameReserved,
                     });
                 }
-            } else {
-                if let Err(error) = validate_channel_name(name) {
-                    return Err(match error {
-                        StringLengthValidationError::TooShort(s) => NameTooShort(s),
-                        StringLengthValidationError::TooLong(l) => NameTooLong(l),
-                    });
-                }
+            } else if let Err(error) = validate_channel_name(name) {
+                return Err(match error {
+                    StringLengthValidationError::TooShort(s) => NameTooShort(s),
+                    StringLengthValidationError::TooLong(l) => NameTooLong(l),
+                });
             }
         }
 

--- a/backend/libraries/utils/src/text_validation.rs
+++ b/backend/libraries/utils/src/text_validation.rs
@@ -87,6 +87,10 @@ pub fn validate_community_name(name: &str, is_public: bool) -> Result<(), NameVa
     validate_group_name(name, is_public, None)
 }
 
+pub fn validate_channel_name(name: &str) -> Result<(), StringLengthValidationError> {
+    validate_string_length(name, MIN_GROUP_NAME_LENGTH, MAX_GROUP_NAME_LENGTH)
+}
+
 pub fn validate_group_name(name: &str, is_public: bool, subtype: Option<&GroupSubtype>) -> Result<(), NameValidationError> {
     match validate_string_length(name, MIN_GROUP_NAME_LENGTH, MAX_GROUP_NAME_LENGTH) {
         Ok(()) => {
@@ -94,7 +98,7 @@ pub fn validate_group_name(name: &str, is_public: bool, subtype: Option<&GroupSu
                 && !subtype
                     .map(|t| matches!(t, GroupSubtype::GovernanceProposals(_)))
                     .unwrap_or_default()
-                && name.to_lowercase().contains("proposals")
+                && name.to_lowercase().ends_with("proposals")
             {
                 Err(NameValidationError::Reserved)
             } else {


### PR DESCRIPTION
Previously we blocked any channels that contained the text "proposals".

This restriction still applies to groups but has been removed from channels.

