### PR TITLE
Filter out approvals when displaying transaction history

### DIFF
--- a/frontend/app/src/components/home/profile/AccountTransactions.svelte
+++ b/frontend/app/src/components/home/profile/AccountTransactions.svelte
@@ -111,17 +111,18 @@
                         transactionData = { kind: "idle" };
                         toastStore.showFailureToast(i18nKey("cryptoAccount.transactionError"));
                     } else {
+                        // Filter out approvals
+                        const transactions = result.transactions.filter((t) => t.kind !== "approve");
                         if (transactionData.kind === "loading") {
-                            transactionData = { kind: "success", data: result };
-                        }
-                        if (transactionData.kind === "loading_more") {
+                            transactionData = { kind: "success", data: { ...result, transactions }};
+                        } else if (transactionData.kind === "loading_more") {
                             transactionData = {
                                 kind: "success",
                                 data: {
                                     oldestTransactionId: result.oldestTransactionId,
                                     transactions: [
                                         ...transactionData.data.transactions,
-                                        ...result.transactions,
+                                        ...transactions,
                                     ],
                                 },
                             };


### PR DESCRIPTION
Currently approvals look like regular transactions so it appears as if you're double spending.
We could potentially improve this to show them but highlight the fact that they are approvals, but for now I think removing them is a good improvement.