### PR TITLE
Reduce gap between latest message and message entry box

### DIFF
--- a/frontend/app/src/styles/mixins.scss
+++ b/frontend/app/src/styles/mixins.scss
@@ -444,7 +444,7 @@ $shadow-level-3: 2px 6px 12px 0 rgba(25, 25, 25, 0.55);
 @mixin message-list() {
     flex: auto;
     background-color: var(--panel-bg);
-    padding: $sp3 $sp4;
+    padding: $sp3 $sp4 0 $sp4;
     overflow-x: hidden;
     overscroll-behavior-y: contain;
     position: relative;


### PR DESCRIPTION
Current:

<img width="503" alt="Screenshot 2025-04-02 at 09 43 49" src="https://github.com/user-attachments/assets/4f932c8e-21e6-4349-bfda-0e53f90b59eb" />

After this change:

<img width="503" alt="Screenshot 2025-04-02 at 09 43 30" src="https://github.com/user-attachments/assets/17e79462-c8f1-4694-a0e4-0edf88247102" />
