### PR TITLE
correct a couple of performance issues

### DIFF
--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -22,11 +22,11 @@
         userGroupKeys,
         draftMessagesStore,
         focusMessageIndex,
-        chatStateStore,
         chatListScopeStore as chatListScope,
         selectedCommunity,
         expandedDeletedMessages,
         eventsStore,
+        chatStateStore,
     } from "openchat-client";
     import InitialChatMessage from "./InitialChatMessage.svelte";
     import page from "page";

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -96,7 +96,7 @@ export const chatStateStore = createChatSpecificObjectStore<ChatSpecificState>(
     }),
 );
 
-const serverEventsStore = createDerivedPropStore<ChatSpecificState, "serverEvents">(
+export const serverEventsStore = createDerivedPropStore<ChatSpecificState, "serverEvents">(
     chatStateStore,
     "serverEvents",
     () => [],
@@ -205,7 +205,7 @@ export const expiredEventRangesStore = createDerivedPropStore<
 
 export const hideMessagesFromDirectBlocked = createLsBoolStore(configKeys.hideBlocked, false);
 
-const currentChatBlockedOrSuspendedUsers = derived(
+export const currentChatBlockedOrSuspendedUsers = derived(
     [
         currentChatBlockedUsers,
         currentCommunityBlockedUsers,

--- a/frontend/openchat-client/src/stores/index.ts
+++ b/frontend/openchat-client/src/stores/index.ts
@@ -29,3 +29,7 @@ export * from "./bots";
 export * from "./ephemeralMessages";
 export * from "./minutesOnline";
 export * from "./streakInsurance";
+export * from "./recentlySentMessages";
+export * from "./messageFilters";
+export * from "./proposalTallies";
+export * from "./localMessageUpdates";

--- a/frontend/openchat-client/src/stores/setStore.ts
+++ b/frontend/openchat-client/src/stores/setStore.ts
@@ -1,4 +1,5 @@
 import type { Writable } from "svelte/store";
+import { setsAreEqual } from "../utils/set";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createSetStore<T>(store: Writable<Set<T>>) {
@@ -7,7 +8,11 @@ export function createSetStore<T>(store: Writable<Set<T>>) {
 
     return {
         subscribe: store.subscribe,
-        set: store.set,
+        set: (s: Set<T>) => {
+            if (!setsAreEqual(s, storeValue)) {
+                store.set(s);
+            }
+        },
         add: (id: T): boolean => {
             if (!storeValue.has(id)) {
                 store.update((ids) => {


### PR DESCRIPTION
This covers the case where too many (or even _all_) events are filtered out from the initial load. This would then wait for the next iteration of the update loop to go and load more giving the impression that the chat was really slow to load. 

We also add an equality check to the set store. This stops some unnecessary re-computation of derived state that can have some big knock on effects.  