### PR TITLE
Bump Vite packages

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -61,7 +61,7 @@
         "typescript": "=5.4.2",
         "url": "^0.11.1",
         "util": "0.12.5",
-        "vite": "^6.0.14",
+        "vite": "^6.2.6",
         "vite-plugin-html": "^3.2.2"
     },
     "dependencies": {

--- a/frontend/openchat-agent/package.json
+++ b/frontend/openchat-agent/package.json
@@ -44,7 +44,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "ts2typebox": "^1.6.1",
         "typescript": "=5.4.2",
-        "vitest": "^2.1.9",
+        "vitest": "^3.1.1",
         "wait-on": "^7.0.1"
     }
 }

--- a/frontend/openchat-client/package.json
+++ b/frontend/openchat-client/package.json
@@ -44,7 +44,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "svelte": "^5.25.3",
         "typescript": "=5.4.2",
-        "vitest": "^2.1.9",
+        "vitest": "^3.1.1",
         "wait-on": "^7.0.1"
     }
 }

--- a/frontend/openchat-shared/package.json
+++ b/frontend/openchat-shared/package.json
@@ -34,7 +34,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "typescript": "=5.4.2",
-        "vitest": "^2.1.9",
+        "vitest": "^3.1.1",
         "wait-on": "^7.0.1"
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -140,7 +140,7 @@
                 "typescript": "=5.4.2",
                 "url": "^0.11.1",
                 "util": "0.12.5",
-                "vite": "^6.0.14",
+                "vite": "^6.2.6",
                 "vite-plugin-html": "^3.2.2"
             }
         },
@@ -224,9 +224,9 @@
             }
         },
         "app/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-            "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+            "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
             "cpu": [
                 "ppc64"
             ],
@@ -241,9 +241,9 @@
             }
         },
         "app/node_modules/@esbuild/android-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-            "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+            "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
             "cpu": [
                 "arm"
             ],
@@ -258,9 +258,9 @@
             }
         },
         "app/node_modules/@esbuild/android-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-            "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+            "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
             "cpu": [
                 "arm64"
             ],
@@ -275,9 +275,9 @@
             }
         },
         "app/node_modules/@esbuild/android-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-            "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+            "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
             "cpu": [
                 "x64"
             ],
@@ -292,9 +292,9 @@
             }
         },
         "app/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-            "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+            "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
             "cpu": [
                 "arm64"
             ],
@@ -309,9 +309,9 @@
             }
         },
         "app/node_modules/@esbuild/darwin-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-            "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+            "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
             "cpu": [
                 "x64"
             ],
@@ -326,9 +326,9 @@
             }
         },
         "app/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
             "cpu": [
                 "arm64"
             ],
@@ -343,9 +343,9 @@
             }
         },
         "app/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-            "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+            "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
             "cpu": [
                 "x64"
             ],
@@ -360,9 +360,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-            "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+            "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
             "cpu": [
                 "arm"
             ],
@@ -377,9 +377,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-            "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+            "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
             "cpu": [
                 "arm64"
             ],
@@ -394,9 +394,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-            "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+            "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
             "cpu": [
                 "ia32"
             ],
@@ -411,9 +411,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-loong64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-            "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+            "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
             "cpu": [
                 "loong64"
             ],
@@ -428,9 +428,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-            "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+            "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
             "cpu": [
                 "mips64el"
             ],
@@ -445,9 +445,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-            "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+            "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
             "cpu": [
                 "ppc64"
             ],
@@ -462,9 +462,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-            "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+            "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
             "cpu": [
                 "riscv64"
             ],
@@ -479,9 +479,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-s390x": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-            "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+            "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
             "cpu": [
                 "s390x"
             ],
@@ -496,9 +496,9 @@
             }
         },
         "app/node_modules/@esbuild/linux-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-            "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+            "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
             "cpu": [
                 "x64"
             ],
@@ -513,9 +513,9 @@
             }
         },
         "app/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
             "cpu": [
                 "x64"
             ],
@@ -530,9 +530,9 @@
             }
         },
         "app/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
             "cpu": [
                 "x64"
             ],
@@ -547,9 +547,9 @@
             }
         },
         "app/node_modules/@esbuild/sunos-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-            "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+            "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
             "cpu": [
                 "x64"
             ],
@@ -564,9 +564,9 @@
             }
         },
         "app/node_modules/@esbuild/win32-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-            "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+            "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -581,9 +581,9 @@
             }
         },
         "app/node_modules/@esbuild/win32-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-            "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+            "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
             "cpu": [
                 "ia32"
             ],
@@ -598,9 +598,9 @@
             }
         },
         "app/node_modules/@esbuild/win32-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-            "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+            "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
             "cpu": [
                 "x64"
             ],
@@ -1411,9 +1411,9 @@
             }
         },
         "app/node_modules/esbuild": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-            "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+            "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1424,31 +1424,31 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.24.2",
-                "@esbuild/android-arm": "0.24.2",
-                "@esbuild/android-arm64": "0.24.2",
-                "@esbuild/android-x64": "0.24.2",
-                "@esbuild/darwin-arm64": "0.24.2",
-                "@esbuild/darwin-x64": "0.24.2",
-                "@esbuild/freebsd-arm64": "0.24.2",
-                "@esbuild/freebsd-x64": "0.24.2",
-                "@esbuild/linux-arm": "0.24.2",
-                "@esbuild/linux-arm64": "0.24.2",
-                "@esbuild/linux-ia32": "0.24.2",
-                "@esbuild/linux-loong64": "0.24.2",
-                "@esbuild/linux-mips64el": "0.24.2",
-                "@esbuild/linux-ppc64": "0.24.2",
-                "@esbuild/linux-riscv64": "0.24.2",
-                "@esbuild/linux-s390x": "0.24.2",
-                "@esbuild/linux-x64": "0.24.2",
-                "@esbuild/netbsd-arm64": "0.24.2",
-                "@esbuild/netbsd-x64": "0.24.2",
-                "@esbuild/openbsd-arm64": "0.24.2",
-                "@esbuild/openbsd-x64": "0.24.2",
-                "@esbuild/sunos-x64": "0.24.2",
-                "@esbuild/win32-arm64": "0.24.2",
-                "@esbuild/win32-ia32": "0.24.2",
-                "@esbuild/win32-x64": "0.24.2"
+                "@esbuild/aix-ppc64": "0.25.2",
+                "@esbuild/android-arm": "0.25.2",
+                "@esbuild/android-arm64": "0.25.2",
+                "@esbuild/android-x64": "0.25.2",
+                "@esbuild/darwin-arm64": "0.25.2",
+                "@esbuild/darwin-x64": "0.25.2",
+                "@esbuild/freebsd-arm64": "0.25.2",
+                "@esbuild/freebsd-x64": "0.25.2",
+                "@esbuild/linux-arm": "0.25.2",
+                "@esbuild/linux-arm64": "0.25.2",
+                "@esbuild/linux-ia32": "0.25.2",
+                "@esbuild/linux-loong64": "0.25.2",
+                "@esbuild/linux-mips64el": "0.25.2",
+                "@esbuild/linux-ppc64": "0.25.2",
+                "@esbuild/linux-riscv64": "0.25.2",
+                "@esbuild/linux-s390x": "0.25.2",
+                "@esbuild/linux-x64": "0.25.2",
+                "@esbuild/netbsd-arm64": "0.25.2",
+                "@esbuild/netbsd-x64": "0.25.2",
+                "@esbuild/openbsd-arm64": "0.25.2",
+                "@esbuild/openbsd-x64": "0.25.2",
+                "@esbuild/sunos-x64": "0.25.2",
+                "@esbuild/win32-arm64": "0.25.2",
+                "@esbuild/win32-ia32": "0.25.2",
+                "@esbuild/win32-x64": "0.25.2"
             }
         },
         "app/node_modules/eventemitter3": {
@@ -1727,9 +1727,9 @@
             "license": "MIT"
         },
         "app/node_modules/postcss": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-            "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "dev": true,
             "funding": [
                 {
@@ -1855,15 +1855,15 @@
             }
         },
         "app/node_modules/vite": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-            "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+            "version": "6.2.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+            "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.24.2",
-                "postcss": "^8.4.49",
-                "rollup": "^4.23.0"
+                "esbuild": "^0.25.0",
+                "postcss": "^8.5.3",
+                "rollup": "^4.30.1"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -4647,9 +4647,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
             "cpu": [
                 "arm64"
             ],
@@ -4680,9 +4680,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
             "cpu": [
                 "arm64"
             ],
@@ -15312,6 +15312,8 @@
             "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/spy": "2.1.9",
                 "@vitest/utils": "2.1.9",
@@ -15328,6 +15330,8 @@
             "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tinyrainbow": "^1.2.0"
             },
@@ -15341,6 +15345,8 @@
             "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "2.1.9",
                 "pathe": "^1.1.2"
@@ -15355,6 +15361,8 @@
             "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/pretty-format": "2.1.9",
                 "magic-string": "^0.30.12",
@@ -15370,6 +15378,8 @@
             "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tinyspy": "^3.0.2"
             },
@@ -15383,6 +15393,8 @@
             "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/pretty-format": "2.1.9",
                 "loupe": "^3.1.2",
@@ -18352,6 +18364,8 @@
             "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "assertion-error": "^2.0.1",
                 "check-error": "^2.1.1",
@@ -21861,6 +21875,8 @@
             "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -36758,6 +36774,8 @@
             "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
             }
@@ -36768,6 +36786,8 @@
             "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -38117,7 +38137,6 @@
             "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "postcss": "^8.5.3",
@@ -38190,6 +38209,8 @@
             "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "cac": "^6.7.14",
                 "debug": "^4.3.7",
@@ -38220,6 +38241,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38237,6 +38259,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38254,6 +38277,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38271,6 +38295,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38288,6 +38313,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38305,6 +38331,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38322,6 +38349,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38339,6 +38367,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38356,6 +38385,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38373,6 +38403,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38390,6 +38421,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38407,6 +38439,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38424,6 +38457,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38441,6 +38475,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38458,6 +38493,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38475,6 +38511,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38492,6 +38529,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38509,6 +38547,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38526,6 +38565,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38543,6 +38583,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38560,6 +38601,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38577,6 +38619,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38594,6 +38637,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -38605,6 +38649,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -38643,6 +38689,8 @@
             "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -38710,7 +38758,6 @@
             "os": [
                 "aix"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38728,7 +38775,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38746,7 +38792,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38764,7 +38809,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38782,7 +38826,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38800,7 +38843,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38818,7 +38860,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38836,7 +38877,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38854,7 +38894,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38872,7 +38911,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38890,7 +38928,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38908,7 +38945,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38926,7 +38962,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38944,7 +38979,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38962,7 +38996,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38980,7 +39013,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -38998,25 +39030,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
-            "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39034,25 +39047,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
-            "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39070,7 +39064,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39088,7 +39081,6 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39106,7 +39098,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39124,7 +39115,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39142,7 +39132,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -39154,7 +39143,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -39209,7 +39197,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -39244,6 +39231,8 @@
             "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "2.1.9",
                 "@vitest/mocker": "2.1.9",
@@ -39317,6 +39306,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39334,6 +39324,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39351,6 +39342,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39368,6 +39360,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39385,6 +39378,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39402,6 +39396,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39419,6 +39414,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39436,6 +39432,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39453,6 +39450,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39470,6 +39468,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39487,6 +39486,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39504,6 +39504,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39521,6 +39522,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39538,6 +39540,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39555,6 +39558,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39572,6 +39576,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39589,6 +39594,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39606,6 +39612,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39623,6 +39630,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39640,6 +39648,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39657,6 +39666,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39674,6 +39684,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39691,6 +39702,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -39701,6 +39713,8 @@
             "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/spy": "2.1.9",
                 "estree-walker": "^3.0.3",
@@ -39729,6 +39743,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -39767,6 +39783,8 @@
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.0"
             }
@@ -39777,6 +39795,8 @@
             "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -40661,7 +40681,7 @@
                 "eslint-plugin-prettier": "^5.0.0",
                 "ts2typebox": "^1.6.1",
                 "typescript": "=5.4.2",
-                "vitest": "^2.1.9",
+                "vitest": "^3.1.1",
                 "wait-on": "^7.0.1"
             }
         },
@@ -40736,6 +40756,147 @@
             "integrity": "sha512-rIljj8VPYAfn26ANY+5pCNVBPiv6hSufuKGe46y65cJZpvx8vHvPXlU0Q/Le4OGtlNaL8Jg2FuhtvQX18lSIqA==",
             "license": "MIT"
         },
+        "openchat-agent/node_modules/@vitest/expect": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+            "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/@vitest/pretty-format": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+            "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/@vitest/runner": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+            "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.1.1",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/@vitest/snapshot": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+            "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/@vitest/spy": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+            "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/@vitest/utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+            "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "loupe": "^3.1.3",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/chai": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "openchat-agent/node_modules/debug": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-agent/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "openchat-agent/node_modules/expect-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+            "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "openchat-agent/node_modules/msgpackr": {
             "version": "1.11.2",
             "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.2.tgz",
@@ -40743,6 +40904,160 @@
             "license": "MIT",
             "optionalDependencies": {
                 "msgpackr-extract": "^3.0.2"
+            }
+        },
+        "openchat-agent/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-agent/node_modules/std-env": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-agent/node_modules/tinypool": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+            "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "openchat-agent/node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "openchat-agent/node_modules/vite-node": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+            "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.0",
+                "es-module-lexer": "^1.6.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-agent/node_modules/vitest": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+            "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "3.1.1",
+                "@vitest/mocker": "3.1.1",
+                "@vitest/pretty-format": "^3.1.1",
+                "@vitest/runner": "3.1.1",
+                "@vitest/snapshot": "3.1.1",
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "debug": "^4.4.0",
+                "expect-type": "^1.2.0",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "std-env": "^3.8.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinypool": "^1.0.2",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0",
+                "vite-node": "3.1.1",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.1.1",
+                "@vitest/ui": "3.1.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-agent/node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+            "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
             }
         },
         "openchat-client": {
@@ -40774,7 +41089,7 @@
                 "eslint-plugin-prettier": "^5.0.0",
                 "svelte": "^5.25.3",
                 "typescript": "=5.4.2",
-                "vitest": "^2.1.9",
+                "vitest": "^3.1.1",
                 "wait-on": "^7.0.1"
             }
         },
@@ -40927,6 +41242,92 @@
                 "@noble/hashes": "^1.3.1"
             }
         },
+        "openchat-client/node_modules/@vitest/expect": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+            "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/@vitest/pretty-format": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+            "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/@vitest/runner": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+            "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.1.1",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/@vitest/snapshot": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+            "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/@vitest/spy": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+            "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/@vitest/utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+            "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "loupe": "^3.1.3",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "openchat-client/node_modules/borc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/borc/-/borc-3.0.0.tgz",
@@ -40972,11 +41373,100 @@
                 "node": ">=10.18.0"
             }
         },
+        "openchat-client/node_modules/chai": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "openchat-client/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
+        },
+        "openchat-client/node_modules/debug": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-client/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "openchat-client/node_modules/expect-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+            "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "openchat-client/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-client/node_modules/std-env": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-client/node_modules/tinypool": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+            "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "openchat-client/node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "openchat-client/node_modules/usergeek-ic-js": {
             "version": "1.0.6",
@@ -40985,6 +41475,126 @@
             "peerDependencies": {
                 "@dfinity/agent": ">=1.4.0",
                 "@dfinity/auth-client": ">=1.4.0"
+            }
+        },
+        "openchat-client/node_modules/vite-node": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+            "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.0",
+                "es-module-lexer": "^1.6.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-client/node_modules/vitest": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+            "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "3.1.1",
+                "@vitest/mocker": "3.1.1",
+                "@vitest/pretty-format": "^3.1.1",
+                "@vitest/runner": "3.1.1",
+                "@vitest/snapshot": "3.1.1",
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "debug": "^4.4.0",
+                "expect-type": "^1.2.0",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "std-env": "^3.8.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinypool": "^1.0.2",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0",
+                "vite-node": "3.1.1",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.1.1",
+                "@vitest/ui": "3.1.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-client/node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+            "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
             }
         },
         "openchat-service-worker": {
@@ -41042,7 +41652,7 @@
                 "eslint-config-prettier": "^9.0.0",
                 "eslint-plugin-prettier": "^5.0.0",
                 "typescript": "=5.4.2",
-                "vitest": "^2.1.9",
+                "vitest": "^3.1.1",
                 "wait-on": "^7.0.1"
             }
         },
@@ -41109,6 +41719,301 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/hashes": "^1.3.1"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/expect": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+            "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/pretty-format": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+            "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/runner": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+            "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.1.1",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/snapshot": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+            "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/spy": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+            "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/@vitest/utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+            "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.1.1",
+                "loupe": "^3.1.3",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/chai": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "openchat-shared/node_modules/debug": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-shared/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "openchat-shared/node_modules/expect-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+            "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "openchat-shared/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-shared/node_modules/std-env": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "openchat-shared/node_modules/tinypool": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+            "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "openchat-shared/node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "openchat-shared/node_modules/vite-node": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+            "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.0",
+                "es-module-lexer": "^1.6.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "openchat-shared/node_modules/vitest": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+            "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "3.1.1",
+                "@vitest/mocker": "3.1.1",
+                "@vitest/pretty-format": "^3.1.1",
+                "@vitest/runner": "3.1.1",
+                "@vitest/snapshot": "3.1.1",
+                "@vitest/spy": "3.1.1",
+                "@vitest/utils": "3.1.1",
+                "chai": "^5.2.0",
+                "debug": "^4.4.0",
+                "expect-type": "^1.2.0",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "std-env": "^3.8.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinypool": "^1.0.2",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0",
+                "vite-node": "3.1.1",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.1.1",
+                "@vitest/ui": "3.1.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "openchat-shared/node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+            "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.1.1",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
             }
         },
         "openchat-worker": {


### PR DESCRIPTION
GitHub made PR #7776 saying we should update Vite but the PR didn't look quite right, so this PR simply gets all of the Vite packages onto their latest versions.