### PR TITLE
Transfer excess cycles back to the CyclesDispenser

### DIFF
--- a/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,13 +1,17 @@
 use crate::lifecycle::{init_env, init_state};
 use crate::memory::get_upgrades_memory;
-use crate::Data;
+use crate::{read_state, Data};
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use group_index_canister::post_upgrade::Args;
+use ic_cdk::management_canister::DepositCyclesArgs;
 use ic_cdk::post_upgrade;
 use stable_memory::get_reader;
-use tracing::info;
+use std::time::Duration;
+use tracing::{error, info};
 use utils::cycles::init_cycles_dispenser_client;
+
+const T: u128 = 1_000_000_000_000;
 
 #[post_upgrade]
 #[trace]
@@ -26,4 +30,29 @@ fn post_upgrade(args: Args) {
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");
+
+    let cycles_balance = ic_cdk::api::canister_liquid_cycle_balance();
+    let excess_cycles = cycles_balance.saturating_sub(200 * T);
+
+    if excess_cycles > 0 {
+        ic_cdk_timers::set_timer(Duration::ZERO, move || {
+            ic_cdk::futures::spawn(transfer_excess_cycles(excess_cycles))
+        });
+    }
+}
+
+async fn transfer_excess_cycles(cycles: u128) {
+    let cycles_dispenser_canister_id = read_state(|state| state.data.cycles_dispenser_canister_id);
+
+    match ic_cdk::management_canister::deposit_cycles(
+        &DepositCyclesArgs {
+            canister_id: cycles_dispenser_canister_id,
+        },
+        cycles,
+    )
+    .await
+    {
+        Ok(_) => info!(cycles, "Transferred excess cycles to CyclesDispenser"),
+        Err(error) => error!(?error, "Failed to transfer excess cycles to CyclesDispenser"),
+    }
 }


### PR DESCRIPTION
We've built up ~$2k in the GroupIndex from deleting groups and its only half way.
We should return these cycles to the CyclesDispenser so that it can hold off on burning ICP for a while.