### PR TITLE
Simplify `lookup_user` return type

### DIFF
--- a/backend/canisters/community/impl/src/updates/delete_messages.rs
+++ b/backend/canisters/community/impl/src/updates/delete_messages.rs
@@ -26,7 +26,7 @@ async fn delete_messages(args: Args) -> Response {
 
     if args.as_platform_moderator.unwrap_or_default() && caller != user_index_canister_id {
         match lookup_user(caller, user_index_canister_id).await {
-            Ok(u) if u.is_platform_moderator => {}
+            Ok(Some(u)) if u.is_platform_moderator => {}
             Ok(_) => return NotPlatformModerator,
             Err(error) => return InternalError(format!("{error:?}")),
         }

--- a/backend/canisters/group/impl/src/updates/change_role.rs
+++ b/backend/canisters/group/impl/src/updates/change_role.rs
@@ -7,7 +7,7 @@ use group_canister::change_role::*;
 use group_chat_core::GroupRoleInternal;
 use group_community_common::ExpiringMember;
 use types::{CanisterId, GroupRole, OCResult, UserId};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -34,7 +34,7 @@ async fn change_role(args: Args) -> Response {
     if lookup_caller || lookup_target {
         let user_id = if lookup_caller { caller_id } else { args.user_id };
         match lookup_user(user_id.into(), user_index_canister_id).await {
-            Ok(user) => {
+            Ok(Some(user)) => {
                 if user.is_platform_moderator {
                     if lookup_caller {
                         is_caller_platform_moderator = true;
@@ -43,8 +43,8 @@ async fn change_role(args: Args) -> Response {
                     }
                 }
             }
-            Err(LookupUserError::UserNotFound) => return NotAuthorized,
-            Err(LookupUserError::InternalError(error)) => return InternalError(error),
+            Ok(_) => return NotAuthorized,
+            Err(error) => return InternalError(format!("{error:?}")),
         };
     }
 

--- a/backend/canisters/group/impl/src/updates/convert_into_community.rs
+++ b/backend/canisters/group/impl/src/updates/convert_into_community.rs
@@ -26,7 +26,7 @@ async fn convert_into_community(args: Args) -> Response {
     };
 
     match user_index_canister_c2c_client::lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_diamond_member => {}
+        Ok(Some(user)) if user.is_diamond_member => {}
         _ => return NotAuthorized,
     }
 

--- a/backend/canisters/group/impl/src/updates/delete_messages.rs
+++ b/backend/canisters/group/impl/src/updates/delete_messages.rs
@@ -27,7 +27,7 @@ async fn delete_messages(args: Args) -> Response {
 
     if args.as_platform_moderator.unwrap_or_default() && caller != user_index_canister_id {
         match lookup_user(caller, user_index_canister_id).await {
-            Ok(u) if u.is_platform_moderator => {}
+            Ok(Some(u)) if u.is_platform_moderator => {}
             Ok(_) => return NotPlatformModerator,
             Err(error) => return InternalError(format!("{error:?}")),
         }

--- a/backend/canisters/group_index/impl/src/updates/freeze_community.rs
+++ b/backend/canisters/group_index/impl/src/updates/freeze_community.rs
@@ -4,7 +4,7 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use group_index_canister::{freeze_community, unfreeze_community};
 use types::{CanisterId, CommunityId, FrozenGroupInfo};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -22,9 +22,9 @@ async fn freeze_community(args: freeze_community::Args) -> freeze_community::Res
     };
 
     let user_id = match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_moderator => user.user_id,
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_moderator => user.user_id,
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     let c2c_args = community_canister::c2c_freeze_community::Args {
@@ -88,9 +88,9 @@ async fn unfreeze_community(args: unfreeze_community::Args) -> unfreeze_communit
     };
 
     let user_id = match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_moderator => user.user_id,
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_moderator => user.user_id,
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     let c2c_args = community_canister::c2c_unfreeze_community::Args { caller: user_id };

--- a/backend/canisters/group_index/impl/src/updates/mark_local_group_index_full.rs
+++ b/backend/canisters/group_index/impl/src/updates/mark_local_group_index_full.rs
@@ -3,7 +3,7 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use group_index_canister::mark_local_group_index_full::{Response::*, *};
 use tracing::info;
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -11,9 +11,9 @@ async fn mark_local_group_index_full(args: Args) -> Response {
     let (caller, user_index_canister_id) = read_state(|state| (state.env.caller(), state.data.user_index_canister_id));
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     mutate_state(|state| match state.data.local_index_map.get_mut(&args.canister_id) {

--- a/backend/canisters/group_index/impl/src/updates/set_community_moderation_flags.rs
+++ b/backend/canisters/group_index/impl/src/updates/set_community_moderation_flags.rs
@@ -18,7 +18,7 @@ async fn set_community_moderation_flags(args: Args) -> Response {
     };
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(Some(user)) if user.is_platform_moderator => (),
         Ok(_) => return NotAuthorized,
         Err(error) => return InternalError(format!("{error:?}")),
     };

--- a/backend/canisters/group_index/impl/src/updates/set_community_moderation_flags.rs
+++ b/backend/canisters/group_index/impl/src/updates/set_community_moderation_flags.rs
@@ -4,7 +4,7 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use group_index_canister::set_community_moderation_flags::{Response::*, *};
 use types::CanisterId;
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -18,9 +18,9 @@ async fn set_community_moderation_flags(args: Args) -> Response {
     };
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_moderator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     mutate_state(|state| commit(&args, state))

--- a/backend/canisters/group_index/impl/src/updates/set_community_upgrade_concurrency.rs
+++ b/backend/canisters/group_index/impl/src/updates/set_community_upgrade_concurrency.rs
@@ -4,7 +4,7 @@ use canister_tracing_macros::trace;
 use group_index_canister::set_community_upgrade_concurrency::{Response::*, *};
 use tracing::info;
 use types::CanisterId;
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -18,9 +18,9 @@ async fn set_community_upgrade_concurrency(args: Args) -> Response {
     });
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     let args = local_group_index_canister::c2c_set_community_upgrade_concurrency::Args { value: args.value };

--- a/backend/canisters/group_index/impl/src/updates/set_group_upgrade_concurrency.rs
+++ b/backend/canisters/group_index/impl/src/updates/set_group_upgrade_concurrency.rs
@@ -4,7 +4,7 @@ use canister_tracing_macros::trace;
 use group_index_canister::set_group_upgrade_concurrency::{Response::*, *};
 use tracing::info;
 use types::CanisterId;
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -18,9 +18,9 @@ async fn set_group_upgrade_concurrency(args: Args) -> Response {
     });
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     let args = local_group_index_canister::c2c_set_group_upgrade_concurrency::Args { value: args.value };

--- a/backend/canisters/local_user_index/c2c_client/src/lib.rs
+++ b/backend/canisters/local_user_index/c2c_client/src/lib.rs
@@ -22,23 +22,15 @@ generate_c2c_call!(c2c_user_canister, 300);
 generate_c2c_call!(join_channel);
 generate_c2c_call!(join_group);
 
-#[derive(Debug)]
-pub enum LookupUserError {
-    UserNotFound,
-    InternalError(String),
-}
-
 pub async fn lookup_user(
     user_id_or_principal: Principal,
     local_user_index_canister_id: CanisterId,
-) -> Result<GlobalUser, LookupUserError> {
+) -> Result<Option<GlobalUser>, C2CError> {
     let args = c2c_lookup_user::Args { user_id_or_principal };
 
-    match crate::c2c_lookup_user(local_user_index_canister_id, &args).await {
-        Ok(c2c_lookup_user::Response::Success(user)) => Ok(user),
-        Ok(_) => Err(LookupUserError::UserNotFound),
-        Err(error) => Err(LookupUserError::InternalError(format!("{error:?}"))),
-    }
+    let response = crate::c2c_lookup_user(local_user_index_canister_id, &args).await?;
+
+    Ok(if let c2c_lookup_user::Response::Success(user) = response { Some(user) } else { None })
 }
 
 pub async fn push_wasm_in_chunks(

--- a/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
+++ b/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
@@ -17,7 +17,7 @@ use sns_governance_canister::types::{
 };
 use tracing::{error, info};
 use types::{icrc2, CanisterId, MultiUserChat, SnsNeuronId, UserDetails, UserId};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 const OC_ROOT_URL: &str = "https://oc.app/";
 
@@ -47,9 +47,9 @@ async fn submit_proposal_impl(args: Args) -> Response {
     };
 
     let UserDetails { user_id, username, .. } = match lookup_user(caller, user_index_canister_id).await {
-        Ok(u) => u,
-        Err(LookupUserError::UserNotFound) => panic!("User not found"),
-        Err(LookupUserError::InternalError(error)) => return InternalError(format!("Failed to lookup user: {error}")),
+        Ok(Some(u)) => u,
+        Ok(_) => panic!("User not found"),
+        Err(error) => return InternalError(format!("Failed to lookup user: {error:?}")),
     };
 
     match process_transaction(args.transaction.clone(), this_canister_id).await {

--- a/backend/canisters/proposals_bot/impl/src/updates/top_up_neuron.rs
+++ b/backend/canisters/proposals_bot/impl/src/updates/top_up_neuron.rs
@@ -10,7 +10,6 @@ use sns_governance_canister::types::manage_neuron::claim_or_refresh::By;
 use sns_governance_canister::types::manage_neuron::{ClaimOrRefresh, Command};
 use sns_governance_canister::types::{manage_neuron_response, Empty, ManageNeuron};
 use types::{C2CError, CanisterId, SnsNeuronId};
-use user_index_canister_c2c_client::LookupUserError;
 
 #[update(msgpack = true)]
 #[trace]
@@ -26,9 +25,9 @@ async fn top_up_neuron(args: Args) -> Response {
     };
 
     match user_index_canister_c2c_client::lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => {}
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
-        _ => return Unauthorized,
+        Ok(Some(user)) if user.is_platform_operator => {}
+        Ok(_) => return Unauthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     }
 
     top_up_neuron_impl(&args, ledger_canister_id, sns_neuron_id)

--- a/backend/canisters/registry/impl/src/updates/add_message_filter.rs
+++ b/backend/canisters/registry/impl/src/updates/add_message_filter.rs
@@ -2,7 +2,7 @@ use crate::{mutate_state, read_state};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use registry_canister::add_message_filter::{Response::*, *};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -14,9 +14,9 @@ async fn add_message_filter(args: Args) -> Response {
     let (caller, user_index_canister_id) = read_state(|state| (state.env.caller(), state.data.user_index_canister_id));
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_moderator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_moderator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     }
 
     mutate_state(|state| match state.data.message_filters.add(args.regex, state.env.now()) {

--- a/backend/canisters/registry/impl/src/updates/remove_message_filter.rs
+++ b/backend/canisters/registry/impl/src/updates/remove_message_filter.rs
@@ -2,7 +2,7 @@ use crate::{mutate_state, read_state};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use registry_canister::remove_message_filter::{Response::*, *};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -10,9 +10,9 @@ async fn remove_message_filter(args: Args) -> Response {
     let (caller, user_index_canister_id) = read_state(|state| (state.env.caller(), state.data.user_index_canister_id));
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_moderator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_moderator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     }
 
     mutate_state(|state| match state.data.message_filters.remove(args.id, state.env.now()) {

--- a/backend/canisters/registry/impl/src/updates/set_airdrop_config.rs
+++ b/backend/canisters/registry/impl/src/updates/set_airdrop_config.rs
@@ -2,7 +2,7 @@ use crate::{mutate_state, read_state};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use registry_canister::set_airdrop_config::{Response::*, *};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(msgpack = true)]
 #[trace]
@@ -10,9 +10,9 @@ async fn set_airdrop_config(args: Args) -> Response {
     let (caller, user_index_canister_id) = read_state(|state| (state.env.caller(), state.data.user_index_canister_id));
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     }
 
     if mutate_state(|state| {

--- a/backend/canisters/translations/impl/src/queries/proposed.rs
+++ b/backend/canisters/translations/impl/src/queries/proposed.rs
@@ -2,7 +2,7 @@ use crate::read_state;
 use canister_api_macros::query;
 use canister_tracing_macros::trace;
 use translations_canister::proposed::{Response::*, *};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[query(composite = true, candid = true, msgpack = true)]
 #[trace]
@@ -10,9 +10,9 @@ async fn proposed(_args: Args) -> Response {
     let (user_index_canister_id, caller) = read_state(|state| (state.data.user_index_canister_id, state.env.caller()));
 
     match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) if user.is_platform_operator => (),
-        Ok(_) | Err(LookupUserError::UserNotFound) => return NotAuthorized,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) if user.is_platform_operator => (),
+        Ok(_) => return NotAuthorized,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     let records = read_state(|state| state.data.translations.proposed());

--- a/backend/canisters/translations/impl/src/updates/propose.rs
+++ b/backend/canisters/translations/impl/src/updates/propose.rs
@@ -2,7 +2,7 @@ use crate::{model::translations::ProposeArgs, mutate_state, read_state};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use translations_canister::propose::{Response::*, *};
-use user_index_canister_c2c_client::{lookup_user, LookupUserError};
+use user_index_canister_c2c_client::lookup_user;
 
 #[update(candid = true, msgpack = true)]
 #[trace]
@@ -29,9 +29,9 @@ async fn propose(args: Args) -> Response {
         read_state(|state| (state.data.user_index_canister_id, state.env.caller(), state.env.now()));
 
     let user_id = match lookup_user(caller, user_index_canister_id).await {
-        Ok(user) => user.user_id,
-        Err(LookupUserError::UserNotFound) => return UserNotFound,
-        Err(LookupUserError::InternalError(error)) => return InternalError(error),
+        Ok(Some(user)) => user.user_id,
+        Ok(None) => return UserNotFound,
+        Err(error) => return InternalError(format!("{error:?}")),
     };
 
     mutate_state(|state| {

--- a/backend/canisters/user_index/c2c_client/src/lib.rs
+++ b/backend/canisters/user_index/c2c_client/src/lib.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use canister_client::generate_c2c_call;
-use types::{CanisterId, UserDetails};
+use types::{C2CError, CanisterId, UserDetails};
 use user_index_canister::*;
 
 // Queries
@@ -19,21 +19,13 @@ generate_c2c_call!(c2c_send_openchat_bot_messages);
 generate_c2c_call!(c2c_set_avatar);
 generate_c2c_call!(c2c_suspend_users);
 
-#[derive(Debug)]
-pub enum LookupUserError {
-    UserNotFound,
-    InternalError(String),
-}
-
 pub async fn lookup_user(
     user_id_or_principal: Principal,
     user_index_canister_id: CanisterId,
-) -> Result<UserDetails, LookupUserError> {
+) -> Result<Option<UserDetails>, C2CError> {
     let args = c2c_lookup_user::Args { user_id_or_principal };
 
-    match crate::c2c_lookup_user(user_index_canister_id, &args).await {
-        Ok(c2c_lookup_user::Response::Success(user)) => Ok(user),
-        Ok(_) => Err(LookupUserError::UserNotFound),
-        Err(error) => Err(LookupUserError::InternalError(format!("{error:?}"))),
-    }
+    let response = crate::c2c_lookup_user(user_index_canister_id, &args).await?;
+
+    Ok(if let c2c_lookup_user::Response::Success(user) = response { Some(user) } else { None })
 }


### PR DESCRIPTION
This opens the doors for follow on changes where it integrates nicer with the new `OCError` and `OCResult` response types.

Eg. if a function is returning `OCResult` we can simply do `lookup_user(..)?;`