### PR TITLE
Use more fine grained error codes for P2P swaps

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Migrate more endpoints to returning standardised error codes ([#7797](https://github.com/open-chat-labs/open-chat/pull/7797))
+- Use more fine grained error codes for P2P swaps ([#7801](https://github.com/open-chat-labs/open-chat/pull/7801))
 
 ## [[2.0.1701](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1701-community)] - 2025-04-15
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Introduce `UnitResult` type to reduce duplication ([#7800](https://github.com/open-chat-labs/open-chat/pull/7800))
+- Use more fine grained error codes for P2P swaps ([#7801](https://github.com/open-chat-labs/open-chat/pull/7801))
 
 ## [[2.0.1704](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1704-group)] - 2025-04-15
 
@@ -20,7 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Switch more canister endpoints over to the new `OCError` response type ([#7793](https://github.com/open-chat-labs/open-chat/pull/7793))
 - Migrate more endpoints to returning standardised error codes ([#7797](https://github.com/open-chat-labs/open-chat/pull/7797))
-- Use more fine grained error codes for P2P swaps ([#7801](https://github.com/open-chat-labs/open-chat/pull/7801))
 
 ### Removed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Switch more canister endpoints over to the new `OCError` response type ([#7793](https://github.com/open-chat-labs/open-chat/pull/7793))
 - Migrate more endpoints to returning standardised error codes ([#7797](https://github.com/open-chat-labs/open-chat/pull/7797))
+- Use more fine grained error codes for P2P swaps ([#7801](https://github.com/open-chat-labs/open-chat/pull/7801))
 
 ### Removed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use accurate freezing threshold rather than an approximation ([#7771](https://github.com/open-chat-labs/open-chat/pull/7771))
 - Migrate more endpoints to returning standardised error codes ([#7797](https://github.com/open-chat-labs/open-chat/pull/7797))
 - Migrate more endpoints to returning standardised error codes ([#7799](https://github.com/open-chat-labs/open-chat/pull/7799))
+- Use more fine grained error codes for P2P swaps ([#7801](https://github.com/open-chat-labs/open-chat/pull/7801))
 
 ### Fixed
 

--- a/backend/libraries/error_codes/src/lib.rs
+++ b/backend/libraries/error_codes/src/lib.rs
@@ -97,7 +97,7 @@ pub enum OCErrorCode {
     NotDiamondMember = 253,
     UnexpectedIndex = 254,
     NoChange = 255,
-    SwapStatusError = 256,
+
     CyclesBalanceTooLow = 257,
     AlreadyInProgress = 258,
     InvalidPublicKey = 259,
@@ -169,6 +169,12 @@ pub enum OCErrorCode {
     SwapFailed = 325,
     PinTooShort = 326,
     PinTooLong = 327,
+    SwapStatusOpen = 328,
+    SwapStatusCancelled = 329,
+    SwapStatusExpired = 330,
+    SwapStatusReserved = 331,
+    SwapStatusAccepted = 332,
+    SwapStatusCompleted = 333,
 
     // InternalError
     C2CError = 500,

--- a/backend/libraries/types/src/p2p_swaps.rs
+++ b/backend/libraries/types/src/p2p_swaps.rs
@@ -1,5 +1,6 @@
 use crate::{Chat, MessageId, MessageIndex, P2PSwapContent, TimestampMillis, UserId};
 use candid::CandidType;
+use oc_error_codes::OCErrorCode;
 use serde::{Deserialize, Serialize};
 use ts_export::ts_export;
 
@@ -12,6 +13,19 @@ pub enum P2PSwapStatus {
     Reserved(P2PSwapReserved),
     Accepted(P2PSwapAccepted),
     Completed(P2PSwapCompleted),
+}
+
+impl P2PSwapStatus {
+    pub fn error_code(&self) -> OCErrorCode {
+        match self {
+            P2PSwapStatus::Open => OCErrorCode::SwapStatusOpen,
+            P2PSwapStatus::Cancelled(_) => OCErrorCode::SwapStatusCancelled,
+            P2PSwapStatus::Expired(_) => OCErrorCode::SwapStatusExpired,
+            P2PSwapStatus::Reserved(_) => OCErrorCode::SwapStatusReserved,
+            P2PSwapStatus::Accepted(_) => OCErrorCode::SwapStatusAccepted,
+            P2PSwapStatus::Completed(_) => OCErrorCode::SwapStatusCompleted,
+        }
+    }
 }
 
 pub enum UpdateP2PSwapResult<T> {


### PR DESCRIPTION
This will allow us to update the status on the UI based on the error code