### PR TITLE
make github markdown image links work

### DIFF
--- a/frontend/app/src/components/home/Markdown.svelte
+++ b/frontend/app/src/components/home/Markdown.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { marked } from "marked";
-    import { getContext } from "svelte";
     import type { OpenChat, UserGroupSummary } from "openchat-client";
-    import { userStore, userGroupSummaries as userGroups } from "openchat-client";
+    import { userGroupSummaries as userGroups, userStore } from "openchat-client";
+    import { getContext } from "svelte";
     import { DOMPurifyDefault, DOMPurifyOneLine } from "../../utils/domPurify";
     import { isSingleEmoji } from "../../utils/emojis";
 

--- a/frontend/app/src/utils/domPurify.ts
+++ b/frontend/app/src/utils/domPurify.ts
@@ -6,7 +6,7 @@ export const DOMPurifyOneLine = createOneLine();
 function createDefault(): DOMPurify.DOMPurify {
     const domPurify = DOMPurify();
     domPurify.setConfig({
-        ALLOWED_ATTR: ["target", "href", "class", "user-id", "suppress-links"],
+        ALLOWED_ATTR: ["target", "href", "class", "user-id", "suppress-links", "src", "alt"],
         CUSTOM_ELEMENT_HANDLING: {
             tagNameCheck: (tag) => tag === "profile-link",
             attributeNameCheck: (attr) => ["text", "userId"].includes(attr),
@@ -19,7 +19,7 @@ function createDefault(): DOMPurify.DOMPurify {
 function createOneLine(): DOMPurify.DOMPurify {
     const domPurify = DOMPurify();
     domPurify.setConfig({
-        ALLOWED_ATTR: ["target", "href", "class", "user-id", "suppress-links"],
+        ALLOWED_ATTR: ["target", "href", "class", "user-id", "suppress-links", "src", "alt"],
         FORBID_TAGS: ["br"],
         CUSTOM_ELEMENT_HANDLING: {
             tagNameCheck: (tag) => tag === "profile-link",


### PR DESCRIPTION
This will make it possible to embed images inside messages with markdown like this: 

![Screenshot of a comment on a GitHub issue showing an image, added in the Markdown, of an Octocat smiling and raising a tentacle.](https://myoctocat.com/assets/images/base-octocat.svg)

Which is cool!