### PR TITLE
Fix `isContiguous` checks and avoid exiting early when processing events

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3577,7 +3577,7 @@ export class OpenChat {
                     }
                 }
             }
-        } else if (isContiguousInThread(context, newEvents)) {
+        } else if (isContiguousInThread({ chatId, threadRootMessageIndex }, newEvents)) {
             app.updateServerThreadEvents({ chatId, threadRootMessageIndex }, (events) =>
                 mergeServerEvents(events, newEvents, context),
             );

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3480,17 +3480,6 @@ export class OpenChat {
             return;
         }
 
-        if (
-            threadRootMessageIndex === undefined &&
-            !isContiguous(chatId, newEvents, expiredEventRanges)
-        ) {
-            return;
-        }
-
-        if (threadRootMessageIndex !== undefined && !isContiguousInThread(newEvents)) {
-            return;
-        }
-
         const context = { chatId, threadRootMessageIndex };
         const myUserId = app.currentUserId;
         const now = BigInt(Date.now());
@@ -3564,27 +3553,31 @@ export class OpenChat {
         }
 
         if (threadRootMessageIndex === undefined) {
-            app.updateServerEvents(chatId, (events) =>
-                mergeServerEvents(events, newEvents, context),
-            );
             if (newLatestMessage !== undefined) {
                 localUpdates.updateLatestMessage(chatId, newLatestMessage);
             }
-            const selectedThreadRootMessageIndex = this.#liveState.selectedThreadRootMessageIndex;
-            if (selectedThreadRootMessageIndex !== undefined) {
-                const threadRootEvent = newEvents.find(
-                    (e) =>
-                        e.event.kind === "message" &&
-                        e.event.messageIndex === selectedThreadRootMessageIndex,
+
+            if (isContiguous(chatId, newEvents, expiredEventRanges)) {
+                app.updateServerEvents(chatId, (events) =>
+                    mergeServerEvents(events, newEvents, context),
                 );
-                if (threadRootEvent !== undefined) {
-                    publish("chatUpdated", {
-                        chatId,
-                        threadRootMessageIndex: selectedThreadRootMessageIndex,
-                    });
+
+                const selectedThreadRootMessageIndex = this.#liveState.selectedThreadRootMessageIndex;
+                if (selectedThreadRootMessageIndex !== undefined) {
+                    const threadRootEvent = newEvents.find(
+                        (e) =>
+                            e.event.kind === "message" &&
+                            e.event.messageIndex === selectedThreadRootMessageIndex,
+                    );
+                    if (threadRootEvent !== undefined) {
+                        publish("chatUpdated", {
+                            chatId,
+                            threadRootMessageIndex: selectedThreadRootMessageIndex,
+                        });
+                    }
                 }
             }
-        } else {
+        } else if (isContiguousInThread(context, newEvents)) {
             app.updateServerThreadEvents({ chatId, threadRootMessageIndex }, (events) =>
                 mergeServerEvents(events, newEvents, context),
             );

--- a/frontend/openchat-client/src/state/chat_details/merged.svelte.ts
+++ b/frontend/openchat-client/src/state/chat_details/merged.svelte.ts
@@ -76,6 +76,10 @@ export class ChatDetailsMergedState {
         this.#server?.updateEvents(chatId, fn);
     }
 
+    get selectedThread() {
+        return this.#server?.selectedThread
+    }
+
     setSelectedThread(id: ThreadIdentifier) {
         this.#server?.setSelectedThread(id);
     }

--- a/frontend/openchat-client/src/state/chat_details/server.svelte.ts
+++ b/frontend/openchat-client/src/state/chat_details/server.svelte.ts
@@ -114,6 +114,10 @@ export class ChatDetailsServerState {
         this.#events = fn(this.#events);
     }
 
+    get selectedThread() {
+        return this.#thread;
+    }
+
     setSelectedThread(id: ThreadIdentifier) {
         this.#thread = ThreadServerState.empty(id);
     }

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -7,6 +7,7 @@ import type {
     EventWrapper,
     ExpiredEventsRange,
     MessageContext,
+    ThreadIdentifier,
     ThreadSyncDetails,
 } from "openchat-shared";
 import { chatIdentifiersEqual, ChatMap, compareChats, messageContextsEqual } from "openchat-shared";
@@ -372,8 +373,8 @@ function isContiguousInternal(
     return isContiguous;
 }
 
-export function isContiguousInThread(context: MessageContext, events: EventWrapper<ChatEvent>[]): boolean {
-    return messageContextsEqual(context, app.selectedMessageContext)
+export function isContiguousInThread(threadId: ThreadIdentifier, events: EventWrapper<ChatEvent>[]): boolean {
+    return messageContextsEqual(threadId, app.selectedChat?.selectedThread?.id)
         && isContiguousInternal(app.selectedChat.confirmedThreadEventIndexesLoaded, events, []);
 }
 

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -372,8 +372,9 @@ function isContiguousInternal(
     return isContiguous;
 }
 
-export function isContiguousInThread(events: EventWrapper<ChatEvent>[]): boolean {
-    return isContiguousInternal(app.selectedChat.confirmedThreadEventIndexesLoaded, events, []);
+export function isContiguousInThread(context: MessageContext, events: EventWrapper<ChatEvent>[]): boolean {
+    return messageContextsEqual(context, app.selectedMessageContext)
+        && isContiguousInternal(app.selectedChat.confirmedThreadEventIndexesLoaded, events, []);
 }
 
 export function isContiguous(
@@ -381,7 +382,8 @@ export function isContiguous(
     events: EventWrapper<ChatEvent>[],
     expiredEventRanges: ExpiredEventsRange[],
 ): boolean {
-    return isContiguousInternal(confirmedEventIndexesLoaded(chatId), events, expiredEventRanges);
+    return chatIdentifiersEqual(chatId, app.selectedChat.chatId)
+        && isContiguousInternal(confirmedEventIndexesLoaded(chatId), events, expiredEventRanges);
 }
 
 export const currentChatDraftMessage = derived(


### PR DESCRIPTION
Previously the `isContiguous` checks weren't checking the chatId still matched which resulted in warnings being logged when attempting to add events to a no longer selected chat.

This PR also changes it such that we always run the various tasks on events, such as marking things read if current user was the sender, or bumping the latest message in the chat summary, whereas before these were skipped if the events were not contiguous.