### PR TITLE
Install additional required libs within `setup-rust` action

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install additional libs
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
@@ -41,8 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install additional libs
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read

--- a/.github/workflows/setup-rust/action.yml
+++ b/.github/workflows/setup-rust/action.yml
@@ -18,4 +18,5 @@ runs:
         shared-key: 'build-debug'
         save-if: ${{ inputs.cache == 'write' }}
     - name: Install additional libs
+      shell: bash
       run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev

--- a/.github/workflows/setup-rust/action.yml
+++ b/.github/workflows/setup-rust/action.yml
@@ -17,3 +17,5 @@ runs:
       with:
         shared-key: 'build-debug'
         save-if: ${{ inputs.cache == 'write' }}
+    - name: Install additional libs
+      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev


### PR DESCRIPTION
This should fix the failing `build-caches` action + avoids duplicating the installation step