### PR TITLE
make sure spotify & youtube previews use the intersection observer

### DIFF
--- a/frontend/app/src/components/home/LinkPreviews.svelte
+++ b/frontend/app/src/components/home/LinkPreviews.svelte
@@ -138,11 +138,13 @@
                 <Tweet tweetId={preview.tweetId} {intersecting} />
             {:else if preview.kind === "youtube"}
                 <YouTubePreview
+                    {intersecting}
                     {pinned}
                     fill={fill && previews.length === 1}
                     youtubeMatch={preview.regexMatch} />
             {:else if preview.kind === "spotify"}
                 <SpotifyPreviewComponent
+                    {intersecting}
                     {pinned}
                     fill={fill && previews.length === 1}
                     matches={preview.regexMatch} />

--- a/frontend/app/src/components/home/SpotifyPreview.svelte
+++ b/frontend/app/src/components/home/SpotifyPreview.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+    import { offlineStore, ui } from "openchat-client";
+
     interface Props {
         pinned: boolean;
         fill: boolean;
         matches: RegExpMatchArray;
+        intersecting: boolean;
     }
 
-    let { pinned, fill, matches }: Props = $props();
+    let { pinned, fill, matches, intersecting }: Props = $props();
 
     function buildUrl(type: string, id: string) {
         return `https://open.spotify.com/embed/${type}/${id}?utm_source=generator`;
@@ -13,22 +16,31 @@
     let type = $derived(matches[1]);
     let id = $derived(matches[2]);
     let url = $derived(buildUrl(type, id));
+    let rendered = $state(false);
+
+    $effect(() => {
+        if (intersecting && !ui.eventListScrolling && !rendered && !$offlineStore) {
+            rendered = true;
+        }
+    });
 </script>
 
-<div>
-    <iframe
-        class:pinned
-        class:fill
-        style="border-radius:12px"
-        src={url}
-        width="100%"
-        height="352"
-        frameBorder="0"
-        title="Spotify player"
-        allowfullscreen
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"></iframe>
-</div>
+{#if rendered}
+    <div>
+        <iframe
+            class:pinned
+            class:fill
+            style="border-radius:12px"
+            src={url}
+            width="100%"
+            height="352"
+            frameBorder="0"
+            title="Spotify player"
+            allowfullscreen
+            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            loading="lazy"></iframe>
+    </div>
+{/if}
 
 <style lang="scss">
     iframe {

--- a/frontend/app/src/components/home/YouTubePreview.svelte
+++ b/frontend/app/src/components/home/YouTubePreview.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
+    import { offlineStore, ui } from "openchat-client";
+
     interface Props {
         pinned: boolean;
         fill: boolean;
         youtubeMatch: RegExpMatchArray;
+        intersecting: boolean;
     }
 
-    let { pinned, fill, youtubeMatch }: Props = $props();
+    let { pinned, fill, youtubeMatch, intersecting }: Props = $props();
+    let rendered = $state(false);
+
+    $effect(() => {
+        if (intersecting && !ui.eventListScrolling && !rendered && !$offlineStore) {
+            rendered = true;
+        }
+    });
 
     let youtubeCode = $derived(
         youtubeMatch && (youtubeMatch[1] ?? youtubeMatch[2] ?? youtubeMatch[3])?.split("?")[0],
@@ -15,23 +25,25 @@
     );
 </script>
 
-<div>
-    <iframe
-        class:pinned
-        class:fill
-        width="100%"
-        height="315"
-        src={`https://www.youtube.com/embed/${youtubeCode}?start=${youtubeStartTime}`}
-        title="YouTube video player"
-        frameborder="0"
-        allow="accelerometer;
+{#if rendered}
+    <div>
+        <iframe
+            class:pinned
+            class:fill
+            width="100%"
+            height="315"
+            src={`https://www.youtube.com/embed/${youtubeCode}?start=${youtubeStartTime}`}
+            title="YouTube video player"
+            frameborder="0"
+            allow="accelerometer;
                             autoplay;
                             clipboard-write;
                             encrypted-media;
                             gyroscope;
                             picture-in-picture"
-        allowfullscreen></iframe>
-</div>
+            allowfullscreen></iframe>
+    </div>
+{/if}
 
 <style lang="scss">
     iframe {

--- a/frontend/app/src/components/home/communities/details/BrowseChannels.svelte
+++ b/frontend/app/src/components/home/communities/details/BrowseChannels.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { app, ChatMap, publish, type ChannelMatch, type OpenChat } from "openchat-client";
+    import { app, publish, type ChannelMatch, type OpenChat } from "openchat-client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../../../i18n/i18n";
     import { browseChannels } from "../../../../stores/settings";
@@ -17,8 +17,6 @@
     let { searchTerm }: Props = $props();
 
     let selectedCommunityId = $derived(app.selectedCommunitySummary?.id.communityId);
-    let allChannels = $derived(ChatMap.fromList(app.selectedCommunitySummary?.channels ?? []));
-
     let searching = $state(false);
     let pageIndex = 0;
     let pageSize = 100;
@@ -27,9 +25,7 @@
     let autoOpen = $state(false);
     let matchedCommunityId: string | undefined = undefined;
     let more = $derived(total > searchResults.length);
-    let filteredResults = $derived(
-        searchResults.filter((c) => !app.chatSummaries.has(c.id) && allChannels.has(c.id)),
-    );
+    let filteredResults = $derived(searchResults.filter((c) => !app.chatSummaries.has(c.id)));
 
     function search(term: string, reset = false) {
         const communityId = selectedCommunityId;


### PR DESCRIPTION
Hard to believe that we weren't already doing this. This can cause channels with lots of youtube videos in particular to crash. 

Secondary issue to be followed up - is there a better / more efficient / more recommended way to embed youtube links that _doesn't_ cause the site to crash. 