### PR TITLE
Bump Group/Community wasm versions to avoid `VersionNotHigher` error

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Bump Group/Community wasm versions to avoid `VersionNotHigher` error ([#7943](https://github.com/open-chat-labs/open-chat/pull/7943))
+
 ## [[2.0.1736](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1736-group_index)] - 2025-05-09
 
 ### Changed

--- a/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,12 +1,18 @@
-use crate::Data;
 use crate::lifecycle::{init_env, init_state};
 use crate::memory::get_upgrades_memory;
+use crate::updates::upgrade_community_canister_wasm::upgrade_community_wasm_in_local_group_index;
+use crate::updates::upgrade_group_canister_wasm::upgrade_group_wasm_in_local_group_index;
+use crate::{Data, mutate_state, read_state};
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
+use group_index_canister::ChildCanisterType;
 use group_index_canister::post_upgrade::Args;
 use ic_cdk::post_upgrade;
 use stable_memory::get_reader;
+use std::collections::HashMap;
+use std::time::Duration;
 use tracing::info;
+use types::{CanisterId, UpgradesFilter};
 use utils::cycles::init_cycles_dispenser_client;
 
 #[post_upgrade]
@@ -18,6 +24,8 @@ fn post_upgrade(args: Args) {
     let (data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
         msgpack::deserialize(reader).unwrap();
 
+    let test_mode = data.test_mode;
+
     canister_logger::init_with_logs(data.test_mode, errors, logs, traces);
 
     let env = init_env(data.rng_seed);
@@ -26,4 +34,72 @@ fn post_upgrade(args: Args) {
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");
+
+    ic_cdk_timers::set_timer(Duration::ZERO, move || {
+        ic_cdk::futures::spawn(switch_to_local_user_indexes(test_mode));
+    });
+}
+
+async fn switch_to_local_user_indexes(test_mode: bool) {
+    // Switch the LocalGroupIndex canisterIds to the LocalUserIndex canisterIds, since the
+    // LocalUserIndexes now support all the functionality of the LocalGroupIndexes and we will soon
+    // remove the LocalGroupIndexes
+    let mut index_replacements = Vec::new();
+    if test_mode {
+        index_replacements.push((
+            CanisterId::from_text("sbhuw-gyaaa-aaaaf-bfynq-cai").unwrap(),
+            CanisterId::from_text("pecvb-tqaaa-aaaaf-bhdiq-cai").unwrap(),
+        ));
+    } else {
+        index_replacements.push((
+            CanisterId::from_text("suaf3-hqaaa-aaaaf-bfyoa-cai").unwrap(),
+            CanisterId::from_text("nq4qv-wqaaa-aaaaf-bhdgq-cai").unwrap(),
+        ));
+        index_replacements.push((
+            CanisterId::from_text("ainth-qaaaa-aaaar-aaaba-cai").unwrap(),
+            CanisterId::from_text("aboy3-giaaa-aaaar-aaaaq-cai").unwrap(),
+        ));
+        index_replacements.push((
+            CanisterId::from_text("lrqxq-2qaaa-aaaac-aadla-cai").unwrap(),
+            CanisterId::from_text("lyt4m-myaaa-aaaac-aadkq-cai").unwrap(),
+        ));
+    }
+    let index_replacements_map: HashMap<_, _> = index_replacements.into_iter().collect();
+
+    let (mut group_canister_wasm, mut community_canister_wasm) = read_state(|state| {
+        (
+            state.data.child_canister_wasms.get(ChildCanisterType::Group).clone(),
+            state.data.child_canister_wasms.get(ChildCanisterType::Community).clone(),
+        )
+    });
+
+    community_canister_wasm.wasm.version.patch += 1;
+    group_canister_wasm.wasm.version.patch += 1;
+
+    let filter = UpgradesFilter {
+        include: [CanisterId::anonymous()].into_iter().collect(),
+        ..Default::default()
+    };
+
+    for index in index_replacements_map.values().copied() {
+        upgrade_group_wasm_in_local_group_index(
+            index,
+            &group_canister_wasm.wasm,
+            group_canister_wasm.wasm_hash,
+            Some(filter.clone()),
+        )
+        .await
+        .unwrap();
+
+        upgrade_community_wasm_in_local_group_index(
+            index,
+            &community_canister_wasm.wasm,
+            community_canister_wasm.wasm_hash,
+            Some(filter.clone()),
+        )
+        .await
+        .unwrap();
+    }
+
+    mutate_state(|state| state.data.local_index_map.switch_index_canisters(index_replacements_map));
 }

--- a/backend/canisters/group_index/impl/src/model/local_group_index_map.rs
+++ b/backend/canisters/group_index/impl/src/model/local_group_index_map.rs
@@ -1,6 +1,7 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::mem;
 use types::{BuildVersion, CanisterId, ChatId, CommunityId};
 
 #[derive(CandidType, Serialize, Deserialize, Default)]
@@ -19,6 +20,23 @@ pub struct LocalGroupIndex {
 }
 
 impl LocalGroupIndexMap {
+    pub fn switch_index_canisters(&mut self, replacements: HashMap<CanisterId, CanisterId>) {
+        self.index_map = mem::take(&mut self.index_map)
+            .into_iter()
+            .map(|(k, v)| (replacements.get(&k).copied().unwrap_or(k), v))
+            .collect();
+
+        self.group_to_index = mem::take(&mut self.group_to_index)
+            .into_iter()
+            .map(|(k, v)| (k, replacements.get(&v).copied().unwrap_or(v)))
+            .collect();
+
+        self.community_to_index = mem::take(&mut self.community_to_index)
+            .into_iter()
+            .map(|(k, v)| (k, replacements.get(&v).copied().unwrap_or(v)))
+            .collect();
+    }
+
     pub fn add_index(&mut self, index_id: CanisterId) -> bool {
         let exists = self.index_map.contains_key(&index_id);
         if !exists {


### PR DESCRIPTION
This reinstates the logic to push Group/Community wasms to each LocalUserIndex in `post_upgrade` but this time bumps each wasm version by 1. This is because the LocalUserIndexes reject the upgrade if the version is not higher.
This wasn't picked up in testing because we don't apply that same version restriction on the test environment.