### PR TITLE
Store bot endpoints in LocalUserIndexes

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Store `notifications_index_canister_id` within LocalUserIndexes ([#7947](https://github.com/open-chat-labs/open-chat/pull/7947))
+- Store bot endpoints in LocalUserIndexes ([#7949](https://github.com/open-chat-labs/open-chat/pull/7949))
 
 ## [[2.0.1739](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1739-local_user_index)] - 2025-05-09
 

--- a/backend/canisters/local_user_index/api/src/lib.rs
+++ b/backend/canisters/local_user_index/api/src/lib.rs
@@ -119,12 +119,13 @@ pub struct UserRegistered {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BotRegistered {
-    #[serde(alias = "user_id")]
     pub bot_id: UserId,
     pub owner_id: UserId,
     pub user_principal: Principal,
     pub name: String,
     pub commands: Vec<BotCommandDefinition>,
+    #[serde(default)]
+    pub endpoint: String,
     pub autonomous_config: Option<AutonomousConfig>,
     pub permitted_install_location: Option<BotInstallationLocation>,
 }
@@ -138,6 +139,8 @@ pub struct BotPublished {
 pub struct BotUpdated {
     pub bot_id: UserId,
     pub owner_id: UserId,
+    #[serde(default)]
+    pub endpoint: String,
     pub definition: BotDefinition,
 }
 

--- a/backend/canisters/local_user_index/impl/src/model/bots_map.rs
+++ b/backend/canisters/local_user_index/impl/src/model/bots_map.rs
@@ -15,6 +15,8 @@ pub struct Bot {
     pub owner_id: UserId,
     pub name: String,
     pub commands: Vec<BotCommandDefinition>,
+    #[serde(default)]
+    pub endpoint: String,
     pub autonomous_config: Option<AutonomousConfig>,
     pub principal: Principal,
     pub registration_status: BotRegistrationStatus,
@@ -39,6 +41,7 @@ impl BotsMap {
         owner_id: UserId,
         name: String,
         commands: Vec<BotCommandDefinition>,
+        endpoint: String,
         autonomous_config: Option<AutonomousConfig>,
         permitted_install_location: Option<BotInstallationLocation>,
     ) {
@@ -49,6 +52,7 @@ impl BotsMap {
                 owner_id,
                 name,
                 commands,
+                endpoint,
                 autonomous_config,
                 principal: user_principal,
                 registration_status: BotRegistrationStatus::Private(permitted_install_location),
@@ -63,10 +67,11 @@ impl BotsMap {
         });
     }
 
-    pub fn update(&mut self, bot_id: UserId, owner_id: UserId, definition: BotDefinition) {
+    pub fn update(&mut self, bot_id: UserId, owner_id: UserId, endpoint: String, definition: BotDefinition) {
         self.bots.entry(bot_id).and_modify(|bot| {
             bot.owner_id = owner_id;
             bot.commands = definition.commands;
+            bot.endpoint = endpoint;
             bot.autonomous_config = definition.autonomous_config;
         });
     }

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
@@ -96,6 +96,7 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
                 ev.owner_id,
                 ev.name,
                 ev.commands,
+                ev.endpoint,
                 ev.autonomous_config,
                 ev.permitted_install_location,
             );
@@ -104,7 +105,7 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
             state.data.bots.publish(ev.bot_id);
         }
         UserIndexEvent::BotUpdated(ev) => {
-            state.data.bots.update(ev.bot_id, ev.owner_id, ev.definition);
+            state.data.bots.update(ev.bot_id, ev.owner_id, ev.endpoint, ev.definition);
         }
         UserIndexEvent::PlatformOperatorStatusChanged(ev) => {
             state

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support exclusion of installed bots from `explore_bots` ([#7904](https://github.com/open-chat-labs/open-chat/pull/7904))
 - Store `notifications_index_canister_id` within LocalUserIndexes ([#7947](https://github.com/open-chat-labs/open-chat/pull/7947))
+- Sync bot endpoints to LocalUserIndexes ([#7949](https://github.com/open-chat-labs/open-chat/pull/7949))
 
 ## [[2.0.1724](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1724-user_index)] - 2025-05-06
 

--- a/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -4,8 +4,10 @@ use crate::memory::get_upgrades_memory;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use ic_cdk::post_upgrade;
+use local_user_index_canister::{BotUpdated, UserIndexEvent};
 use stable_memory::get_reader;
 use tracing::info;
+use types::BotDefinition;
 use user_index_canister::post_upgrade::Args;
 use utils::cycles::init_cycles_dispenser_client;
 
@@ -15,8 +17,26 @@ fn post_upgrade(args: Args) {
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);
 
-    let (data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
+    let (mut data, errors, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>, Vec<LogEntry>) =
         msgpack::deserialize(reader).unwrap();
+
+    for (bot_id, bot) in data.users.iter_bots() {
+        for canister_id in data.local_index_map.canisters() {
+            data.user_index_event_sync_queue.push(
+                *canister_id,
+                UserIndexEvent::BotUpdated(BotUpdated {
+                    bot_id: *bot_id,
+                    owner_id: bot.owner,
+                    endpoint: bot.endpoint.clone(),
+                    definition: BotDefinition {
+                        description: bot.description.clone(),
+                        commands: bot.commands.clone(),
+                        autonomous_config: bot.autonomous_config.clone(),
+                    },
+                }),
+            );
+        }
+    }
 
     canister_logger::init_with_logs(data.test_mode, errors, logs, traces);
 

--- a/backend/canisters/user_index/impl/src/updates/register_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/register_bot.rs
@@ -86,6 +86,7 @@ fn register_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
             user_principal: args.principal,
             name: args.name.clone(),
             commands: args.definition.commands.clone(),
+            endpoint: args.endpoint.clone(),
             autonomous_config: args.definition.autonomous_config.clone(),
             permitted_install_location: args.permitted_install_location,
         }),

--- a/backend/canisters/user_index/impl/src/updates/update_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/update_bot.rs
@@ -69,7 +69,8 @@ fn update_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
         bot.autonomous_config = definition.autonomous_config.clone();
     }
 
-    let owner = bot.owner;
+    let owner_id = bot.owner;
+    let endpoint = bot.endpoint.clone();
 
     bot.last_updated = now;
 
@@ -84,7 +85,8 @@ fn update_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
         state.push_event_to_all_local_user_indexes(
             UserIndexEvent::BotUpdated(BotUpdated {
                 bot_id: args.bot_id,
-                owner_id: owner,
+                owner_id,
+                endpoint,
                 definition,
             }),
             None,


### PR DESCRIPTION
This is needed to switch notifications over to being handled by the LocalUserIndexes