### PR TITLE
Fix transfer amount when submitting proposal

### DIFF
--- a/frontend/app/src/components/home/proposal/MakeProposalModal.svelte
+++ b/frontend/app/src/components/home/proposal/MakeProposalModal.svelte
@@ -150,7 +150,7 @@
         busy = true;
 
         if (
-            !(await approvePayment(PROPOSALS_BOT_CANISTER, proposalCost + BigInt(2) * transferFee))
+            !(await approvePayment(PROPOSALS_BOT_CANISTER, proposalCost + transferFee))
         ) {
             busy = false;
             return;

--- a/frontend/openchat-agent/src/services/proposalsBot/proposalsBot.client.ts
+++ b/frontend/openchat-agent/src/services/proposalsBot/proposalsBot.client.ts
@@ -44,7 +44,7 @@ export class ProposalsBotClient extends MsgpackCanisterAgent {
             transaction: {
                 ledger: principalStringToBytes(ledger),
                 token_symbol: token,
-                amount: proposalRejectionFee,
+                amount: proposalRejectionFee + transactionFee,
                 from: principalToIcrcAccount(userId),
                 to: principalToIcrcAccount(this.canisterId),
                 fee: transactionFee,


### PR DESCRIPTION
This fixes the transfer fees specified when submitting a proposal.
They should be as follows:

1 fee for the approval + 1 fee for the transfer to the ProposalsBot + 1 fee for the transfer to the neuron if required.
So 3 fees in total.