### PR TITLE
Revert "Always save community details in the cache to bump `last_updated` (#7974)"

### DIFF
--- a/frontend/openchat-agent/src/services/community/community.client.ts
+++ b/frontend/openchat-agent/src/services/community/community.client.ts
@@ -998,7 +998,9 @@ export class CommunityClient extends MsgpackCanisterAgent {
         previous: CommunityDetails,
     ): Promise<CommunityDetails> {
         const response = await this.getCommunityDetailsUpdatesFromBackend(previous);
-        await setCachedCommunityDetails(this.db, id.communityId, response);
+        if (response.lastUpdated > previous.lastUpdated) {
+            await setCachedCommunityDetails(this.db, id.communityId, response);
+        }
         return response;
     }
 


### PR DESCRIPTION
This reverts commit 71d96d9318cb6be33cd488abcfed9def0023c2c6.