### PR TITLE
Use single digit to specify dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
  "candid",
  "ic-agent",
  "ic-utils",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "types",
 ]
 
@@ -1364,7 +1364,7 @@ version = "0.1.0"
 name = "canister_time"
 version = "0.1.0"
 dependencies = [
- "ic0 0.24.0",
+ "ic0 0.25.0",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ dependencies = [
  "ic-cdk 0.18.0",
  "ic-ledger-types",
  "ic-stable-structures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ledger_utils",
  "msgpack",
  "oc_error_codes",
@@ -1850,7 +1850,7 @@ dependencies = [
  "icrc-ledger-types",
  "installed_bots",
  "instruction_counts_log",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "ledger_utils",
  "local_user_index_canister",
@@ -3724,7 +3724,7 @@ dependencies = [
  "icrc-ledger-types",
  "installed_bots",
  "instruction_counts_log",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ledger_utils",
  "local_user_index_canister",
  "local_user_index_canister_c2c_client",
@@ -3761,7 +3761,7 @@ dependencies = [
  "group_community_common",
  "hex",
  "ic-stable-structures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "msgpack",
  "oc_error_codes",
@@ -4780,6 +4780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
 
 [[package]]
+name = "ic0"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ecd5c978846f2f917a899f5d644dca9a7f01b4cf7d16b361a5746c4f1922029"
+
+[[package]]
 name = "ic_bls12_381"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,7 +5256,7 @@ dependencies = [
  "ic-stable-structures",
  "icrc-ledger-types",
  "identity_canister",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jwt",
  "jwt-simple 0.12.9",
  "lazy_static",
@@ -5334,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -5891,7 +5897,7 @@ dependencies = [
  "ic-cdk 0.18.0",
  "ic-cdk-timers",
  "ic-stable-structures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "json",
  "jwt",
  "ledger_utils",
@@ -6037,7 +6043,7 @@ dependencies = [
  "icdex_client",
  "icrc-ledger-types",
  "icrc_ledger_canister_c2c_client",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "market_maker_canister",
  "msgpack",
  "rand 0.8.5",
@@ -7741,9 +7747,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -7751,7 +7757,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7825,7 +7831,7 @@ dependencies = [
  "ic-stable-structures",
  "icrc-ledger-types",
  "icrc_ledger_canister_c2c_client",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ledger_utils",
  "msgpack",
  "nns_governance_canister",
@@ -7867,9 +7873,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psm"
@@ -7882,9 +7902,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d31cbfcd94884c3a67ec210c83efb06cb43674043458b0ad59f6947f8462c23"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags 2.9.0",
  "memchr",
@@ -10773,7 +10793,7 @@ version = "0.1.0"
 dependencies = [
  "canister_agent_utils",
  "clap 4.5.4",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "tokio",
@@ -10821,7 +10841,7 @@ dependencies = [
  "icrc-ledger-types",
  "icrc_ledger_canister",
  "icrc_ledger_canister_c2c_client",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ledger_utils",
  "msgpack",
  "rand 0.8.5",
@@ -11191,7 +11211,7 @@ dependencies = [
  "icrc_ledger_canister_c2c_client",
  "identity_utils",
  "installed_bots",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "kongswap_canister",
  "kongswap_canister_c2c_client",
  "ledger_utils",
@@ -11319,7 +11339,7 @@ dependencies = [
  "identity_canister",
  "identity_canister_c2c_client",
  "identity_utils",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jwt",
  "ledger_utils",
  "local_user_index_canister",
@@ -11385,7 +11405,7 @@ dependencies = [
  "ic-cdk 0.18.0",
  "ic-cdk-timers",
  "ic-management-canister-types 0.3.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "msgpack",
  "oc_error_codes",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,98 +178,98 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace.dependencies]
-async-channel = "2.1.0"
-async-trait = "0.1.74"
-aws-config = "1.1.5"
-aws-sdk-dynamodb = "1.14.0"
-aws-types = "1.1.5"
-base64 = "0.22.1"
-bitflags = { version = "2.4.1", features = ["serde"] }
-candid = "0.10.13"
-canbench-rs = "0.1.12"
-clap = "4.5.4"
-ct-codecs = "1.1.1"
-data-encoding = "2.6.0"
-dataurl = "0.1.2"
-dotenv = "0.15.0"
-enum-repr = "0.2.6"
+async-channel = "2"
+async-trait = "0.1"
+aws-config = "1"
+aws-sdk-dynamodb = "1"
+aws-types = "1"
+base64 = "0.22"
+bitflags = { version = "2", features = ["serde"] }
+candid = "0.10"
+canbench-rs = "0.1"
+clap = "4"
+ct-codecs = "1"
+data-encoding = "2"
+dataurl = "0.1"
+dotenv = "0.15"
+enum-repr = "0.2"
 event_store_canister = { git = "https://github.com/open-chat-labs/event-store", tag = "v0.10.0" }
 event_store_producer = { git = "https://github.com/open-chat-labs/event-store", tag = "v0.10.0" }
 event_store_producer_cdk_runtime = { git = "https://github.com/open-chat-labs/event-store", tag = "v0.10.0" }
 event_store_types = { git = "https://github.com/open-chat-labs/event-store", tag = "v0.10.0" }
 event_store_utils = { git = "https://github.com/open-chat-labs/event-store", tag = "v0.10.0" }
-futures = "0.3.30"
-getrandom = { version = "0.2.15", features = ["custom"] }
-hex = "0.4.3"
-hmac-sha256 = { version = "1.1.7", features = ["traits010"] }
-http = "1.1.0"
-ic-agent = "0.40.0"
-ic-canister-sig-creation = "1.1.0"
-ic-captcha = "1.0.0"
-ic-cbor = "2.5.0"
-ic-cdk = "0.18.0"
-ic-cdk-macros = "0.18.0"
-ic-cdk-timers = "0.12.0"
-ic-certificate-verification = "2.4.0"
-ic-certification = "2.5.0"
-ic-http-certification = "2.5.0"
-ic-ledger-types = "0.15.0"
-ic-management-canister-types = "0.3.0"
-ic_principal = "0.1.1"
-ic-stable-structures = "0.6.8"
-ic-transport-types = "0.40.0"
-ic-utils = "0.40.0"
-ic-verifiable-credentials = "1.0.1"
-icrc-ledger-types = "0.1.5"
-ic0 = "0.24.0"
-itertools = "0.13.0"
-jwt-simple = { version = "0.12.9", default-features = false, features = [
+futures = "0.3"
+getrandom = { version = "0.2", features = ["custom"] }
+hex = "0.4"
+hmac-sha256 = { version = "1", features = ["traits010"] }
+http = "1"
+ic-agent = "0.40"
+ic-canister-sig-creation = "1"
+ic-captcha = "1"
+ic-cbor = "2"
+ic-cdk = "0.18"
+ic-cdk-macros = "0.18"
+ic-cdk-timers = "0.12"
+ic-certificate-verification = "2"
+ic-certification = "2"
+ic-http-certification = "2"
+ic-ledger-types = "0.15"
+ic-management-canister-types = "0.3"
+ic_principal = "0.1"
+ic-stable-structures = "0.6"
+ic-transport-types = "0.40"
+ic-utils = "0.40"
+ic-verifiable-credentials = "1"
+icrc-ledger-types = "0.1"
+ic0 = "0.25"
+itertools = "0.14"
+jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-lazy_static = "1.4.0"
-num-traits = "0.2.19"
-openssl = "0.10.72"
-p256 = { version = "0.13.2" }
-pocket-ic = "8.0.0"
-proc-macro2 = "1.0.83"
-prometheus = "0.13.4"
-proptest = "1.6.0"
-pulldown-cmark = { version = "0.12.0", default-features = false, features = [
+lazy_static = "1"
+num-traits = "0.2"
+openssl = "0.10"
+p256 = { version = "0.13" }
+pocket-ic = "8"
+proc-macro2 = "1"
+prometheus = "0.14"
+proptest = "1"
+pulldown-cmark = { version = "0.13", default-features = false, features = [
     "html",
 ] }
-quote = "1.0.36"
-rand = "0.8.5"
+quote = "1"
+rand = "0.8"
 range-set = "0.0.11"
-regex-lite = "0.1.5"
-reqwest = "0.12.15"
-rmp-serde = "1.3.0"
-serde = "1.0.216"
-serde_bytes = "0.11.15"
-serde_cbor = "0.11.2"
-serde_json = "1.0.140"
-serde_repr = "0.1.19"
-serde_tokenstream = "0.2.2"
-sha2 = "0.10.8"
-sha3 = "0.10.8"
+regex-lite = "0.1"
+reqwest = "0.12"
+rmp-serde = "1"
+serde = "1"
+serde_bytes = "0.11"
+serde_cbor = "0.11"
+serde_json = "1"
+serde_repr = "0.1"
+serde_tokenstream = "0.2"
+sha2 = "0.10"
+sha3 = "0.10"
 sign_in_with_email_canister = { git = "https://github.com/open-chat-labs/ic-sign-in-with-email", rev = "v0.13.0" }
 sign_in_with_email_canister_test_utils = { package = "test_utils", git = "https://github.com/open-chat-labs/ic-sign-in-with-email", rev = "v0.13.0" }
-syn = "2.0.65"
-tauri = "2.5.1"
-test-case = "3.3.1"
-test-strategy = "0.4.0"
-thiserror = "2.0.12"
-time = "0.3.36"
-tokio = "1.44.2"
-tracing = "0.1.40"
-tracing-subscriber = "0.3.19"
-ts-rs = { version = "10.1.0", features = ["no-serde-warnings"] }
-twox-hash = { version = "2.1.0", features = ["xxhash3_128"] }
-url = "2.5.2"
-urlencoding = "2.1.3"
-web-push = { version = "0.10.4", default-features = false, features = [
+syn = "2"
+tauri = "2"
+test-case = "3"
+test-strategy = "0.4"
+thiserror = "2"
+time = "0.3"
+tokio = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+ts-rs = { version = "10", features = ["no-serde-warnings"] }
+twox-hash = { version = "2", features = ["xxhash3_128"] }
+url = "2"
+urlencoding = "2"
+web-push = { version = "0.10", default-features = false, features = [
     "hyper-client",
 ] }
-x509-parser = "0.16.0"
+x509-parser = "0.16"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This will allow us to use `cargo update` to pull in all latest non-breaking version updates