### PR TITLE
A more efficient approach to community details updates

### DIFF
--- a/frontend/app/src/components/home/AcceptRulesModal.svelte
+++ b/frontend/app/src/components/home/AcceptRulesModal.svelte
@@ -3,7 +3,7 @@
         type OpenChat,
         app,
         captureRulesAcceptanceStore as rulesAcceptanceStore,
-        selectedCommunityStore,
+        selectedCommunityRulesStore,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
@@ -19,9 +19,7 @@
 
 <AreYouSure
     title={i18nKey("rules.acceptTitle")}
-    message={i18nKey(
-        client.combineRulesText(app.selectedChat.rules, $selectedCommunityStore?.rules),
-    )}
+    message={i18nKey(client.combineRulesText(app.selectedChat.rules, $selectedCommunityRulesStore))}
     yesLabel={i18nKey("rules.accept")}
     noLabel={i18nKey("rules.reject")}
     action={onAction} />

--- a/frontend/app/src/components/home/ChannelOrCommunitySummary.svelte
+++ b/frontend/app/src/components/home/ChannelOrCommunitySummary.svelte
@@ -5,7 +5,7 @@
         OpenChat,
         publish,
         selectedCommunityReferralsStore,
-        selectedCommunityStore,
+        selectedCommunityRulesStore,
         type ChannelSummary,
         type CommunitySummary,
     } from "openchat-client";
@@ -41,7 +41,7 @@
     let canEditChannel = $derived(
         !channelFrozen && !communityFrozen && client.canEditGroupDetails(channel.id),
     );
-    let rules = $derived($selectedCommunityStore?.rules ?? defaultChatRules("community"));
+    let rules = $derived($selectedCommunityRulesStore ?? defaultChatRules("community"));
     let canDeleteCommunity = $derived(client.canDeleteCommunity(community.id));
     let canInviteToCommunity = $derived(!communityFrozen && client.canInviteUsers(community.id));
 

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -48,7 +48,7 @@
         routeForScope,
         routeStore,
         captureRulesAcceptanceStore as rulesAcceptanceStore,
-        selectedCommunityStore,
+        selectedCommunityRulesStore,
         subscribe,
         suspendedUserStore,
         ui,
@@ -849,7 +849,7 @@
         modal = {
             kind: "edit_community",
             community,
-            communityRules: $selectedCommunityStore?.rules ?? defaultChatRules("community"),
+            communityRules: $selectedCommunityRulesStore ?? defaultChatRules("community"),
         };
     }
 

--- a/frontend/app/src/components/home/communities/details/CommunitySummary.svelte
+++ b/frontend/app/src/components/home/communities/details/CommunitySummary.svelte
@@ -3,7 +3,7 @@
         type OpenChat,
         defaultChatRules,
         selectedCommunityReferralsStore,
-        selectedCommunityStore,
+        selectedCommunityRulesStore,
         selectedCommunitySummaryStore,
     } from "openchat-client";
     import { getContext } from "svelte";
@@ -14,7 +14,7 @@
     const client = getContext<OpenChat>("client");
 
     let frozen = $derived(client.isCommunityFrozen($selectedCommunitySummaryStore?.id));
-    let rules = $derived($selectedCommunityStore?.rules ?? defaultChatRules("community"));
+    let rules = $derived($selectedCommunityRulesStore ?? defaultChatRules("community"));
     let canDelete = $derived(
         $selectedCommunitySummaryStore !== undefined &&
             !frozen &&

--- a/frontend/app/src/components/home/groupdetails/GroupDetailsBody.svelte
+++ b/frontend/app/src/components/home/groupdetails/GroupDetailsBody.svelte
@@ -4,7 +4,7 @@
         app,
         AvatarSize,
         currentUserIdStore,
-        selectedCommunityStore,
+        selectedCommunityRulesStore,
         selectedCommunitySummaryStore,
     } from "openchat-client";
     import { getContext } from "svelte";
@@ -48,7 +48,7 @@
     let avatarSrc = $derived(client.groupAvatarUrl(chat, $selectedCommunitySummaryStore));
     let combinedRulesText = $derived(
         canSend
-            ? client.combineRulesText(app.selectedChat.rules, $selectedCommunityStore?.rules)
+            ? client.combineRulesText(app.selectedChat.rules, $selectedCommunityRulesStore)
             : "",
     );
     let externalUrl = $derived(chat.kind === "channel" ? chat.externalUrl : undefined);

--- a/frontend/openchat-client/src/state/app.svelte.spec.ts
+++ b/frontend/openchat-client/src/state/app.svelte.spec.ts
@@ -349,13 +349,12 @@ describe("app state", () => {
             });
 
             test("local map updates - remove member", () => {
-                expect(app.selectedCommunity).not.toBeUndefined();
-                expect(app.selectedCommunity!.members.has("user_one")).toBe(true);
+                expect(app.selectedCommunityMembers.has("user_one")).toBe(true);
                 const undo = communityLocalUpdates.removeMember(communityId, "user_one");
                 expect(get(selectedCommunityMembersStore).has("user_one")).toBe(false);
-                expect(app.selectedCommunity!.members.has("user_one")).toBe(false);
+                expect(app.selectedCommunityMembers.has("user_one")).toBe(false);
                 undo();
-                expect(app.selectedCommunity!.members.has("user_one")).toBe(true);
+                expect(app.selectedCommunityMembers.has("user_one")).toBe(true);
             });
 
             test("local map updates - update member", () => {
@@ -365,34 +364,30 @@ describe("app state", () => {
                     displayName: "Mr One",
                     lapsed: false,
                 };
-                expect(app.selectedCommunity).not.toBeUndefined();
-                expect(app.selectedCommunity!.members.has("user_two")).toBe(false);
+                expect(app.selectedCommunityMembers.has("user_two")).toBe(false);
                 const undo = communityLocalUpdates.updateMember(communityId, "user_one", updated);
-                expect(app.selectedCommunity!.members.get("user_one")?.displayName).toEqual(
-                    "Mr One",
-                );
+                expect(app.selectedCommunityMembers.get("user_one")?.displayName).toEqual("Mr One");
                 undo();
-                expect(app.selectedCommunity!.members.get("user_one")?.displayName).toEqual(
+                expect(app.selectedCommunityMembers.get("user_one")?.displayName).toEqual(
                     "User One",
                 );
             });
 
             test("local set updates", () => {
-                expect(app.selectedCommunity).not.toBeUndefined();
-                expect(app.selectedCommunity!.blockedUsers.has("a")).toBe(true);
-                expect(app.selectedCommunity!.blockedUsers.has("d")).toBe(false);
+                expect(app.selectedCommunityBlockedUsers.has("a")).toBe(true);
+                expect(app.selectedCommunityBlockedUsers.has("d")).toBe(false);
 
                 // check that local updates work and are correctly merged with server state
                 const undo = communityLocalUpdates.blockUser(communityId, "d");
-                expect(app.selectedCommunity!.blockedUsers.has("d")).toBe(true);
+                expect(app.selectedCommunityBlockedUsers.has("d")).toBe(true);
 
                 // undo the local update
                 undo();
-                expect(app.selectedCommunity!.blockedUsers.has("d")).toBe(false);
+                expect(app.selectedCommunityBlockedUsers.has("d")).toBe(false);
 
                 // try unblock
                 communityLocalUpdates.unblockUser(communityId, "a");
-                expect(app.selectedCommunity!.blockedUsers.has("a")).toBe(false);
+                expect(app.selectedCommunityBlockedUsers.has("a")).toBe(false);
             });
         });
     });

--- a/frontend/openchat-client/src/state/community/detailUpdates.ts
+++ b/frontend/openchat-client/src/state/community/detailUpdates.ts
@@ -2,7 +2,6 @@ import {
     type CommunityIdentifier,
     type ExternalBotPermissions,
     type Member,
-    type PublicApiKeyDetails,
     type UserGroupDetails,
     type VersionedRules,
 } from "openchat-shared";
@@ -10,101 +9,48 @@ import { CommunityMapStore, LocalMap } from "../map";
 import { LocalSet } from "../set";
 import { scheduleUndo, type UndoLocalUpdate } from "../undo";
 
-export class CommunityDetailUpdates {
-    rules?: VersionedRules;
-    invitedUsers = new LocalSet<string>();
-    blockedUsers = new LocalSet<string>();
-    referrals = new LocalSet<string>();
-    lapsedMembers = new LocalSet<string>();
-    members = new LocalMap<string, Member>();
-    userGroups = new LocalMap<number, UserGroupDetails>();
-    bots = new LocalMap<string, ExternalBotPermissions>();
-    apiKeys = new LocalMap<string, PublicApiKeyDetails>();
-}
-
-export class CommunityDetailsUpdatesManager extends CommunityMapStore<CommunityDetailUpdates> {
-    #getOrCreate(id: CommunityIdentifier): CommunityDetailUpdates {
-        return this.get(id) ?? new CommunityDetailUpdates();
-    }
-
-    #withState(id: CommunityIdentifier, fn: (state: CommunityDetailUpdates) => UndoLocalUpdate) {
-        const state = this.#getOrCreate(id);
-        const undo = fn(state);
-        this.set(id, state);
-        return scheduleUndo(() => {
-            undo();
-            this.publish();
-        });
-    }
+export class CommunityDetailsUpdatesManager {
+    members = new CommunityLocalMapStore<string, Member>();
+    invitedUsers = new CommunityLocalSetStore<string>();
+    blockedUsers = new CommunityLocalSetStore<string>();
+    userGroups = new CommunityLocalMapStore<number, UserGroupDetails>();
+    bots = new CommunityLocalMapStore<string, ExternalBotPermissions>();
+    rules = new CommunityMapStore<VersionedRules>();
 
     updateMember(id: CommunityIdentifier, userId: string, member: Member) {
-        return this.#withState(id, (state) => {
-            return state.members.addOrUpdate(userId, member);
-        });
-    }
-
-    blockUser(id: CommunityIdentifier, userId: string): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.blockedUsers.add(userId);
-        });
-    }
-
-    unblockUser(id: CommunityIdentifier, userId: string): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.blockedUsers.remove(userId);
-        });
+        return this.members.addOrUpdate(id, userId, member);
     }
 
     removeMember(id: CommunityIdentifier, userId: string): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.members.remove(userId);
-        });
+        return this.members.remove(id, userId);
     }
 
     inviteUsers(id: CommunityIdentifier, userIds: string[]): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            const undos = userIds.map((u) => state.invitedUsers.add(u));
-            return () => {
-                undos.forEach((u) => u());
-            };
-        });
+        return this.invitedUsers.addMany(id, userIds);
     }
 
     uninviteUsers(id: CommunityIdentifier, userIds: string[]): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            const undos = userIds.map((u) => state.invitedUsers.remove(u));
-            return () => {
-                undos.forEach((u) => u());
-            };
-        });
+        return this.invitedUsers.removeMany(id, userIds);
     }
 
-    updateRules(id: CommunityIdentifier, rules: VersionedRules): UndoLocalUpdate {
-        const state = this.#getOrCreate(id);
-        const previous = state.rules;
-        state.rules = rules;
-        this.set(id, state);
-        return scheduleUndo(() => {
-            this.update(id, (val) => ({ ...val, rules: previous }));
-        });
+    blockUser(id: CommunityIdentifier, userId: string): UndoLocalUpdate {
+        return this.blockedUsers.add(id, userId);
+    }
+
+    unblockUser(id: CommunityIdentifier, userId: string): UndoLocalUpdate {
+        return this.blockedUsers.remove(id, userId);
     }
 
     deleteUserGroup(id: CommunityIdentifier, userGroupId: number): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.userGroups.remove(userGroupId);
-        });
+        return this.userGroups.remove(id, userGroupId);
     }
 
     addOrUpdateUserGroup(id: CommunityIdentifier, userGroup: UserGroupDetails): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.userGroups.addOrUpdate(userGroup.id, userGroup);
-        });
+        return this.userGroups.addOrUpdate(id, userGroup.id, userGroup);
     }
 
     removeBot(id: CommunityIdentifier, botId: string): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.bots.remove(botId);
-        });
+        return this.bots.remove(id, botId);
     }
 
     installBot(
@@ -112,8 +58,85 @@ export class CommunityDetailsUpdatesManager extends CommunityMapStore<CommunityD
         botId: string,
         perm: ExternalBotPermissions,
     ): UndoLocalUpdate {
-        return this.#withState(id, (state) => {
-            return state.bots.addOrUpdate(botId, perm);
+        return this.bots.addOrUpdate(id, botId, perm);
+    }
+
+    updateRules(id: CommunityIdentifier, rules: VersionedRules): UndoLocalUpdate {
+        const previous = this.rules.get(id);
+        this.rules.set(id, rules);
+        return scheduleUndo(() => {
+            if (previous === undefined) {
+                this.rules.delete(id);
+            } else {
+                this.rules.set(id, previous);
+            }
+        });
+    }
+
+    clear() {
+        this.members.clear();
+        this.invitedUsers.clear();
+        this.blockedUsers.clear();
+        this.userGroups.clear();
+        this.bots.clear();
+        this.rules.clear();
+    }
+}
+
+export class CommunityLocalSetStore<V> extends CommunityMapStore<LocalSet<V>> {
+    add(id: CommunityIdentifier, value: V) {
+        return this.#withSet(id, (set) => set.add(value));
+    }
+
+    addMany(id: CommunityIdentifier, values: V[]) {
+        return this.#withSet(id, (set) => {
+            const undos = values.map((v) => set.add(v));
+            return () => {
+                undos.forEach((u) => u());
+            };
+        });
+    }
+
+    removeMany(id: CommunityIdentifier, values: V[]) {
+        return this.#withSet(id, (set) => {
+            const undos = values.map((v) => set.remove(v));
+            return () => {
+                undos.forEach((u) => u());
+            };
+        });
+    }
+
+    remove(id: CommunityIdentifier, value: V) {
+        return this.#withSet(id, (set) => set.remove(value));
+    }
+
+    #withSet(id: CommunityIdentifier, fn: (map: LocalSet<V>) => UndoLocalUpdate) {
+        const set = this.get(id) ?? new LocalSet();
+        const undo = fn(set);
+        this.set(id, set);
+        return scheduleUndo(() => {
+            undo();
+            this.publish();
+        });
+    }
+}
+
+export class CommunityLocalMapStore<K, V> extends CommunityMapStore<LocalMap<K, V>> {
+    addOrUpdate(id: CommunityIdentifier, key: K, value: V) {
+        return this.#withMap(id, (map) => map.addOrUpdate(key, value));
+    }
+
+    remove(id: CommunityIdentifier, key: K) {
+        return this.#withMap(id, (map) => map.remove(key));
+    }
+
+    #withMap(id: CommunityIdentifier, fn: (map: LocalMap<K, V>) => UndoLocalUpdate) {
+        const map = this.get(id) ?? new LocalMap();
+        const undo = fn(map);
+        this.set(id, map);
+        return scheduleUndo(() => {
+            undo();
+            this.publish();
         });
     }
 }


### PR DESCRIPTION
Since local updates occur on individual collections (e.g. members or blocked users), if makes much more sense to apply these updates at the same scope. Previously if _any_ of the community details had updates all of the derived stores would be re-run. Not a huge cost, but this re-organisation avoids that. 