### PR TITLE
Make updates still work when User canister inaccessible

### DIFF
--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1875,7 +1875,7 @@ export class OpenChatAgent extends EventTarget {
                     anyUpdates = true;
                 }
             } catch (error) {
-                console.error("Failed to get user canister updates", error);
+                console.error("Failed to get updates from User canister", error);
             }
         }
 


### PR DESCRIPTION
If you hide whitespace you'll see that this is a tiny change.
I've just wrapped the call to the User canister within a `try ... catch ...`, so that we can still fetch updates from the LocalUserIndexes if the User canister is inaccessible.