### PR TITLE
Rehydrate users after loading from cache

### DIFF
--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -407,7 +407,8 @@ export class OpenChatAgent extends EventTarget {
     }
 
     getAllCachedUsers(): Promise<UserSummary[]> {
-        return measure("getAllUsers", () => getAllUsers());
+        return measure("getAllUsers", () => getAllUsers().then((users) =>
+            users.map((u) => this.rehydrateUserSummary(u))));
     }
 
     logError(message?: unknown, ...optionalParams: unknown[]): void {


### PR DESCRIPTION
In #8099 I changed the response of `getAllCachedUsers` from being a `UserLookup` to `UserSummary[]`, but I also inadvertently removed the code which was hydrating those user summaries. This PR reinstates that code.