### PR TITLE
Only skip updating chat details store if chatId matches

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3368,11 +3368,10 @@ export class OpenChat {
         switch (serverChat.kind) {
             case "group_chat":
             case "channel":
-                const lastUpdated = serverChat.lastUpdated;
                 const resp: GroupChatDetailsResponse = await this.#sendRequest({
                     kind: "getGroupDetails",
                     chatId: serverChat.id,
-                    chatLastUpdated: lastUpdated,
+                    chatLastUpdated: serverChat.lastUpdated,
                 }).catch(CommonResponses.failure);
                 if ("members" in resp) {
                     if (!chatIdentifiersEqual(serverChat.id, selectedChatIdStore.value)) {
@@ -3383,7 +3382,9 @@ export class OpenChat {
                         );
                         return;
                     }
-                    if (selectedServerChatStore.value?.chatId === serverChat.id && resp.timestamp <= lastUpdated) {
+                    if (selectedServerChatStore.value?.chatId === serverChat.id &&
+                        resp.timestamp <= selectedServerChatStore.value.timestamp
+                    ) {
                         return;
                     }
                     const members = resp.members.filter((m) => !m.lapsed);
@@ -3394,6 +3395,7 @@ export class OpenChat {
                     selectedServerChatStore.set(
                         new ChatDetailsState(
                             serverChat.id,
+                            resp.timestamp,
                             new Map(members.map((m) => [m.userId, m])),
                             lapsed,
                             resp.blockedUsers,

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3382,9 +3382,12 @@ export class OpenChat {
                         );
                         return;
                     }
-                    if (chatIdentifiersEqual(selectedServerChatStore.value?.chatId, serverChat.id) &&
-                        resp.timestamp <= selectedServerChatStore.value.timestamp
+                    const currentStoreValue = selectedServerChatStore.value;
+                    if (currentStoreValue !== undefined &&
+                        chatIdentifiersEqual(currentStoreValue.chatId, serverChat.id) &&
+                        resp.timestamp <= currentStoreValue.timestamp
                     ) {
+                        // The store already has the latest updates, exiting
                         return;
                     }
                     const members = resp.members.filter((m) => !m.lapsed);

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3374,21 +3374,35 @@ export class OpenChat {
                     chatId: serverChat.id,
                     chatLastUpdated: lastUpdated,
                 }).catch(CommonResponses.failure);
-                if ("members" in resp && resp.timestamp > lastUpdated) {
+                if ("members" in resp) {
+                    if (!chatIdentifiersEqual(serverChat.id, selectedChatIdStore.value)) {
+                        console.warn(
+                            "Attempting to set chat details on the wrong chat - probably a stale response",
+                            serverChat.id,
+                            selectedChatIdStore.value,
+                        );
+                        return;
+                    }
+                    if (selectedServerChatStore.value?.chatId === serverChat.id && resp.timestamp <= lastUpdated) {
+                        return;
+                    }
                     const members = resp.members.filter((m) => !m.lapsed);
                     const lapsed = new Set(
                         resp.members.filter((m) => m.lapsed).map((m) => m.userId),
                     );
-                    this.#setChatDetailsFromServer(
-                        serverChat.id,
-                        new Map(members.map((m) => [m.userId, m])),
-                        lapsed,
-                        resp.blockedUsers,
-                        resp.invitedUsers,
-                        resp.pinnedMessages,
-                        resp.rules,
-                        resp.bots.reduce((all, b) => all.set(b.id, b.permissions), new Map()),
-                        new Map(resp.webhooks.map((w) => [w.id, w])),
+
+                    selectedServerChatStore.set(
+                        new ChatDetailsState(
+                            serverChat.id,
+                            new Map(members.map((m) => [m.userId, m])),
+                            lapsed,
+                            resp.blockedUsers,
+                            resp.invitedUsers,
+                            resp.pinnedMessages,
+                            resp.bots.reduce((all, b) => all.set(b.id, b.permissions), new Map()),
+                            new Map(resp.webhooks.map((w) => [w.id, w])),
+                            resp.rules,
+                        ),
                     );
                     await this.#updateUserStoreFromEvents([]);
                 }
@@ -3397,40 +3411,6 @@ export class OpenChat {
                 // app.setDirectChatDetails(serverChat.id, currentUserIdStore.value);  //TODO - make sure this still works without this
                 break;
         }
-    }
-
-    #setChatDetailsFromServer(
-        chatId: ChatIdentifier,
-        members: Map<string, Member>,
-        lapsedMembers: Set<string>,
-        blockedUsers: Set<string>,
-        invitedUsers: Set<string>,
-        pinnedMessages: Set<number>,
-        rules: VersionedRules,
-        bots: Map<string, GrantedBotPermissions>,
-        webhooks: Map<string, WebhookDetails>,
-    ) {
-        if (!chatIdentifiersEqual(chatId, selectedChatIdStore.value)) {
-            console.warn(
-                "Attempting to set chat details on the wrong chat - probably a stale response",
-                chatId,
-                selectedChatIdStore.value,
-            );
-            return;
-        }
-        selectedServerChatStore.set(
-            new ChatDetailsState(
-                chatId,
-                members,
-                lapsedMembers,
-                blockedUsers,
-                invitedUsers,
-                pinnedMessages,
-                bots,
-                webhooks,
-                rules,
-            ),
-        );
     }
 
     achievementLogo(id: number): string {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3382,7 +3382,7 @@ export class OpenChat {
                         );
                         return;
                     }
-                    if (selectedServerChatStore.value?.chatId === serverChat.id &&
+                    if (chatIdentifiersEqual(selectedServerChatStore.value?.chatId, serverChat.id) &&
                         resp.timestamp <= selectedServerChatStore.value.timestamp
                     ) {
                         return;

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -155,6 +155,7 @@ describe("app state", () => {
             selectedServerChatStore.set(
                 new ChatDetailsState(
                     chatId,
+                    BigInt(0),
                     new Map([
                         [
                             "user_one",

--- a/frontend/openchat-client/src/state/chat/serverDetails.ts
+++ b/frontend/openchat-client/src/state/chat/serverDetails.ts
@@ -12,6 +12,7 @@ import {
 export class ChatDetailsState {
     constructor(
         public chatId: ChatIdentifier,
+        public timestamp: bigint,
         public members: ReadonlyMap<string, Member>,
         public lapsedMembers: ReadonlySet<string>,
         public blockedUsers: ReadonlySet<string>,


### PR DESCRIPTION
Prior to this, we would detect that there have been no new updates and so skip setting the store value.
But when you change chat we need to update the store regardless of if there are new updates.