### PR TITLE
Update `ChatMap` and `ChatSet` to use numbers as keys

### DIFF
--- a/frontend/openchat-client/src/state/set.ts
+++ b/frontend/openchat-client/src/state/set.ts
@@ -1,4 +1,11 @@
-import { SafeSet, type ChatIdentifier, type Primitive, type ReadonlySet } from "openchat-shared";
+import {
+    SafeSet,
+    type ChatIdentifier,
+    type Primitive,
+    type ReadonlySet,
+    chatIdentifierToInt,
+    chatIdentifierFromInt
+} from "openchat-shared";
 import { type UndoLocalUpdate } from "./undo";
 
 export class LocalSet<T> {
@@ -64,8 +71,8 @@ export class LocalSet<T> {
 export class ChatLocalSet extends LocalSet<ChatIdentifier> {
     constructor() {
         super(
-            (k) => JSON.stringify(k),
-            (k) => JSON.parse(String(k)),
+            chatIdentifierToInt,
+            (k) => chatIdentifierFromInt(k as number),
         );
     }
 }

--- a/frontend/openchat-shared/src/utils/map.ts
+++ b/frontend/openchat-shared/src/utils/map.ts
@@ -11,6 +11,7 @@ import {
     type Primitive,
 } from "../domain";
 import type { ChatIdentifier, MessageContext } from "../domain/chat";
+import { chatIdentifierFromInt, chatIdentifierToInt } from "./chat";
 
 export interface ReadonlyMap<K, V> {
     get(key: K): V | undefined;
@@ -209,8 +210,8 @@ export class GlobalMap<V> extends SafeMap<"global", V> {
 export class ChatMap<V> extends SafeMap<ChatIdentifier, V> {
     constructor(_map?: Map<string, V>) {
         super(
-            (k) => JSON.stringify(k),
-            (k) => JSON.parse(String(k)) as ChatIdentifier,
+            chatIdentifierToInt,
+            (k) => chatIdentifierFromInt(k as number),
             _map,
         );
     }


### PR DESCRIPTION
This avoids using `JSON.stringify` and `JSON.parse` every time we access items in the `ChatMap/Set`.
We instead generate a number based on the chat Id and use that as the key.
We then store the keys by their number in a map to avoid allocating new objects each time we traverse the entries.