### PR TITLE
Restrict prize message coin spinning

### DIFF
--- a/frontend/app/src/components/home/ChatMessageContent.svelte
+++ b/frontend/app/src/components/home/ChatMessageContent.svelte
@@ -120,7 +120,7 @@
         text={i18nKey(failed ? "p2pSwap.failedToCreateMessage" : "p2pSwap.creatingYourMessage")}
         {failed} />
 {:else if content.kind === "prize_content"}
-    <PrizeContent chatId={messageContext.chatId} {messageId} {content} {me} />
+    <PrizeContent chatId={messageContext.chatId} {messageId} {content} {me} {intersecting} />
 {:else if content.kind === "p2p_swap_content"}
     <P2PSwapContent {senderId} {messageContext} {messageId} {content} {me} {reply} {pinned} />
 {:else if content.kind === "prize_winner_content"}

--- a/frontend/app/src/components/home/PrizeContent.svelte
+++ b/frontend/app/src/components/home/PrizeContent.svelte
@@ -113,7 +113,7 @@
             content.requiresCaptcha,
     );
     let showChallenge = $state(false);
-    let spin = $derived(intersecting && !finished && !allClaimed && !claimedByYou);
+    let spin = $derived(intersecting && !finished && !allClaimed);
 
     function onChallengeResult(e: MouseEvent, success: boolean) {
         if (success) {

--- a/frontend/app/src/components/home/PrizeContent.svelte
+++ b/frontend/app/src/components/home/PrizeContent.svelte
@@ -38,9 +38,10 @@
         chatId: ChatIdentifier;
         messageId: bigint;
         me: boolean;
+        intersecting: boolean;
     }
 
-    let { content, chatId, messageId, me }: Props = $props();
+    let { content, chatId, messageId, me, intersecting }: Props = $props();
 
     let progressWidth = $state(0);
 
@@ -112,6 +113,7 @@
             content.requiresCaptcha,
     );
     let showChallenge = $state(false);
+    let spin = $derived(intersecting && !finished && !allClaimed && !claimedByYou);
 
     function onChallengeResult(e: MouseEvent, success: boolean) {
         if (success) {
@@ -148,7 +150,7 @@
             {/if}
         </div>
         <div class="prize-coin">
-            <SpinningToken {logo} />
+            <SpinningToken {logo} {spin} />
         </div>
     </div>
     <div class="bottom">


### PR DESCRIPTION
In channels with loads of prizes things get a bit janky. I _think_ this will help. If not, we will have another look. 

fixes #8123 