### PR TITLE
Update dev userId to send test tokens to

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -81,5 +81,5 @@ echo "Canisters created"
     true \
 
 ./scripts/deploy-test-chat-ledger.sh $IDENTITY
-./scripts/get-test-icp.sh "w7lou-c7777-77774-qaamq-cai" $IDENTITY
-./scripts/get-test-chat-tokens.sh "w7lou-c7777-77774-qaamq-cai" $IDENTITY
+./scripts/get-test-icp.sh "xvemo-ap777-77774-qaalq-cai" $IDENTITY
+./scripts/get-test-chat-tokens.sh "xvemo-ap777-77774-qaalq-cai" $IDENTITY


### PR DESCRIPTION
The canisterId changed because we removed the LocalGroupIndex and Notifications canisters