### PR TITLE
Avoid superfluous events computation after changing selected chat

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3821,7 +3821,7 @@ export class OpenChat {
             return;
         }
         serverThreadEventsStore.update((state) => {
-            const existing = messageContextsEqual(state?.threadId, id) ? state.events : [];
+            const existing = state && messageContextsEqual(state.threadId, id) ? state.events : [];
             return {
                 threadId: id,
                 events: fn(existing),
@@ -3842,7 +3842,7 @@ export class OpenChat {
             return;
         }
         serverEventsStore.update((state) => {
-            const existing = chatIdentifiersEqual(state?.chatId, chatId) ? state.events : [];
+            const existing = state && chatIdentifiersEqual(state.chatId, chatId) ? state.events : [];
             return {
                 chatId,
                 events: fn(existing),

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -2527,7 +2527,7 @@ export class OpenChat {
         if (!isSuccessfulEventsResponse(resp)) return false;
 
         if (!keepCurrentEvents) {
-            serverEventsStore.set([]);
+            serverEventsStore.set(undefined);
         }
 
         await this.#updateUserStoreFromEvents(resp.events);
@@ -2881,7 +2881,7 @@ export class OpenChat {
 
         // clear some chat state
         withPausedStores(() => {
-            serverEventsStore.set([]);
+            serverEventsStore.set(undefined);
             expiredServerEventRanges.set(new DRange());
             selectedChatUserIdsStore.set(new Set());
             selectedChatUserGroupKeysStore.set(new Set());
@@ -2943,7 +2943,7 @@ export class OpenChat {
         focusThreadMessageIndex?: number,
     ): void {
         withPausedStores(() => {
-            serverThreadEventsStore.set([]);
+            serverThreadEventsStore.set(undefined);
             selectedThreadIdStore.set({
                 chatId,
                 threadRootMessageIndex: threadRootEvent.event.messageIndex,
@@ -3811,7 +3811,13 @@ export class OpenChat {
             );
             return;
         }
-        serverThreadEventsStore.update(fn);
+        serverThreadEventsStore.update((state) => {
+            const existing = state?.threadId === id ? state.events : [];
+            return {
+                threadId: id,
+                events: fn(existing),
+            };
+        });
     }
 
     #updateServerEventsStore(
@@ -3826,7 +3832,13 @@ export class OpenChat {
             );
             return;
         }
-        serverEventsStore.update(fn);
+        serverEventsStore.update((state) => {
+            const existing = state?.chatId === chatId ? state.events : [];
+            return {
+                chatId,
+                events: fn(existing),
+            }
+        });
     }
 
     async #sendMessageWebRtc(

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -2879,19 +2879,9 @@ export class OpenChat {
         // TODO - this might belong as a derivation in the selected chat state
         this.#userLookupForMentions = undefined;
 
-        // clear some chat state
-        withPausedStores(() => {
-            serverEventsStore.set([]);
-            expiredServerEventRanges.set(new DRange());
-            selectedChatUserIdsStore.set(new Set());
-            selectedChatUserGroupKeysStore.set(new Set());
-            selectedChatExpandedDeletedMessageStore.set(new Set());
-            filteredProposalsStore.set(
-                isProposalsChat(clientChat)
-                    ? FilteredProposals.fromStorage(clientChat.subtype.governanceCanisterId)
-                    : undefined,
-            );
-        });
+        if (isProposalsChat(clientChat)) {
+            filteredProposalsStore.set(FilteredProposals.fromStorage(clientChat.subtype.governanceCanisterId));
+        }
 
         const selectedChat = selectedChatSummaryStore.value;
         if (selectedChat !== undefined) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3812,7 +3812,7 @@ export class OpenChat {
             return;
         }
         serverThreadEventsStore.update((state) => {
-            const existing = state?.threadId === id ? state.events : [];
+            const existing = messageContextsEqual(state?.threadId, id) ? state.events : [];
             return {
                 threadId: id,
                 events: fn(existing),
@@ -3833,7 +3833,7 @@ export class OpenChat {
             return;
         }
         serverEventsStore.update((state) => {
-            const existing = state?.chatId === chatId ? state.events : [];
+            const existing = chatIdentifiersEqual(state?.chatId, chatId) ? state.events : [];
             return {
                 chatId,
                 events: fn(existing),

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -2527,7 +2527,7 @@ export class OpenChat {
         if (!isSuccessfulEventsResponse(resp)) return false;
 
         if (!keepCurrentEvents) {
-            serverEventsStore.set(undefined);
+            serverEventsStore.set([]);
         }
 
         await this.#updateUserStoreFromEvents(resp.events);
@@ -2881,7 +2881,7 @@ export class OpenChat {
 
         // clear some chat state
         withPausedStores(() => {
-            serverEventsStore.set(undefined);
+            serverEventsStore.set([]);
             expiredServerEventRanges.set(new DRange());
             selectedChatUserIdsStore.set(new Set());
             selectedChatUserGroupKeysStore.set(new Set());
@@ -2943,7 +2943,7 @@ export class OpenChat {
         focusThreadMessageIndex?: number,
     ): void {
         withPausedStores(() => {
-            serverThreadEventsStore.set(undefined);
+            serverThreadEventsStore.set([]);
             selectedThreadIdStore.set({
                 chatId,
                 threadRootMessageIndex: threadRootEvent.event.messageIndex,
@@ -3820,13 +3820,7 @@ export class OpenChat {
             );
             return;
         }
-        serverThreadEventsStore.update((state) => {
-            const existing = state && messageContextsEqual(state.threadId, id) ? state.events : [];
-            return {
-                threadId: id,
-                events: fn(existing),
-            };
-        });
+        serverThreadEventsStore.update(fn);
     }
 
     #updateServerEventsStore(
@@ -3841,13 +3835,7 @@ export class OpenChat {
             );
             return;
         }
-        serverEventsStore.update((state) => {
-            const existing = state && chatIdentifiersEqual(state.chatId, chatId) ? state.events : [];
-            return {
-                chatId,
-                events: fn(existing),
-            }
-        });
+        serverEventsStore.update(fn);
     }
 
     async #sendMessageWebRtc(

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -78,7 +78,7 @@ const mockContext: PageJS.Context = {
 };
 
 function setSelectedChat() {
-    serverEventsStore.set([]);
+    serverEventsStore.set(undefined);
     expiredServerEventRanges.set(new DRange());
     selectedChatUserIdsStore.set(new Set());
     selectedChatUserGroupKeysStore.set(new Set());
@@ -182,7 +182,10 @@ describe("app state", () => {
                 ),
             );
             serverEventsStore.update(() => {
-                return [chatMessage()];
+                return {
+                    chatId,
+                    events: [chatMessage()],
+                };
             });
         }
 
@@ -359,14 +362,14 @@ describe("app state", () => {
 
             test("server events are returned when there are no updates", () => {
                 const client = get(eventsStore)[0];
-                const server = get(serverEventsStore)[0];
+                const server = get(serverEventsStore)?.events[0];
                 expect(client === server).toBe(true);
             });
 
             test("server object should not be mutated if there are updates", () => {
                 addToWritableMap(123456n, "whatever", translationsStore);
                 const client = get(eventsStore)[0];
-                const server = get(serverEventsStore)[0];
+                const server = get(serverEventsStore)?.events[0];
                 expect(client === server).toBe(false);
                 expect(
                     client.event.kind === "message" &&

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -78,7 +78,7 @@ const mockContext: PageJS.Context = {
 };
 
 function setSelectedChat() {
-    serverEventsStore.set(undefined);
+    serverEventsStore.set([]);
     expiredServerEventRanges.set(new DRange());
     selectedChatUserIdsStore.set(new Set());
     selectedChatUserGroupKeysStore.set(new Set());
@@ -182,10 +182,7 @@ describe("app state", () => {
                 ),
             );
             serverEventsStore.update(() => {
-                return {
-                    chatId,
-                    events: [chatMessage()],
-                };
+                return [chatMessage()];
             });
         }
 
@@ -362,14 +359,14 @@ describe("app state", () => {
 
             test("server events are returned when there are no updates", () => {
                 const client = get(eventsStore)[0];
-                const server = get(serverEventsStore)?.events[0];
+                const server = get(serverEventsStore)[0];
                 expect(client === server).toBe(true);
             });
 
             test("server object should not be mutated if there are updates", () => {
                 addToWritableMap(123456n, "whatever", translationsStore);
                 const client = get(eventsStore)[0];
-                const server = get(serverEventsStore)?.events[0];
+                const server = get(serverEventsStore)[0];
                 expect(client === server).toBe(false);
                 expect(
                     client.event.kind === "message" &&

--- a/frontend/openchat-client/src/state/app/stores.ts
+++ b/frontend/openchat-client/src/state/app/stores.ts
@@ -567,11 +567,13 @@ export const serverEventsStore = writable<EventWrapper<ChatEvent>[]>([], undefin
 export const serverThreadEventsStore = writable<EventWrapper<ChatEvent>[]>([], undefined, eqIfEmpty);
 export const expiredServerEventRanges = writable<DRange>(new DRange(), undefined, eqIfEmpty);
 
+// Whenever the selectedChatIdStore value changes we immediately clear the server events and the selected thread
 selectedChatIdStore.subscribe(_ => {
     serverEventsStore.set([]);
     expiredServerEventRanges.set(new DRange());
     selectedThreadIdStore.set(undefined);
 });
+// Whenever the selectedThreadIdStore value changes we immediately clear the serverThreadEventsStore
 selectedThreadIdStore.subscribe(_ => serverThreadEventsStore.set([]));
 
 export const chatListScopeStore = derived(routeStore, (route) => route.scope, dequal);

--- a/frontend/openchat-client/src/state/utils.ts
+++ b/frontend/openchat-client/src/state/utils.ts
@@ -8,6 +8,10 @@ export const notEq = (_a: unknown, _b: unknown) => false;
 export function eqIfEmpty<T extends { length: number }>(a: T, b: T): boolean {
     return a.length === 0 && b.length === 0;
 }
+export function eqIfUndefined<T>(a: T | undefined, b: T | undefined): boolean {
+    return a === undefined && b === undefined;
+}
+
 type UndoTimeout = number | "never";
 
 export function modifyWritable<T>(

--- a/frontend/openchat-client/src/state/utils.ts
+++ b/frontend/openchat-client/src/state/utils.ts
@@ -5,6 +5,9 @@ import type { LocalSet } from "./set";
 import { scheduleUndo, type UndoLocalUpdate } from "./undo";
 
 export const notEq = (_a: unknown, _b: unknown) => false;
+export function eqIfEmpty<T extends { length: number }>(a: T, b: T): boolean {
+    return a.length === 0 && b.length === 0;
+}
 type UndoTimeout = number | "never";
 
 export function modifyWritable<T>(


### PR DESCRIPTION
After selecting a new chat the route changes, this causes the `selectedChatId` to update, which then triggers the `eventsStore` to be recalculated but the `serverEventsStore` is still holding events for the previous chat.
The `serverEventsStore` then gets updated and the `eventsStore` is calculated again.

As of this PR, we clear the server events store immediately after the selected chat changes, before the events store is recalculated.