### PR TITLE
Skip recalculating community details derived stores if no updates

### DIFF
--- a/frontend/openchat-agent/src/services/community/mappersV2.ts
+++ b/frontend/openchat-agent/src/services/community/mappersV2.ts
@@ -357,6 +357,7 @@ export function communityDetailsResponse(
     if (typeof value === "object" && "Success" in value) {
         console.log("Community details: ", value.Success);
         return {
+            kind: "success",
             members: value.Success.members
                 .map((m) => ({
                     role: memberRole(m.role),
@@ -382,7 +383,7 @@ export function communityDetailsResponse(
         };
     } else {
         console.warn("CommunityDetails failed with", value);
-        return "failure";
+        return { kind: "failure" };
     }
 }
 

--- a/frontend/openchat-agent/src/utils/caching.ts
+++ b/frontend/openchat-agent/src/utils/caching.ts
@@ -55,7 +55,7 @@ import {
     updateCreatedUser,
 } from "openchat-shared";
 
-const CACHE_VERSION = 138;
+const CACHE_VERSION = 139;
 const EARLIEST_SUPPORTED_MIGRATION = 138;
 const MAX_INDEX = 9999999999;
 
@@ -177,28 +177,28 @@ type MigrationFunction<T> = (
 //     db.createObjectStore("activityFeed");
 // }
 //
-async function clearChatsStore(
-    _db: IDBPDatabase<ChatSchema>,
-    _principal: Principal,
-    tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
-) {
-    await tx.objectStore("chats").clear();
-}
-async function clearChatEventsStore(
-    _db: IDBPDatabase<ChatSchema>,
-    _principal: Principal,
-    tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
-) {
-    await tx.objectStore("chat_events").clear();
-}
-
-async function clearGroupDetailsStore(
-    _db: IDBPDatabase<ChatSchema>,
-    _principal: Principal,
-    tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
-) {
-    await tx.objectStore("group_details").clear();
-}
+// async function clearChatsStore(
+//     _db: IDBPDatabase<ChatSchema>,
+//     _principal: Principal,
+//     tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
+// ) {
+//     await tx.objectStore("chats").clear();
+// }
+// async function clearChatEventsStore(
+//     _db: IDBPDatabase<ChatSchema>,
+//     _principal: Principal,
+//     tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
+// ) {
+//     await tx.objectStore("chat_events").clear();
+// }
+//
+// async function clearGroupDetailsStore(
+//     _db: IDBPDatabase<ChatSchema>,
+//     _principal: Principal,
+//     tx: IDBPTransaction<ChatSchema, StoreNames<ChatSchema>[], "versionchange">,
+// ) {
+//     await tx.objectStore("group_details").clear();
+// }
 
 async function clearCommunityDetailsStore(
     _db: IDBPDatabase<ChatSchema>,
@@ -242,14 +242,7 @@ async function clearCommunityDetailsStore(
 // }
 
 const migrations: Record<number, MigrationFunction<ChatSchema>> = {
-    126: clearChatsStore,
-    127: clearChatsStore,
-    128: clearCommunityDetailsStore,
-    129: clearChatsStore,
-    130: clearChatsStore,
-    131: clearChatEventsStore,
-    132: clearGroupDetailsStore,
-    133: clearChatsStore,
+    139: clearCommunityDetailsStore,
 };
 
 async function migrate(

--- a/frontend/openchat-agent/src/utils/chat.ts
+++ b/frontend/openchat-agent/src/utils/chat.ts
@@ -75,6 +75,7 @@ export function mergeCommunityDetails(
     updates: CommunityDetailsUpdates,
 ): CommunityDetails {
     return {
+        kind: "success",
         lastUpdated: updates.lastUpdated,
         members: mergeThings((p) => p.userId, mergeParticipants, previous.members, {
             added: [],

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3308,8 +3308,8 @@ export class OpenChat {
             kind: "getCommunityDetails",
             id,
             communityLastUpdated: community.lastUpdated,
-        }).catch(() => "failure");
-        if (resp !== "failure") {
+        }).catch(() => ({ kind: "failure" }));
+        if (resp.kind !== "failure") {
             if (!communityIdentifiersEqual(community.id, selectedCommunityIdStore.value)) {
                 console.warn(
                     "Attempting to set community details on the wrong community - probably a stale response",
@@ -3328,23 +3328,32 @@ export class OpenChat {
                 return;
             }
 
-            const [lapsed, members] = partition(resp.members, (m) => m.lapsed);
+            if (resp.kind === "success_no_updates") {
+                selectedServerCommunityStore.update((state) => {
+                    if (state) {
+                        state.timestamp = resp.lastUpdated;
+                    }
+                    return state;
+                });
+            } else {
+                const [lapsed, members] = partition(resp.members, (m) => m.lapsed);
 
-            selectedServerCommunityStore.set(
-                new CommunityDetailsState(
-                    community.id,
-                    resp.lastUpdated,
-                    resp.userGroups,
-                    new Map(members.map((m) => [m.userId, m])),
-                    resp.blockedUsers,
-                    new Set(lapsed.map((m) => m.userId)),
-                    resp.invitedUsers,
-                    resp.referrals,
-                    resp.bots.reduce((all, b) => all.set(b.id, b.permissions), new Map()),
-                    resp.rules,
-                ),
-            );
-            this.#updateUserStoreFromCommunityState();
+                selectedServerCommunityStore.set(
+                    new CommunityDetailsState(
+                        community.id,
+                        resp.lastUpdated,
+                        resp.userGroups,
+                        new Map(members.map((m) => [m.userId, m])),
+                        resp.blockedUsers,
+                        new Set(lapsed.map((m) => m.userId)),
+                        resp.invitedUsers,
+                        resp.referrals,
+                        resp.bots.reduce((all, b) => all.set(b.id, b.permissions), new Map()),
+                        resp.rules,
+                    ),
+                );
+                this.#updateUserStoreFromCommunityState();
+            }
         }
     }
 

--- a/frontend/openchat-client/src/state/app/stores.ts
+++ b/frontend/openchat-client/src/state/app/stores.ts
@@ -593,7 +593,7 @@ export const selectedCommunityUserGroupsStore = derived(
         if (updates === undefined) return community.userGroups;
         return updates.apply(community.userGroups);
     },
-    mapsEqualIfEmpty,
+    dequal,
 );
 export const selectedCommunityInvitedUsersStore = derived(
     [selectedServerCommunityStore, communityLocalUpdates.invitedUsers],
@@ -658,7 +658,7 @@ export const selectedChatBlockedUsersStore = derived(
         if (chat === undefined) return new Set() as ReadonlySet<string>;
         return blockedUsers.get(chat.chatId)?.apply(chat.blockedUsers) ?? chat.blockedUsers;
     },
-    setsEqualIfEmpty,
+    setsAreEqual,
 );
 export const selectedChatLapsedMembersStore = derived(selectedServerChatStore, (chat) => {
     return chat?.lapsedMembers ?? (new Set() as ReadonlySet<string>);

--- a/frontend/openchat-shared/src/domain/community/index.ts
+++ b/frontend/openchat-shared/src/domain/community/index.ts
@@ -218,7 +218,7 @@ export type ChannelMatch = {
     public: boolean;
 };
 
-export type CommunityDetailsResponse = "failure" | CommunityDetails;
+export type CommunityDetailsResponse = CommunityDetails | { kind: "success_no_updates", lastUpdated: bigint } | Failure;
 
 export type CommunityDetailsUpdatesResponse =
     | ({
@@ -231,6 +231,7 @@ export type CommunityDetailsUpdatesResponse =
     | Failure;
 
 export type CommunityDetails = {
+    kind: "success";
     members: Member[];
     blockedUsers: Set<string>;
     invitedUsers: Set<string>;


### PR DESCRIPTION
Prior to this PR, every time a community was updated (eg. after a message is sent in any channel), the community details store would be overwritten (members, invited, blocked, etc). This would cause all derived stores to be recalculated.
As of this PR, if the community details are unchanged, only the timestamp will be updated, so no downstream derived stores will be recalculated.