### PR TITLE
fix localMap and localSet

### DIFF
--- a/frontend/openchat-client/src/state/map.spec.ts
+++ b/frontend/openchat-client/src/state/map.spec.ts
@@ -40,6 +40,19 @@ describe("LocalMap", () => {
         map = new TestLocalMap();
     });
 
+    test("make sure that the order of operations doesn't cause a problem", () => {
+        // perform two operations
+        const removeUndo = map.remove("123");
+        const addUndo = map.addOrUpdate("123", "456");
+
+        // undo them both
+        removeUndo();
+        addUndo();
+
+        expect(map.addedOrUpdated("123")).toBe(false);
+        expect(map.removed("123")).toBe(false);
+    });
+
     it("make sure manual undo works", () => {
         const undo = map.addOrUpdate("a", "b");
         expect(map.addedOrUpdated("a")).toBe(true);
@@ -54,7 +67,7 @@ describe("LocalMap", () => {
         const undo = map.addOrUpdate("a", "b");
 
         expect(map.addedOrUpdated("a")).toBe(true);
-        expect(map.removed("a")).toBe(false);
+        expect(map.removed("a")).toBe(true);
 
         undo();
 

--- a/frontend/openchat-client/src/state/set.spec.ts
+++ b/frontend/openchat-client/src/state/set.spec.ts
@@ -23,6 +23,54 @@ describe("LocalSet", () => {
         set = new LocalSet(identity);
     });
 
+    test("make sure that the order of operations doesn't cause a problem", () => {
+        // perform two operations
+        const removeUndo = set.remove("123");
+        const addUndo = set.add("123");
+
+        // undo them both
+        removeUndo();
+        addUndo();
+
+        expect(set.added.has("123")).toBe(false);
+        expect(set.removed.has("123")).toBe(false);
+    });
+
+    test("remove trumps add", () => {
+        set.add("123");
+        set.remove("123");
+        set.add("123");
+        set.remove("123");
+
+        const original = new Set<string>();
+        const result = set.apply(original);
+        expect(result.has("123")).toBe(false);
+    });
+
+    test("last mod wins", () => {
+        set.add("123");
+        set.remove("123");
+        set.remove("123");
+        set.add("123");
+
+        const original = new Set<string>();
+        const result = set.apply(original);
+        expect(result.has("123")).toBe(true);
+    });
+
+    test("multiple undos", () => {
+        set.add("123");
+        const u1 = set.remove("123");
+        const u2 = set.remove("123");
+
+        u1();
+        u2();
+
+        const original = new Set<string>();
+        const result = set.apply(original);
+        expect(result.has("123")).toBe(true);
+    });
+
     it("make sure manual undo works", () => {
         const undo = set.add("a");
         expect(set.added.has("a")).toBe(true);
@@ -37,7 +85,7 @@ describe("LocalSet", () => {
         const undo = set.add("a");
 
         expect(set.added.has("a")).toBe(true);
-        expect(set.removed.has("a")).toBe(false);
+        expect(set.removed.has("a")).toBe(true);
 
         undo();
 

--- a/frontend/openchat-client/src/state/set.ts
+++ b/frontend/openchat-client/src/state/set.ts
@@ -1,62 +1,61 @@
 import { SafeSet, type ChatIdentifier, type Primitive, type ReadonlySet } from "openchat-shared";
 import { type UndoLocalUpdate } from "./undo";
 
+type Add<V> = { kind: "add"; value: V };
+type Remove<V> = { kind: "remove"; value: V };
+type Modification<V> = Add<V> | Remove<V>;
+
 export class LocalSet<T> {
-    #added: SafeSet<T>;
-    #removed: SafeSet<T>;
+    #queue: Modification<T>[] = [];
 
     constructor(
         private serialiser?: (x: T) => Primitive,
         private deserialiser?: (x: Primitive) => T,
-    ) {
-        this.#added = new SafeSet(serialiser, deserialiser);
-        this.#removed = new SafeSet(serialiser, deserialiser);
-    }
+    ) {}
 
     get added(): ReadonlySet<T> {
-        return this.#added;
+        return new Set(this.#queue.filter((m) => m.kind === "add").map((m) => m.value));
     }
 
     get removed(): ReadonlySet<T> {
-        return this.#removed;
+        return new Set(this.#queue.filter((m) => m.kind === "remove").map((m) => m.value));
     }
 
     // only use for testing
     clear() {
-        this.#added.clear();
-        this.#removed.clear();
+        this.#queue = [];
     }
 
     add(thing: T): UndoLocalUpdate {
-        this.#added.add(thing);
-        const removed = this.#removed.delete(thing);
+        const add: Add<T> = { kind: "add", value: thing };
+        this.#queue.push(add);
         return () => {
-            this.#added.delete(thing);
-            if (removed) {
-                this.#removed.add(thing);
-            }
+            this.#queue = this.#queue.filter((m) => m !== add);
         };
     }
 
     remove(thing: T) {
-        this.#removed.add(thing);
-        const removed = this.#added.delete(thing);
+        const remove: Remove<T> = { kind: "remove", value: thing };
+        this.#queue.push(remove);
         return () => {
-            this.#removed.delete(thing);
-            if (removed) {
-                this.#added.add(thing);
-            }
+            this.#queue = this.#queue.filter((m) => m !== remove);
         };
     }
 
     apply(original: ReadonlySet<T>): ReadonlySet<T> {
-        if (this.#added.size === 0 && this.#removed.size === 0) return original;
+        if (this.#queue.length === 0) return original;
         const merged = new SafeSet<T>(this.serialiser, this.deserialiser);
         for (const v of original) {
             merged.add(v);
         }
-        this.#added.forEach((t) => merged.add(t));
-        this.#removed.forEach((t) => merged.delete(t));
+        for (const mod of this.#queue) {
+            if (mod.kind === "remove") {
+                merged.delete(mod.value);
+            }
+            if (mod.kind === "add") {
+                merged.add(mod.value);
+            }
+        }
         return merged;
     }
 }


### PR DESCRIPTION
The order of local updates matters so we now store the updates as a queue so that they behave like a mini event store and do not interfere with each other. 

fixes #8178 