### PR TITLE
Avoid marking chat as active if only proposal tally has been updated

### DIFF
--- a/backend/canisters/community/impl/src/updates/c2c_update_proposals.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_update_proposals.rs
@@ -23,11 +23,12 @@ fn c2c_update_proposals_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         return Err(OCErrorCode::InitiatorNotInChat.into());
     }
 
-    channel
+    if channel
         .chat
         .events
-        .update_proposals(member.user_id, args.proposals, state.env.now());
-
-    handle_activity_notification(state);
+        .update_proposals(member.user_id, args.proposals, state.env.now())
+    {
+        handle_activity_notification(state);
+    }
     Ok(())
 }

--- a/backend/canisters/group/impl/src/updates/c2c_update_proposals.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_update_proposals.rs
@@ -15,7 +15,8 @@ fn c2c_update_proposals_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     let user_id = state.get_caller_user_id()?;
     let now = state.env.now();
 
-    state.data.chat.events.update_proposals(user_id, args.proposals, now);
-    handle_activity_notification(state);
+    if state.data.chat.events.update_proposals(user_id, args.proposals, now) {
+        handle_activity_notification(state);
+    }
     Ok(())
 }

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Avoid marking chat as active if only proposal tally has been updated ([#8206](https://github.com/open-chat-labs/open-chat/pull/8206))
+
 ## [[2.0.1743](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1743-proposals_bot)] - 2025-05-12
 
 ### Changed

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -22,7 +22,7 @@ use types::{
     EventWrapperInternal, EventsTimeToLiveUpdated, GroupCanisterThreadDetails, GroupCreated, GroupFrozen, GroupUnfrozen,
     HydratedMention, Mention, Message, MessageEditedEventPayload, MessageEventPayload, MessageId, MessageIndex, MessageMatch,
     MessageTippedEventPayload, Milliseconds, MultiUserChat, OCResult, OptionUpdate, P2PSwapAccepted, P2PSwapCompleted,
-    P2PSwapCompletedEventPayload, P2PSwapContent, P2PSwapStatus, PendingCryptoTransaction, PollVotes, ProposalDecisionStatus,
+    P2PSwapCompletedEventPayload, P2PSwapContent, P2PSwapStatus, PendingCryptoTransaction, PollVotes, ProposalRewardStatus,
     ProposalUpdate, Reaction, ReactionAddedEventPayload, RegisterVoteResult, ReserveP2PSwapSuccess, SenderContext, Tally,
     TimestampMillis, TimestampNanos, Timestamped, Tips, UserId, VideoCall, VideoCallEndedEventPayload, VideoCallParticipants,
     VideoCallPresence, VideoCallType, VoteOperation,
@@ -757,7 +757,7 @@ impl ChatEvents {
                 ChatEventType::MessageOther,
                 |message, _| Self::update_proposal_inner(message, user_id, update, now),
             ) {
-                if !matches!(success.value, ProposalDecisionStatus::Open) {
+                if !matches!(success.value, ProposalRewardStatus::AcceptVotes) {
                     self.in_progress_proposal_tallies.remove(&success.event_index);
                 } else if let Some(tally) = tally_update {
                     self.in_progress_proposal_tallies.insert(success.event_index, tally);
@@ -775,11 +775,11 @@ impl ChatEvents {
         user_id: UserId,
         update: ProposalUpdate,
         now: TimestampMillis,
-    ) -> Result<ProposalDecisionStatus, UpdateEventError> {
+    ) -> Result<ProposalRewardStatus, UpdateEventError> {
         if message.sender == user_id {
             if let MessageContentInternal::GovernanceProposal(p) = &mut message.content {
                 p.proposal.update_status(update.into(), now);
-                return Ok(p.proposal.status());
+                return Ok(p.proposal.reward_status());
             }
         }
         Err(UpdateEventError::NotFound)

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -742,7 +742,8 @@ impl ChatEvents {
         }
     }
 
-    pub fn update_proposals(&mut self, user_id: UserId, updates: Vec<ProposalUpdate>, now: TimestampMillis) {
+    pub fn update_proposals(&mut self, user_id: UserId, updates: Vec<ProposalUpdate>, now: TimestampMillis) -> bool {
+        let mut mark_chat_updated = false;
         for update in updates {
             // If only the tally has been updated, skip marking the message as having been updated
             let should_mark_updated = update.deadline.is_some() || update.reward_status.is_some() || update.status.is_some();
@@ -761,8 +762,12 @@ impl ChatEvents {
                 } else if let Some(tally) = tally_update {
                     self.in_progress_proposal_tallies.insert(success.event_index, tally);
                 }
+                if should_mark_updated {
+                    mark_chat_updated = true;
+                }
             }
         }
+        mark_chat_updated
     }
 
     fn update_proposal_inner(


### PR DESCRIPTION
This isn't needed because we now poll for proposal updates whenever a proposal chat is selected.