### PR TITLE
Simplify how we create new messages

### DIFF
--- a/frontend/app/src/components/home/ChatEvent.svelte
+++ b/frontend/app/src/components/home/ChatEvent.svelte
@@ -140,15 +140,25 @@
     }
 
     function deleteFailedMessage() {
-        client.deleteFailedMessage(
-            chatId,
-            event as EventWrapper<Message>,
-            threadRootMessage?.messageIndex,
-        );
+        if (event.event.kind === "message") {
+            client.deleteFailedMessage(
+                chatId,
+                event.event.messageId,
+                threadRootMessage?.messageIndex,
+            );
+        }
     }
 
     function retrySend() {
-        client.retrySendMessage(messageContext, event as EventWrapper<Message>);
+        const message = event as EventWrapper<Message>;
+        client.sendMessageWithContent(
+            messageContext,
+            message.event.content,
+            message.event.blockLevelMarkdown,
+            [],
+            message.event.forwarded,
+            true
+        );
     }
 
     let sender = $derived(

--- a/frontend/openchat-client/src/state/localUpdates.ts
+++ b/frontend/openchat-client/src/state/localUpdates.ts
@@ -246,19 +246,20 @@ export class GlobalLocalState {
     }
 
     addUnconfirmed(key: MessageContext, message: EventWrapper<Message>): UndoLocalUpdate {
+        const messageId = message.event.messageId;
         return modifyWritableMap(
             key,
             (state) => {
-                if (!state.has(message.event.messageId)) {
-                    state.set(message.event.messageId, { ...message, accepted: false });
+                if (!state.has(messageId)) {
+                    state.set(messageId, { ...message, accepted: false });
                     this.#recentlySentMessages.update((map) => {
-                        map.set(message.event.messageId, message.timestamp);
+                        map.set(messageId, message.timestamp);
                         return map;
                     });
                     return (state) => {
-                        this.#deleteLocalMessage(state, message.event.messageId);
+                        this.#deleteLocalMessage(state, messageId);
                         this.#recentlySentMessages.update((map) => {
-                            map.delete(message.event.messageId);
+                            map.delete(messageId);
                             return map;
                         });
                         return state;

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -35,6 +35,7 @@ import type {
     Metrics,
     MultiUserChat,
     MultiUserChatIdentifier,
+    NewUnconfirmedMessage,
     OptionalChatPermissions,
     OptionalMessagePermissions,
     OptionUpdate,
@@ -42,7 +43,6 @@ import type {
     PollVotes,
     Reaction,
     ReadonlyMap,
-    ReplyContext,
     SendMessageSuccess,
     Tally,
     ThreadIdentifier,
@@ -73,7 +73,6 @@ import {
     OPENCHAT_BOT_USER_ID,
     OPENCHAT_VIDEO_CALL_AVATAR_URL,
     OPENCHAT_VIDEO_CALL_USER_ID,
-    random64,
     ROLE_MEMBER,
     ROLE_NONE,
     ROLE_OWNER,
@@ -81,16 +80,18 @@ import {
     type ReadonlySet,
 } from "openchat-shared";
 import {
+    allServerChatsStore,
     confirmedEventIndexesLoadedStore,
     confirmedThreadEventIndexesLoadedStore,
     cryptoLookup,
     currentUserIdStore,
     currentUserStore,
+    eventsStore,
     localUpdates,
     selectedChatIdStore,
     selectedChatUserIdsStore,
-    selectedServerChatSummaryStore,
     selectedThreadIdStore,
+    threadEventsStore,
 } from "../state";
 import type { LocalTipsReceived, MessageLocalUpdates } from "../state/message/localUpdates";
 import { userStore } from "../state/users/state";
@@ -274,28 +275,27 @@ export function getMembersString(
         : sorted.join();
 }
 
-export function createMessage(
-    userId: string,
-    messageIndex: number,
-    content: MessageContent,
-    blockLevelMarkdown: boolean,
-    replyingTo: ReplyContext | undefined,
-    forwarded: boolean,
-    messageId: bigint = random64(),
-): Message {
+export function createMessage(context: MessageContext, message: NewUnconfirmedMessage): EventWrapper<Message> {
+    const [eventIndex, messageIndex] = nextEventAndMessageIndex(context);
     return {
-        kind: "message",
-        content,
-        sender: userId,
-        repliesTo: replyingTo,
-        messageId,
-        messageIndex,
-        reactions: [],
-        tips: {},
-        edited: false,
-        forwarded,
-        deleted: false,
-        blockLevelMarkdown,
+        event: {
+            kind: "message",
+            messageId: message.messageId,
+            messageIndex,
+            sender: message.sender,
+            content: message.content,
+            repliesTo: message.repliesTo,
+            reactions: [],
+            tips: {},
+            edited: false,
+            forwarded: message.forwarded,
+            deleted: false,
+            blockLevelMarkdown: message.blockLevelMarkdown,
+            senderContext: message.senderContext,
+        },
+        timestamp: message.timestamp,
+        index: eventIndex,
+        expiresAt: message.expiresAt,
     };
 }
 
@@ -405,7 +405,7 @@ export function mergeUnconfirmedIntoSummary(
         // Don't hide the sender's own messages
         const failedMessageFilter =
             latestMessage.event.sender !== currentUserId
-                ? doesMessageFailFilter(latestMessage.event, messageFilters) !== undefined
+                ? doesMessageFailFilter(latestMessage.event.content, messageFilters) !== undefined
                 : false;
 
         if (updates !== undefined || senderBlocked || failedMessageFilter) {
@@ -821,19 +821,16 @@ function sortByTimestampThenEventIndex(
     return Number(a.timestamp - b.timestamp);
 }
 
-export function serialiseMessageForRtc(messageEvent: EventWrapper<Message>): EventWrapper<Message> {
-    if (isAttachmentContent(messageEvent.event.content)) {
+export function serialiseMessageForRtc(message: NewUnconfirmedMessage): NewUnconfirmedMessage {
+    if (isAttachmentContent(message.content)) {
         return {
-            ...messageEvent,
-            event: {
-                ...messageEvent.event,
-                content: {
-                    kind: "placeholder_content",
-                },
+            ...message,
+            content: {
+                kind: "placeholder_content",
             },
         };
     }
-    return messageEvent;
+    return message;
 }
 
 export function groupChatFromCandidate(
@@ -1385,7 +1382,7 @@ export function mergeEventsAndLocalUpdates(
             // Don't hide the sender's own messages
             const failedMessageFilter =
                 e.event.sender !== currentUserIdStore.value
-                    ? doesMessageFailFilter(e.event, messageFilters) !== undefined
+                    ? doesMessageFailFilter(e.event.content, messageFilters) !== undefined
                     : false;
 
             if (
@@ -1446,10 +1443,10 @@ export function mergeEventsAndLocalUpdates(
 }
 
 export function doesMessageFailFilter(
-    message: Message,
+    messageContent: MessageContent,
     filters: MessageFilter[],
 ): bigint | undefined {
-    const text = getContentAsText(message.content);
+    const text = getContentAsText(messageContent);
 
     if (text !== undefined) {
         for (const f of filters) {
@@ -1968,37 +1965,6 @@ function diffMessagePermissions(
     return diff;
 }
 
-export function nextEventAndMessageIndexesForThread(
-    events: EventWrapper<ChatEvent>[],
-): [number, number] {
-    return events.reduce(
-        ([maxEvtIdx, maxMsgIdx], evt) => {
-            const msgIdx =
-                evt.event.kind === "message"
-                    ? Math.max(evt.event.messageIndex + 1, maxMsgIdx)
-                    : maxMsgIdx;
-            const evtIdx = Math.max(evt.index + 1, maxEvtIdx);
-            return [evtIdx, msgIdx];
-        },
-        [0, 0],
-    );
-}
-
-function sortByIndex(a: EventWrapper<ChatEvent>, b: EventWrapper<ChatEvent>): number {
-    return a.index - b.index;
-}
-
-export function nextEventAndMessageIndexes(): [number, number] {
-    const chat = selectedServerChatSummaryStore.value;
-    if (chat === undefined) {
-        return [0, 0];
-    }
-    return getNextEventAndMessageIndexes(
-        chat,
-        localUpdates.unconfirmedMessages({ chatId: chat.id }).sort(sortByIndex),
-    );
-}
-
 export function confirmedEventIndexesLoaded(chatId: ChatIdentifier): DRange {
     const selected = selectedChatIdStore.value;
     return selected !== undefined && chatIdentifiersEqual(selected, chatId)
@@ -2088,4 +2054,83 @@ export function newDefaultChannel(id: ChannelIdentifier, name: string): ChannelS
         messagesVisibleToNonMembers: true,
         externalUrl: undefined,
     }
+}
+
+function nextEventAndMessageIndex(context: MessageContext): [number, number] {
+    const chat = allServerChatsStore.value.get(context.chatId);
+    const unconfirmedMessages = localUpdates.unconfirmedMessages(context);
+
+    let [eventIndex, messageIndex] = [0, 0];
+
+    if (unconfirmedMessages !== undefined) {
+        for (const event of unconfirmedMessages.values()) {
+            if (event.index >= eventIndex) {
+                eventIndex = event.index + 1;
+            }
+            if (event.event.messageIndex >= messageIndex) {
+                messageIndex = event.event.messageIndex + 1;
+            }
+        }
+    }
+
+    let summary: { latestEventIndex: number, latestMessageIndex: number | undefined } | undefined = undefined;
+    let events: EventWrapper<ChatEvent>[] = [];
+    if (chat !== undefined) {
+        if (context.threadRootMessageIndex === undefined) {
+            summary = chat;
+
+            if (chatIdentifiersEqual(context.chatId, selectedChatIdStore.value)) {
+                events = eventsStore.value;
+            }
+        } else {
+            const thread = chat.membership.latestThreads.find((t) =>
+                t.threadRootMessageIndex === context.threadRootMessageIndex);
+
+            if (thread) {
+                summary = thread;
+
+                if (messageContextsEqual(context, selectedThreadIdStore.value)) {
+                    events = threadEventsStore.value;
+                }
+            }
+        }
+    }
+
+    if (summary) {
+        if (summary.latestEventIndex >= eventIndex) {
+            eventIndex = summary.latestEventIndex + 1;
+        }
+        if (summary.latestMessageIndex !== undefined && summary.latestMessageIndex >= messageIndex) {
+            messageIndex = summary.latestMessageIndex + 1;
+        }
+    }
+
+    const [eventIndexFromEvents, messageIndexFromEvents] = latestEventAndMessageIndexesFromEvents(events);
+
+    if (eventIndexFromEvents !== undefined && eventIndexFromEvents >= eventIndex) {
+        eventIndex = eventIndexFromEvents + 1;
+    }
+    if (messageIndexFromEvents !== undefined && messageIndexFromEvents >= messageIndex) {
+        messageIndex = messageIndexFromEvents + 1;
+    }
+
+    return [eventIndex, messageIndex];
+}
+
+function latestEventAndMessageIndexesFromEvents(events: EventWrapper<ChatEvent>[]): [number | undefined, number | undefined] {
+    let eventIndex: number | undefined = undefined;
+    let messageIndex: number | undefined = undefined;
+
+    for (let i = events.length - 1; i >= 0; i--) {
+        const event = events[i];
+        if (eventIndex === undefined) {
+            eventIndex = event.index;
+        }
+        if (event.event.kind === "message") {
+            messageIndex = event.event.messageIndex;
+            break;
+        }
+    }
+
+    return [eventIndex, messageIndex];
 }

--- a/frontend/openchat-client/src/utils/rtc.ts
+++ b/frontend/openchat-client/src/utils/rtc.ts
@@ -134,23 +134,20 @@ export function parseWebRtcMessage(chatId: ChatIdentifier, msg: WebRtcMessage): 
         };
     }
     if (msg.kind === "remote_user_sent_message") {
-        msg.messageEvent.event.content = hydrateBigIntsInContent(msg.messageEvent.event.content);
-        if (msg.messageEvent.event.repliesTo?.kind === "rehydrated_reply_context") {
-            msg.messageEvent.event.repliesTo = {
-                ...msg.messageEvent.event.repliesTo,
-                messageId: toBigInt64(msg.messageEvent.event.messageId),
-                content: hydrateBigIntsInContent(msg.messageEvent.event.repliesTo.content),
+        msg.message.content = hydrateBigIntsInContent(msg.message.content);
+        if (msg.message.repliesTo?.kind === "rehydrated_reply_context") {
+            msg.message.repliesTo = {
+                ...msg.message.repliesTo,
+                messageId: toBigInt64(msg.message.repliesTo.messageId),
+                content: hydrateBigIntsInContent(msg.message.repliesTo.content),
             };
         }
         return {
             ...msg,
             id: chatId,
-            messageEvent: {
-                ...msg.messageEvent,
-                event: {
-                    ...msg.messageEvent.event,
-                    messageId: toBigInt64(msg.messageEvent.event.messageId),
-                },
+            message: {
+                ...msg.message,
+                messageId: toBigInt64(msg.message.messageId),
                 timestamp: BigInt(Date.now()),
             },
         };

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -2361,6 +2361,18 @@ export type UnconfirmedMessageEvent = EventWrapper<Message> & { accepted: boolea
 
 export type UnconfirmedState = Map<bigint, UnconfirmedMessageEvent>;
 
+export type NewUnconfirmedMessage = {
+    timestamp: bigint;
+    expiresAt?: number;
+    messageId: bigint;
+    sender: string;
+    content: MessageContent;
+    repliesTo?: ReplyContext;
+    forwarded: boolean;
+    blockLevelMarkdown: boolean;
+    senderContext?: SenderContext;
+};
+
 export type VideoCallInProgress = {
     started: bigint;
     startedBy: string;

--- a/frontend/openchat-shared/src/domain/webrtc/webrtc.ts
+++ b/frontend/openchat-shared/src/domain/webrtc/webrtc.ts
@@ -1,4 +1,4 @@
-import type { ChatIdentifier, EventWrapper, Message, VideoCallType } from "../chat/chat";
+import type { ChatIdentifier, NewUnconfirmedMessage, VideoCallType } from "../chat/chat";
 
 export type WebRtcMessage =
     | RemoteUserStoppedTyping
@@ -74,5 +74,5 @@ export type RemoteUserReadMessage = WebRtcMessageCommon & {
 
 export type RemoteUserSentMessage = WebRtcMessageCommon & {
     kind: "remote_user_sent_message";
-    messageEvent: EventWrapper<Message>;
+    message: NewUnconfirmedMessage;
 };


### PR DESCRIPTION
The new version of `createMessage` now assigns the event index and message index, so the callers no longer have to.