### PR TITLE
Use all events rather than only server events in contiguous check

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -319,7 +319,7 @@ import {
     chitStateStore,
     communitiesStore,
     communityFiltersStore,
-    confirmedThreadEventIndexesLoadedStore,
+    threadEventIndexesLoadedStore,
     cryptoBalanceStore,
     cryptoLookup,
     currentUserIdStore,
@@ -465,7 +465,7 @@ import {
     canSendGroupMessage,
     canStartVideoCalls,
     canUnblockUsers,
-    confirmedEventIndexesLoaded,
+    eventIndexesLoaded,
     containsReaction,
     createMessage,
     diffGroupPermissions,
@@ -3218,7 +3218,7 @@ export class OpenChat {
     }
 
     #earliestLoadedIndex(chatId: ChatIdentifier): number | undefined {
-        const confirmedLoaded = confirmedEventIndexesLoaded(chatId);
+        const confirmedLoaded = eventIndexesLoaded(chatId);
         return confirmedLoaded.length > 0 ? confirmedLoaded.index(0) : undefined;
     }
 
@@ -3472,8 +3472,8 @@ export class OpenChat {
         serverChat: ChatSummary,
         updatedEvents: UpdatedEvent[],
     ): Promise<void> {
-        const confirmedLoaded = confirmedEventIndexesLoaded(serverChat.id);
-        const confirmedThreadLoaded = confirmedThreadEventIndexesLoadedStore.value;
+        const confirmedLoaded = eventIndexesLoaded(serverChat.id);
+        const confirmedThreadLoaded = threadEventIndexesLoadedStore.value;
         const selectedThreadRootMessageIndex = selectedThreadIdStore.value?.threadRootMessageIndex;
 
         // Partition the updated events into those that belong to the currently selected thread and those that don't
@@ -3581,7 +3581,7 @@ export class OpenChat {
     }
 
     #confirmedUpToEventIndex(chatId: ChatIdentifier): number | undefined {
-        const ranges = confirmedEventIndexesLoaded(chatId).subranges();
+        const ranges = eventIndexesLoaded(chatId).subranges();
         if (ranges.length > 0) {
             return ranges[0].high;
         }
@@ -3589,7 +3589,7 @@ export class OpenChat {
     }
 
     #confirmedThreadUpToEventIndex(): number | undefined {
-        const ranges = confirmedThreadEventIndexesLoadedStore.value.subranges();
+        const ranges = threadEventIndexesLoadedStore.value.subranges();
         if (ranges.length > 0) {
             return ranges[0].high;
         }
@@ -4529,7 +4529,7 @@ export class OpenChat {
         messageEvent: EventWrapper<Message>,
         threadRootMessageIndex: number | undefined,
     ) {
-        const confirmedLoaded = confirmedEventIndexesLoaded(serverChat.id);
+        const confirmedLoaded = eventIndexesLoaded(serverChat.id);
 
         if (indexIsInRanges(messageEvent.index, confirmedLoaded)) {
             // We already have this confirmed message

--- a/frontend/openchat-client/src/state/app/stores.ts
+++ b/frontend/openchat-client/src/state/app/stores.ts
@@ -1190,8 +1190,8 @@ export const eventsStore = derived(
     },
 );
 
-export const confirmedEventIndexesLoadedStore = derived(
-    [serverEventsStore, expiredServerEventRanges],
+export const eventIndexesLoadedStore = derived(
+    [eventsStore, expiredServerEventRanges],
     ([events, expiredEventRanges]) => {
         const ranges = new DRange();
         events.forEach((e) => ranges.add(e.index));
@@ -1300,7 +1300,7 @@ export const threadEventsStore = derived(
     },
 );
 
-export const confirmedThreadEventIndexesLoadedStore = derived(serverThreadEventsStore, (events) => {
+export const threadEventIndexesLoadedStore = derived(threadEventsStore, (events) => {
     const ranges = new DRange();
     events.forEach((e) => ranges.add(e.index));
     return ranges;

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -81,8 +81,8 @@ import {
 } from "openchat-shared";
 import {
     allServerChatsStore,
-    confirmedEventIndexesLoadedStore,
-    confirmedThreadEventIndexesLoadedStore,
+    eventIndexesLoadedStore,
+    threadEventIndexesLoadedStore,
     cryptoLookup,
     currentUserIdStore,
     currentUserStore,
@@ -1965,10 +1965,10 @@ function diffMessagePermissions(
     return diff;
 }
 
-export function confirmedEventIndexesLoaded(chatId: ChatIdentifier): DRange {
+export function eventIndexesLoaded(chatId: ChatIdentifier): DRange {
     const selected = selectedChatIdStore.value;
     return selected !== undefined && chatIdentifiersEqual(selected, chatId)
-        ? confirmedEventIndexesLoadedStore.value
+        ? eventIndexesLoadedStore.value
         : new DRange();
 }
 
@@ -2004,7 +2004,7 @@ export function isContiguousInThread(
 ): boolean {
     return (
         messageContextsEqual(threadId, selectedThreadIdStore.value) &&
-        isContiguousInternal(confirmedThreadEventIndexesLoadedStore.value, events, [])
+        isContiguousInternal(threadEventIndexesLoadedStore.value, events, [])
     );
 }
 
@@ -2015,7 +2015,7 @@ export function isContiguous(
 ): boolean {
     return (
         chatIdentifiersEqual(chatId, selectedChatIdStore.value) &&
-        isContiguousInternal(confirmedEventIndexesLoaded(chatId), events, expiredEventRanges)
+        isContiguousInternal(eventIndexesLoaded(chatId), events, expiredEventRanges)
     );
 }
 


### PR DESCRIPTION
This fixes the case where the latest few unconfirmed messages will temporarily disappear if they happen to be confirmed out of order