### PR TITLE
Restructured native notification data on the backend

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set `explicit_join` to false if joining channel via joining community ([#8256](https://github.com/open-chat-labs/open-chat/pull/8256))
 - Push community events to subscribed bots ([#8259](https://github.com/open-chat-labs/open-chat/pull/8259))
 - Remove almost all usages of `Candid` from Community canisters ([#8267](https://github.com/open-chat-labs/open-chat/pull/8267))
+- Updated the `FcmData` interface ([8261](https://github.com/open-chat-labs/open-chat/pull/8261))
 
 ### Fixed
 

--- a/backend/canisters/community/impl/src/lib.rs
+++ b/backend/canisters/community/impl/src/lib.rs
@@ -135,7 +135,7 @@ impl RuntimeState {
                 sender,
                 recipients,
                 notification_bytes: ByteBuf::from(serialize_then_unwrap(notification)),
-                fcm_data,
+                fcm_data: Some(fcm_data),
             });
             self.push_notification_inner(notification);
         }

--- a/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
+++ b/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
@@ -4,6 +4,7 @@ use crate::{
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use community_canister::add_members_to_channel::{Response::*, *};
+use futures::channel;
 use oc_error_codes::OCErrorCode;
 use types::{AddedToChannelNotification, ChannelId, CommunityId, FcmData, OCResult, UserId, UserNotificationPayload, UserType};
 
@@ -111,12 +112,10 @@ fn commit(
 
     // TODO i18n
     let fcm_body = format!("You have been added to channel {}", channel_name.clone());
-    let fcm_data = FcmData::builder()
-        .with_body(fcm_body)
-        .with_chat_id(community_id.to_string())
-        .with_alt_sender_name(&added_by_display_name, &added_by_name)
-        .with_sender_avatar_id(community_avatar_id)
-        .build();
+    let fcm_data = FcmData::for_community_chat(community_id, channel_id)
+        .set_body(fcm_body)
+        .set_sender_name_with_alt(&added_by_display_name, &added_by_name)
+        .set_avatar_id(community_avatar_id);
 
     let notification = UserNotificationPayload::AddedToChannel(AddedToChannelNotification {
         community_id: state.env.canister_id().into(),

--- a/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
+++ b/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
@@ -5,7 +5,7 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use community_canister::add_members_to_channel::{Response::*, *};
 use oc_error_codes::OCErrorCode;
-use types::{AddedToChannelNotification, ChannelId, FcmData, OCResult, UserId, UserNotificationPayload, UserType};
+use types::{AddedToChannelNotification, ChannelId, CommunityId, FcmData, OCResult, UserId, UserNotificationPayload, UserType};
 
 #[update(msgpack = true)]
 #[trace]
@@ -106,11 +106,16 @@ fn commit(
         });
     }
 
+    let community_id: CommunityId = state.env.canister_id().into();
+    let community_avatar_id = state.data.avatar.as_ref().map(|d| d.id);
+
     // TODO i18n
     let fcm_body = format!("You have been added to channel {}", channel_name.clone());
     let fcm_data = FcmData::builder()
-        .with_alt_title(&added_by_display_name, &added_by_name)
         .with_body(fcm_body)
+        .with_chat_id(community_id.to_string())
+        .with_alt_sender_name(&added_by_display_name, &added_by_name)
+        .with_sender_avatar_id(community_avatar_id)
         .build();
 
     let notification = UserNotificationPayload::AddedToChannel(AddedToChannelNotification {

--- a/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
+++ b/backend/canisters/community/impl/src/updates/add_members_to_channel.rs
@@ -4,7 +4,6 @@ use crate::{
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use community_canister::add_members_to_channel::{Response::*, *};
-use futures::channel;
 use oc_error_codes::OCErrorCode;
 use types::{AddedToChannelNotification, ChannelId, CommunityId, FcmData, OCResult, UserId, UserNotificationPayload, UserType};
 
@@ -112,7 +111,7 @@ fn commit(
 
     // TODO i18n
     let fcm_body = format!("You have been added to channel {}", channel_name.clone());
-    let fcm_data = FcmData::for_community_chat(community_id, channel_id)
+    let fcm_data = FcmData::for_channel(community_id, channel_id)
         .set_body(fcm_body)
         .set_sender_name_with_alt(&added_by_display_name, &added_by_name)
         .set_avatar_id(community_avatar_id);

--- a/backend/canisters/community/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/community/impl/src/updates/add_reaction.rs
@@ -100,12 +100,10 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
 
                     // TODO i18n
                     let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
-                    let fcm_data = FcmData::builder()
-                        .with_body(fcm_body)
-                        .with_chat_id(community_id.to_string())
-                        .with_alt_sender_name(&display_name, &args.username)
-                        .with_sender_avatar_id(channel_avatar_id)
-                        .build();
+                    let fcm_data = FcmData::for_community_chat(community_id, args.channel_id)
+                        .set_body(fcm_body)
+                        .set_sender_name_with_alt(&display_name, &args.username)
+                        .set_avatar_id(channel_avatar_id);
 
                     let notification = UserNotificationPayload::ChannelReactionAdded(ChannelReactionAddedNotification {
                         community_id,

--- a/backend/canisters/community/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/community/impl/src/updates/add_reaction.rs
@@ -100,7 +100,7 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
 
                     // TODO i18n
                     let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
-                    let fcm_data = FcmData::for_community_chat(community_id, args.channel_id)
+                    let fcm_data = FcmData::for_channel(community_id, args.channel_id)
                         .set_body(fcm_body)
                         .set_sender_name_with_alt(&display_name, &args.username)
                         .set_avatar_id(channel_avatar_id);

--- a/backend/canisters/community/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/community/impl/src/updates/add_reaction.rs
@@ -6,8 +6,8 @@ use canister_tracing_macros::trace;
 use community_canister::{add_reaction::*, c2c_bot_add_reaction};
 use oc_error_codes::OCErrorCode;
 use types::{
-    Achievement, BotCaller, BotPermissions, Caller, ChannelReactionAddedNotification, Chat, ChatPermission, EventIndex,
-    FcmData, OCResult, UserNotificationPayload,
+    Achievement, BotCaller, BotPermissions, Caller, ChannelReactionAddedNotification, Chat, ChatPermission, CommunityId,
+    EventIndex, FcmData, OCResult, UserNotificationPayload,
 };
 use user_canister::{CommunityCanisterEvent, MessageActivity, MessageActivityEvent};
 
@@ -81,7 +81,7 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
     {
         if let Some(sender) = channel.chat.members.get(&message.sender) {
             if message.sender != agent && !sender.user_type().is_bot() {
-                let community_id = state.env.canister_id().into();
+                let community_id: CommunityId = state.env.canister_id().into();
 
                 let notifications_muted = channel
                     .chat
@@ -96,12 +96,15 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
                         .get_by_user_id(&agent)
                         .and_then(|m| m.display_name().value.clone())
                         .or(args.display_name);
+                    let channel_avatar_id = channel.chat.avatar.as_ref().map(|d| d.id);
 
                     // TODO i18n
                     let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
                     let fcm_data = FcmData::builder()
-                        .with_alt_title(&display_name, &args.username)
                         .with_body(fcm_body)
+                        .with_chat_id(community_id.to_string())
+                        .with_alt_sender_name(&display_name, &args.username)
+                        .with_sender_avatar_id(channel_avatar_id)
                         .build();
 
                     let notification = UserNotificationPayload::ChannelReactionAdded(ChannelReactionAddedNotification {
@@ -117,7 +120,7 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
                         added_by_display_name: display_name,
                         reaction: args.reaction,
                         community_avatar_id: state.data.avatar.as_ref().map(|d| d.id),
-                        channel_avatar_id: channel.chat.avatar.as_ref().map(|d| d.id),
+                        channel_avatar_id,
                     });
 
                     state.push_notification(Some(agent), vec![message.sender], notification, fcm_data);

--- a/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
@@ -65,12 +65,10 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let tip = format_crypto_amount_with_symbol(args.amount, args.decimals, &args.token_symbol);
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {}", tip.clone());
-                let fcm_data = FcmData::builder()
-                    .with_body(fcm_body)
-                    .with_chat_id(community_id.to_string())
-                    .with_alt_sender_name(&args.display_name, &args.username)
-                    .with_sender_avatar_id(channel_avatar_id)
-                    .build();
+                let fcm_data = FcmData::for_community_chat(community_id.into(), channel.id.into())
+                    .set_body(fcm_body)
+                    .set_sender_name_with_alt(&args.display_name, &args.username)
+                    .set_avatar_id(channel_avatar_id);
 
                 let notification = UserNotificationPayload::ChannelMessageTipped(ChannelMessageTipped {
                     community_id,

--- a/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
@@ -65,7 +65,7 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let tip = format_crypto_amount_with_symbol(args.amount, args.decimals, &args.token_symbol);
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {}", tip.clone());
-                let fcm_data = FcmData::for_community_chat(community_id.into(), channel.id.into())
+                let fcm_data = FcmData::for_channel(community_id.into(), channel.id.into())
                     .set_body(fcm_body)
                     .set_sender_name_with_alt(&args.display_name, &args.username)
                     .set_avatar_id(channel_avatar_id);

--- a/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
@@ -61,12 +61,15 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                     user_id: Some(user_id),
                 });
 
+                let channel_avatar_id = channel.chat.avatar.as_ref().map(|a| a.id);
                 let tip = format_crypto_amount_with_symbol(args.amount, args.decimals, &args.token_symbol);
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {}", tip.clone());
                 let fcm_data = FcmData::builder()
-                    .with_alt_title(&args.display_name, &args.username)
                     .with_body(fcm_body)
+                    .with_chat_id(community_id.to_string())
+                    .with_alt_sender_name(&args.display_name, &args.username)
+                    .with_sender_avatar_id(channel_avatar_id)
                     .build();
 
                 let notification = UserNotificationPayload::ChannelMessageTipped(ChannelMessageTipped {
@@ -82,7 +85,7 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                     tipped_by_display_name: args.display_name,
                     tip,
                     community_avatar_id: state.data.avatar.as_ref().map(|a| a.id),
-                    channel_avatar_id: channel.chat.avatar.as_ref().map(|a| a.id),
+                    channel_avatar_id,
                 });
 
                 state.push_notification(Some(user_id), vec![message.sender], notification, fcm_data);

--- a/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_tip_message.rs
@@ -65,7 +65,7 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let tip = format_crypto_amount_with_symbol(args.amount, args.decimals, &args.token_symbol);
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {}", tip.clone());
-                let fcm_data = FcmData::for_channel(community_id.into(), channel.id.into())
+                let fcm_data = FcmData::for_channel(community_id, channel.id)
                     .set_body(fcm_body)
                     .set_sender_name_with_alt(&args.display_name, &args.username)
                     .set_avatar_id(channel_avatar_id);

--- a/backend/canisters/community/impl/src/updates/send_message.rs
+++ b/backend/canisters/community/impl/src/updates/send_message.rs
@@ -18,8 +18,8 @@ use rand::RngCore;
 use regex_lite::Regex;
 use std::str::FromStr;
 use types::{
-    Achievement, BotCaller, BotPermissions, Caller, ChannelId, ChannelMessageNotification, Chat, EventIndex, EventWrapper,
-    FcmData, IdempotentEnvelope, Message, MessageContent, MessageIndex, OCResult, TimestampMillis, User, UserId,
+    Achievement, BotCaller, BotPermissions, Caller, ChannelId, ChannelMessageNotification, Chat, CommunityId, EventIndex,
+    EventWrapper, FcmData, IdempotentEnvelope, Message, MessageContent, MessageIndex, OCResult, TimestampMillis, User, UserId,
     UserNotificationPayload, Version,
 };
 use user_canister::{CommunityCanisterEvent, MessageActivity, MessageActivityEvent};
@@ -239,7 +239,7 @@ fn process_send_message_result(
     let message_id = message_event.event.message_id;
     let expires_at = message_event.expires_at;
     let content = &message_event.event.content;
-    let community_id = state.env.canister_id().into();
+    let community_id: CommunityId = state.env.canister_id().into();
 
     register_timer_jobs(channel_id, thread_root_message_index, message_event, now, &mut state.data);
 
@@ -252,8 +252,10 @@ fn process_send_message_result(
 
         // TODO i18n
         let fcm_data = FcmData::builder()
-            .with_alt_title(&sender_display_name, &sender_username)
             .with_alt_body(&message_text, &message_type)
+            .with_chat_id(community_id.to_string())
+            .with_alt_sender_name(&sender_display_name, &sender_username)
+            .with_sender_avatar_id(channel_avatar_id)
             .build();
 
         let notification = UserNotificationPayload::ChannelMessage(ChannelMessageNotification {

--- a/backend/canisters/community/impl/src/updates/send_message.rs
+++ b/backend/canisters/community/impl/src/updates/send_message.rs
@@ -251,12 +251,11 @@ fn process_send_message_result(
             content.notification_text(&users_mentioned.mentioned_directly, &users_mentioned.user_groups_mentioned);
 
         // TODO i18n
-        let fcm_data = FcmData::builder()
-            .with_alt_body(&message_text, &message_type)
-            .with_chat_id(community_id.to_string())
-            .with_alt_sender_name(&sender_display_name, &sender_username)
-            .with_sender_avatar_id(channel_avatar_id)
-            .build();
+        let fcm_data = FcmData::for_community_chat(community_id.into(), channel_id.into())
+            .set_body_with_alt(&message_text, &message_type)
+            .set_sender_id(sender.clone())
+            .set_sender_name_with_alt(&sender_display_name, &sender_username)
+            .set_avatar_id(channel_avatar_id);
 
         let notification = UserNotificationPayload::ChannelMessage(ChannelMessageNotification {
             community_id,

--- a/backend/canisters/community/impl/src/updates/send_message.rs
+++ b/backend/canisters/community/impl/src/updates/send_message.rs
@@ -251,7 +251,7 @@ fn process_send_message_result(
             content.notification_text(&users_mentioned.mentioned_directly, &users_mentioned.user_groups_mentioned);
 
         // TODO i18n
-        let fcm_data = FcmData::for_community_chat(community_id.into(), channel_id.into())
+        let fcm_data = FcmData::for_channel(community_id.into(), channel_id.into())
             .set_body_with_alt(&message_text, &message_type)
             .set_sender_id(sender.clone())
             .set_sender_name_with_alt(&sender_display_name, &sender_username)

--- a/backend/canisters/community/impl/src/updates/send_message.rs
+++ b/backend/canisters/community/impl/src/updates/send_message.rs
@@ -251,9 +251,9 @@ fn process_send_message_result(
             content.notification_text(&users_mentioned.mentioned_directly, &users_mentioned.user_groups_mentioned);
 
         // TODO i18n
-        let fcm_data = FcmData::for_channel(community_id.into(), channel_id.into())
+        let fcm_data = FcmData::for_channel(community_id, channel_id)
             .set_body_with_alt(&message_text, &message_type)
-            .set_sender_id(sender.clone())
+            .set_sender_id(sender)
             .set_sender_name_with_alt(&sender_display_name, &sender_username)
             .set_avatar_id(channel_avatar_id);
 

--- a/backend/canisters/community/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/community/impl/src/updates/start_video_call.rs
@@ -83,7 +83,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
 
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
-    let fcm_data = FcmData::for_community_chat(community_id.into(), args.channel_id.into())
+    let fcm_data = FcmData::for_channel(community_id.into(), args.channel_id.into())
         .set_body("Video call incoming...".to_string())
         .set_sender_id(sender)
         .set_sender_name_with_alt(&args.initiator_display_name, &args.initiator_username)

--- a/backend/canisters/community/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/community/impl/src/updates/start_video_call.rs
@@ -83,7 +83,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
 
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
-    let fcm_data = FcmData::for_channel(community_id.into(), args.channel_id.into())
+    let fcm_data = FcmData::for_channel(community_id, args.channel_id)
         .set_body("Video call incoming...".to_string())
         .set_sender_id(sender)
         .set_sender_name_with_alt(&args.initiator_display_name, &args.initiator_username)

--- a/backend/canisters/community/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/community/impl/src/updates/start_video_call.rs
@@ -83,12 +83,11 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
 
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
-    let fcm_data = FcmData::builder()
-        .with_body("Video call incoming...".to_string())
-        .with_chat_id(community_id.to_string())
-        .with_alt_sender_name(&args.initiator_display_name, &args.initiator_username)
-        .with_sender_avatar_id(channel_avatar_id)
-        .build();
+    let fcm_data = FcmData::for_community_chat(community_id.into(), args.channel_id.into())
+        .set_body("Video call incoming...".to_string())
+        .set_sender_id(sender)
+        .set_sender_name_with_alt(&args.initiator_display_name, &args.initiator_username)
+        .set_avatar_id(channel_avatar_id);
 
     let notification = UserNotificationPayload::ChannelMessage(ChannelMessageNotification {
         community_id,

--- a/backend/canisters/community/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/community/impl/src/updates/start_video_call.rs
@@ -9,7 +9,8 @@ use community_canister::start_video_call_v2::*;
 use constants::HOUR_IN_MS;
 use oc_error_codes::OCErrorCode;
 use types::{
-    Caller, ChannelMessageNotification, FcmData, OCResult, UserId, UserNotificationPayload, VideoCallPresence, VideoCallType,
+    Caller, ChannelMessageNotification, CommunityId, FcmData, OCResult, UserId, UserNotificationPayload, VideoCallPresence,
+    VideoCallType,
 };
 
 #[update(guard = "caller_is_video_call_operator", msgpack = true)]
@@ -77,15 +78,20 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         .filter(|u| state.data.members.get_by_user_id(u).is_some_and(|m| !m.suspended().value))
         .collect();
 
+    let community_id: CommunityId = state.env.canister_id().into();
+    let channel_avatar_id = channel.chat.avatar.as_ref().map(|d| d.id);
+
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
     let fcm_data = FcmData::builder()
-        .with_alt_title(&args.initiator_display_name, &args.initiator_username)
         .with_body("Video call incoming...".to_string())
+        .with_chat_id(community_id.to_string())
+        .with_alt_sender_name(&args.initiator_display_name, &args.initiator_username)
+        .with_sender_avatar_id(channel_avatar_id)
         .build();
 
     let notification = UserNotificationPayload::ChannelMessage(ChannelMessageNotification {
-        community_id: state.env.canister_id().into(),
+        community_id,
         channel_id: args.channel_id,
         thread_root_message_index: None,
         message_index,
@@ -100,7 +106,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         community_name: state.data.name.value.clone(),
         channel_name: channel.chat.name.value.clone(),
         community_avatar_id: state.data.avatar.as_ref().map(|d| d.id),
-        channel_avatar_id: channel.chat.avatar.as_ref().map(|d| d.id),
+        channel_avatar_id,
     });
 
     state.push_notification(Some(sender), users_to_notify, notification, fcm_data);

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `c2c_bot_remove_user` endpoint ([#8217](https://github.com/open-chat-labs/open-chat/pull/8217))
 - Add `c2c_bot_invite_users` endpoint ([#8218](https://github.com/open-chat-labs/open-chat/pull/8218))
 - Add `c2c_bot_members` endpoint ([#8225](https://github.com/open-chat-labs/open-chat/pull/8225))
+- Updated the `FcmData` interface ([8261](https://github.com/open-chat-labs/open-chat/pull/8261))
 
 ### Changed
 

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -136,7 +136,7 @@ impl RuntimeState {
                 sender,
                 recipients,
                 notification_bytes: ByteBuf::from(serialize_then_unwrap(notification)),
-                fcm_data,
+                fcm_data: Some(fcm_data),
             });
             self.push_notification_inner(notification);
         }

--- a/backend/canisters/group/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/group/impl/src/updates/add_reaction.rs
@@ -95,12 +95,10 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
 
                     // TODO i18n
                     // TODO create alternative channels for notifications that we consider to be low priority
-                    let fcm_data = FcmData::builder()
-                        .with_body(format!("Reacted {} to your message", args.reaction.clone().0))
-                        .with_chat_id(chat_id.to_text())
-                        .with_alt_sender_name(&added_by_display_name, &added_by_name)
-                        .with_sender_avatar_id(group_avatar_id)
-                        .build();
+                    let fcm_data = FcmData::for_group_chat(chat_id)
+                        .set_body(format!("Reacted {} to your message", args.reaction.clone().0))
+                        .set_sender_name_with_alt(&added_by_display_name, &added_by_name)
+                        .set_avatar_id(group_avatar_id);
 
                     let user_notification_payload =
                         UserNotificationPayload::GroupReactionAdded(GroupReactionAddedNotification {

--- a/backend/canisters/group/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/group/impl/src/updates/add_reaction.rs
@@ -95,7 +95,7 @@ fn add_reaction_impl(args: Args, ext_caller: Option<Caller>, state: &mut Runtime
 
                     // TODO i18n
                     // TODO create alternative channels for notifications that we consider to be low priority
-                    let fcm_data = FcmData::for_group_chat(chat_id)
+                    let fcm_data = FcmData::for_group(chat_id)
                         .set_body(format!("Reacted {} to your message", args.reaction.clone().0))
                         .set_sender_name_with_alt(&added_by_display_name, &added_by_name)
                         .set_avatar_id(group_avatar_id);

--- a/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
@@ -56,12 +56,10 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let group_avatar_id = state.data.chat.avatar.as_ref().map(|a| a.id);
 
                 // TODO i18n
-                let fcm_data = FcmData::builder()
-                    .with_body(format!("Tipped your message {tip}"))
-                    .with_chat_id(chat_id.to_text())
-                    .with_alt_sender_name(&tipped_by_display_name, &tipped_by_name)
-                    .with_sender_avatar_id(group_avatar_id)
-                    .build();
+                let fcm_data = FcmData::for_group_chat(chat_id)
+                    .set_body(format!("Tipped your message {tip}"))
+                    .set_sender_name_with_alt(&tipped_by_display_name, &tipped_by_name)
+                    .set_avatar_id(group_avatar_id);
 
                 let user_notification_payload = UserNotificationPayload::GroupMessageTipped(GroupMessageTipped {
                     chat_id,

--- a/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
@@ -5,7 +5,7 @@ use canister_tracing_macros::trace;
 use chat_events::TipMessageArgs;
 use group_canister::c2c_tip_message::*;
 use ledger_utils::format_crypto_amount_with_symbol;
-use types::{Achievement, Chat, EventIndex, FcmData, GroupMessageTipped, OCResult, UserNotificationPayload};
+use types::{Achievement, Chat, ChatId, EventIndex, FcmData, GroupMessageTipped, OCResult, UserNotificationPayload};
 use user_canister::{GroupCanisterEvent, MessageActivity, MessageActivityEvent};
 
 #[update(msgpack = true)]
@@ -49,15 +49,18 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     {
         if let Some(sender) = state.data.chat.members.get(&message.sender) {
             if message.sender != user_id && !sender.user_type().is_bot() {
-                let chat_id = state.env.canister_id().into();
+                let chat_id: ChatId = state.env.canister_id().into();
                 let tipped_by_name = args.username;
                 let tipped_by_display_name = args.display_name;
                 let tip = format_crypto_amount_with_symbol(args.amount, args.decimals, &args.token_symbol);
+                let group_avatar_id = state.data.chat.avatar.as_ref().map(|a| a.id);
 
                 // TODO i18n
                 let fcm_data = FcmData::builder()
-                    .with_alt_title(&tipped_by_display_name, &tipped_by_name)
                     .with_body(format!("Tipped your message {tip}"))
+                    .with_chat_id(chat_id.to_text())
+                    .with_alt_sender_name(&tipped_by_display_name, &tipped_by_name)
+                    .with_sender_avatar_id(group_avatar_id)
                     .build();
 
                 let user_notification_payload = UserNotificationPayload::GroupMessageTipped(GroupMessageTipped {

--- a/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_tip_message.rs
@@ -56,7 +56,7 @@ fn c2c_tip_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let group_avatar_id = state.data.chat.avatar.as_ref().map(|a| a.id);
 
                 // TODO i18n
-                let fcm_data = FcmData::for_group_chat(chat_id)
+                let fcm_data = FcmData::for_group(chat_id)
                     .set_body(format!("Tipped your message {tip}"))
                     .set_sender_name_with_alt(&tipped_by_display_name, &tipped_by_name)
                     .set_avatar_id(group_avatar_id);

--- a/backend/canisters/group/impl/src/updates/send_message.rs
+++ b/backend/canisters/group/impl/src/updates/send_message.rs
@@ -196,7 +196,7 @@ fn process_send_message_result(
 
         // TODO i18n
         let fcm_body = message_text.clone().unwrap_or(message_type.clone());
-        let fcm_data = FcmData::for_group_chat(chat_id)
+        let fcm_data = FcmData::for_group(chat_id)
             .set_body(fcm_body)
             .set_sender_name_with_alt(&sender_display_name, &sender_username)
             .set_avatar_id(group_avatar_id);

--- a/backend/canisters/group/impl/src/updates/send_message.rs
+++ b/backend/canisters/group/impl/src/updates/send_message.rs
@@ -196,12 +196,10 @@ fn process_send_message_result(
 
         // TODO i18n
         let fcm_body = message_text.clone().unwrap_or(message_type.clone());
-        let fcm_data = FcmData::builder()
-            .with_body(fcm_body)
-            .with_chat_id(chat_id.to_text())
-            .with_alt_sender_name(&sender_display_name, &sender_username)
-            .with_sender_avatar_id(group_avatar_id)
-            .build();
+        let fcm_data = FcmData::for_group_chat(chat_id)
+            .set_body(fcm_body)
+            .set_sender_name_with_alt(&sender_display_name, &sender_username)
+            .set_avatar_id(group_avatar_id);
 
         let notification = UserNotificationPayload::GroupMessage(GroupMessageNotification {
             chat_id,

--- a/backend/canisters/group/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/group/impl/src/updates/start_video_call.rs
@@ -84,7 +84,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
     let fcm_body = "Video call incoming...".to_string();
-    let fcm_data = FcmData::for_group_chat(chat_id)
+    let fcm_data = FcmData::for_group(chat_id)
         .set_body(fcm_body)
         .set_body_with_alt(&sender_display_name, &sender_name)
         .set_avatar_id(group_avatar_id);

--- a/backend/canisters/group/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/group/impl/src/updates/start_video_call.rs
@@ -84,12 +84,10 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
     let fcm_body = "Video call incoming...".to_string();
-    let fcm_data = FcmData::builder()
-        .with_body(fcm_body)
-        .with_chat_id(chat_id.to_text())
-        .with_alt_sender_name(&sender_display_name, &sender_name)
-        .with_sender_avatar_id(group_avatar_id)
-        .build();
+    let fcm_data = FcmData::for_group_chat(chat_id)
+        .set_body(fcm_body)
+        .set_body_with_alt(&sender_display_name, &sender_name)
+        .set_avatar_id(group_avatar_id);
 
     let notification = UserNotificationPayload::GroupMessage(GroupMessageNotification {
         chat_id,

--- a/backend/canisters/group/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/group/impl/src/updates/start_video_call.rs
@@ -8,7 +8,9 @@ use constants::HOUR_IN_MS;
 use group_canister::start_video_call_v2::*;
 use ic_cdk::update;
 use oc_error_codes::OCErrorCode;
-use types::{Caller, FcmData, GroupMessageNotification, OCResult, UserNotificationPayload, VideoCallPresence, VideoCallType};
+use types::{
+    Caller, ChatId, FcmData, GroupMessageNotification, OCResult, UserNotificationPayload, VideoCallPresence, VideoCallType,
+};
 
 #[update(guard = "caller_is_video_call_operator")]
 #[trace]
@@ -74,19 +76,23 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         }
     }
 
+    let chat_id: ChatId = state.env.canister_id().into();
     let sender_name = args.initiator_username;
     let sender_display_name = args.initiator_display_name;
+    let group_avatar_id = state.data.chat.avatar.as_ref().map(|d| d.id);
 
     // TODO i18n
     // TODO video call notifications could display decline and answer buttons
     let fcm_body = "Video call incoming...".to_string();
     let fcm_data = FcmData::builder()
-        .with_alt_title(&sender_display_name, &sender_name)
         .with_body(fcm_body)
+        .with_chat_id(chat_id.to_text())
+        .with_alt_sender_name(&sender_display_name, &sender_name)
+        .with_sender_avatar_id(group_avatar_id)
         .build();
 
     let notification = UserNotificationPayload::GroupMessage(GroupMessageNotification {
-        chat_id: state.env.canister_id().into(),
+        chat_id,
         thread_root_message_index: None,
         message_index,
         event_index,

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Store Identity canisterId in each User canister ([8220](https://github.com/open-chat-labs/open-chat/pull/8220))
 - Expose more details about daily claims ([8255](https://github.com/open-chat-labs/open-chat/pull/8255))
+- Updated the `FcmData` interface ([8261](https://github.com/open-chat-labs/open-chat/pull/8261))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/lib.rs
+++ b/backend/canisters/user/impl/src/lib.rs
@@ -130,7 +130,7 @@ impl RuntimeState {
                 sender,
                 recipients: vec![recipient],
                 notification_bytes: ByteBuf::from(serialize_then_unwrap(notification)),
-                fcm_data,
+                fcm_data: Some(fcm_data),
             })),
         })
     }

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -203,9 +203,11 @@ pub(crate) fn handle_message_impl(
         let image_url = content.notification_image_url();
 
         let fcm_data = FcmData::builder()
-            .with_alt_title(&args.sender_display_name, &args.sender_name)
             .with_alt_body(&message_text, &message_type)
             .with_optional_image(image_url.clone())
+            .with_sender_id(args.sender.to_text())
+            .with_alt_sender_name(&args.sender_display_name, &args.sender_name)
+            .with_sender_avatar_id(args.sender_avatar_id)
             .build();
 
         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -202,13 +202,11 @@ pub(crate) fn handle_message_impl(
         let message_text = content.notification_text(&args.mentioned, &[]);
         let image_url = content.notification_image_url();
 
-        let fcm_data = FcmData::builder()
-            .with_alt_body(&message_text, &message_type)
-            .with_optional_image(image_url.clone())
-            .with_sender_id(args.sender.to_text())
-            .with_alt_sender_name(&args.sender_display_name, &args.sender_name)
-            .with_sender_avatar_id(args.sender_avatar_id)
-            .build();
+        let fcm_data = FcmData::for_direct_chat(args.sender.into())
+            .set_body_with_alt(&message_text, &message_type)
+            .set_optional_image(image_url.clone())
+            .set_sender_name_with_alt(&args.sender_display_name, &args.sender_name)
+            .set_avatar_id(args.sender_avatar_id);
 
         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {
             sender: args.sender,

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -202,7 +202,7 @@ pub(crate) fn handle_message_impl(
         let message_text = content.notification_text(&args.mentioned, &[]);
         let image_url = content.notification_image_url();
 
-        let fcm_data = FcmData::for_direct_chat(args.sender.into())
+        let fcm_data = FcmData::for_direct_chat(args.sender)
             .set_body_with_alt(&message_text, &message_type)
             .set_optional_image(image_url.clone())
             .set_sender_name_with_alt(&args.sender_display_name, &args.sender_name)

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -317,12 +317,10 @@ fn toggle_reaction(args: ToggleReactionArgs, caller_user_id: UserId, state: &mut
                     {
                         // TODO i18n
                         let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
-                        let fcm_data = FcmData::builder()
-                            .with_body(fcm_body)
-                            .with_sender_id(caller_user_id.to_text())
-                            .with_alt_sender_name(&args.display_name, &args.username)
-                            .with_sender_avatar_id(args.user_avatar_id)
-                            .build();
+                        let fcm_data = FcmData::for_direct_chat(caller_user_id.into())
+                            .set_body(fcm_body)
+                            .set_sender_name_with_alt(&args.display_name, &args.username)
+                            .set_avatar_id(args.user_avatar_id);
 
                         let notification = UserNotificationPayload::DirectReactionAdded(DirectReactionAddedNotification {
                             them: chat.them,
@@ -430,12 +428,10 @@ fn tip_message(args: user_canister::TipMessageArgs, caller_user_id: UserId, stat
 
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {tip}");
-                let fcm_data = FcmData::builder()
-                    .with_body(fcm_body)
-                    .with_sender_id(caller_user_id.to_text())
-                    .with_alt_sender_name(&args.display_name, &args.username)
-                    .with_sender_avatar_id(args.user_avatar_id)
-                    .build();
+                let fcm_data = FcmData::for_direct_chat(caller_user_id.into())
+                    .set_body(fcm_body)
+                    .set_sender_name_with_alt(&args.display_name, &args.username)
+                    .set_avatar_id(args.user_avatar_id);
 
                 let notification = UserNotificationPayload::DirectMessageTipped(DirectMessageTipped {
                     them: caller_user_id,

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -317,7 +317,7 @@ fn toggle_reaction(args: ToggleReactionArgs, caller_user_id: UserId, state: &mut
                     {
                         // TODO i18n
                         let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
-                        let fcm_data = FcmData::for_direct_chat(caller_user_id.into())
+                        let fcm_data = FcmData::for_direct_chat(caller_user_id)
                             .set_body(fcm_body)
                             .set_sender_name_with_alt(&args.display_name, &args.username)
                             .set_avatar_id(args.user_avatar_id);
@@ -428,7 +428,7 @@ fn tip_message(args: user_canister::TipMessageArgs, caller_user_id: UserId, stat
 
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {tip}");
-                let fcm_data = FcmData::for_direct_chat(caller_user_id.into())
+                let fcm_data = FcmData::for_direct_chat(caller_user_id)
                     .set_body(fcm_body)
                     .set_sender_name_with_alt(&args.display_name, &args.username)
                     .set_avatar_id(args.user_avatar_id);

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -318,8 +318,10 @@ fn toggle_reaction(args: ToggleReactionArgs, caller_user_id: UserId, state: &mut
                         // TODO i18n
                         let fcm_body = format!("Reacted {} to your message", args.reaction.clone().0);
                         let fcm_data = FcmData::builder()
-                            .with_alt_title(&args.display_name, &args.username)
                             .with_body(fcm_body)
+                            .with_sender_id(caller_user_id.to_text())
+                            .with_alt_sender_name(&args.display_name, &args.username)
+                            .with_sender_avatar_id(args.user_avatar_id)
                             .build();
 
                         let notification = UserNotificationPayload::DirectReactionAdded(DirectReactionAddedNotification {
@@ -429,8 +431,10 @@ fn tip_message(args: user_canister::TipMessageArgs, caller_user_id: UserId, stat
                 // TODO i18n
                 let fcm_body = format!("Tipped your message {tip}");
                 let fcm_data = FcmData::builder()
-                    .with_alt_title(&args.display_name, &args.username)
                     .with_body(fcm_body)
+                    .with_sender_id(caller_user_id.to_text())
+                    .with_alt_sender_name(&args.display_name, &args.username)
+                    .with_sender_avatar_id(args.user_avatar_id)
                     .build();
 
                 let notification = UserNotificationPayload::DirectMessageTipped(DirectMessageTipped {

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -236,12 +236,10 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
                         let message_text = message_content.notification_text(&[], &[]);
                         let image_url = message_content.notification_image_url();
 
-                        let fcm_data = FcmData::builder()
-                            .with_alt_body(&message_text, &message_type)
-                            .with_optional_image(image_url.clone())
-                            .with_sender_name(bot_name.clone())
-                            .with_sender_id(bot_id.to_text())
-                            .build();
+                        let fcm_data = FcmData::for_direct_chat(bot_id.into())
+                            .set_body_with_alt(&message_text, &message_type)
+                            .set_optional_image(image_url.clone())
+                            .set_sender_name(bot_name.clone());
 
                         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {
                             sender: bot_id,

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -237,9 +237,10 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
                         let image_url = message_content.notification_image_url();
 
                         let fcm_data = FcmData::builder()
-                            .with_title(bot_name.clone())
                             .with_alt_body(&message_text, &message_type)
                             .with_optional_image(image_url.clone())
+                            .with_sender_name(bot_name.clone())
+                            .with_sender_id(bot_id.to_text())
                             .build();
 
                         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -236,7 +236,7 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
                         let message_text = message_content.notification_text(&[], &[]);
                         let image_url = message_content.notification_image_url();
 
-                        let fcm_data = FcmData::for_direct_chat(bot_id.into())
+                        let fcm_data = FcmData::for_direct_chat(bot_id)
                             .set_body_with_alt(&message_text, &message_type)
                             .set_optional_image(image_url.clone())
                             .set_sender_name(bot_name.clone());

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -43,8 +43,10 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         // TODO i18n
         // TODO video call notifications could display decline and answer buttons
         let fcm_data = FcmData::builder()
-            .with_alt_title(&args.initiator_display_name, &args.initiator_username)
             .with_body("Video call incoming...".to_string())
+            .with_sender_id(sender.to_text())
+            .with_alt_sender_name(&args.initiator_display_name, &args.initiator_username)
+            .with_sender_avatar_id(args.initiator_avatar_id)
             .build();
 
         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -42,7 +42,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     if !mute_notification {
         // TODO i18n
         // TODO video call notifications could display decline and answer buttons
-        let fcm_data = FcmData::for_direct_chat(sender.into())
+        let fcm_data = FcmData::for_direct_chat(sender)
             .set_body("Video call incoming...".to_string())
             .set_body_with_alt(&args.initiator_display_name, &args.initiator_username)
             .set_avatar_id(args.initiator_avatar_id);

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -42,12 +42,10 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     if !mute_notification {
         // TODO i18n
         // TODO video call notifications could display decline and answer buttons
-        let fcm_data = FcmData::builder()
-            .with_body("Video call incoming...".to_string())
-            .with_sender_id(sender.to_text())
-            .with_alt_sender_name(&args.initiator_display_name, &args.initiator_username)
-            .with_sender_avatar_id(args.initiator_avatar_id)
-            .build();
+        let fcm_data = FcmData::for_direct_chat(sender.into())
+            .set_body("Video call incoming...".to_string())
+            .set_body_with_alt(&args.initiator_display_name, &args.initiator_username)
+            .set_avatar_id(args.initiator_avatar_id);
 
         let notification = UserNotificationPayload::DirectMessage(DirectMessageNotification {
             sender,

--- a/backend/libraries/chat_events/src/chat_event_internal.rs
+++ b/backend/libraries/chat_events/src/chat_event_internal.rs
@@ -93,7 +93,7 @@ impl ChatEventInternal {
         )
     }
 
-    pub fn is_valid_for_group_chat(&self) -> bool {
+    pub fn is_valid_for_group(&self) -> bool {
         matches!(
             self,
             ChatEventInternal::Message(_)

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -1614,7 +1614,7 @@ impl ChatEvents {
         } else {
             match self.chat {
                 Chat::Direct(_) => event.is_valid_for_direct_chat(),
-                Chat::Group(_) | Chat::Channel(..) => event.is_valid_for_group_chat(),
+                Chat::Group(_) | Chat::Channel(..) => event.is_valid_for_group(),
             }
         };
 

--- a/backend/libraries/types/src/fcm_data.rs
+++ b/backend/libraries/types/src/fcm_data.rs
@@ -5,50 +5,68 @@ use std::collections::HashMap;
 // Values relevant for the FCM notifications
 #[derive(CandidType, Serialize, Deserialize, Clone, Default, Debug)]
 pub struct FcmData {
-    #[serde(rename = "t")]
-    pub title: String,
     #[serde(rename = "b")]
     pub body: String,
     #[serde(rename = "i")]
     pub image: Option<String>,
-    #[serde(rename = "d")]
-    pub data: Option<HashMap<String, String>>,
+    #[serde(rename = "c")]
+    pub chat_id: Option<String>,
+    #[serde(rename = "s")]
+    pub sender_id: Option<String>,
+    #[serde(rename = "n")]
+    pub sender_name: String,
+    #[serde(rename = "a")]
+    pub sender_avatar_id: Option<u128>,
 }
 
 impl FcmData {
     pub fn builder() -> FcmDataBuilder {
         FcmDataBuilder::new()
     }
+
+    pub fn as_data(&self) -> HashMap<String, String> {
+        let clone = self.clone();
+        let mut map = HashMap::new();
+
+        map.insert("body".into(), clone.body);
+        map.insert("sender_name".into(), clone.sender_name);
+
+        if let Some(image) = clone.image {
+            map.insert("image".into(), image);
+        }
+
+        if let Some(chat_id) = clone.chat_id {
+            map.insert("chat_id".into(), chat_id);
+        }
+
+        if let Some(sender_id) = clone.sender_id {
+            map.insert("sender_id".into(), sender_id);
+        }
+
+        if let Some(sender_avatar_id) = clone.sender_avatar_id {
+            map.insert("sender_avatar_id".into(), sender_avatar_id.to_string());
+        }
+
+        map
+    }
 }
 
 #[derive(Default)]
 pub struct FcmDataBuilder {
-    title: String,
     body: String,
     image: Option<String>,
-    data: HashMap<String, String>,
+    chat_id: Option<String>,
+    sender_id: Option<String>,
+    sender_name: Option<String>,
+    sender_avatar_id: Option<u128>,
 }
 
 impl FcmDataBuilder {
     fn new() -> Self {
         Self {
-            title: "OpenChat".to_string(),
+            // TODO i18n?
             body: "You have a notification...".to_string(),
             ..Self::default()
-        }
-    }
-
-    /// Set title when we know what it will be!
-    pub fn with_title(self, title: String) -> Self {
-        Self { title, ..self }
-    }
-
-    /// If wanted title value is optional, also provide alternative title!
-    /// Borrows the arg values, then creates copies to reduce boilerplate.
-    pub fn with_alt_title(self, title: &Option<String>, alt_title: &str) -> Self {
-        Self {
-            title: title.clone().unwrap_or(alt_title.to_string()),
-            ..self
         }
     }
 
@@ -72,19 +90,54 @@ impl FcmDataBuilder {
         Self { image, ..self }
     }
 
-    /// Additional notification data in key & value format!
-    pub fn with_data(self, key: String, value: String) -> Self {
-        let mut data = self.data;
-        data.insert(key, value);
-        Self { data, ..self }
+    pub fn with_chat_id(self, chat_id: String) -> Self {
+        Self {
+            chat_id: Some(chat_id),
+            ..self
+        }
     }
 
+    pub fn with_sender_id(self, sender_id: String) -> Self {
+        Self {
+            sender_id: Some(sender_id),
+            ..self
+        }
+    }
+
+    /// Set sender name when we know what it will be!
+    pub fn with_sender_name(self, sender_name: String) -> Self {
+        Self {
+            sender_name: Some(sender_name),
+            ..self
+        }
+    }
+
+    /// If wanted title value is optional, also provide alternative title!
+    /// Borrows the arg values, then creates copies to reduce boilerplate.
+    pub fn with_alt_sender_name(self, sender_name: &Option<String>, alt_sender_name: &str) -> Self {
+        Self {
+            sender_name: sender_name.clone().or_else(|| Some(alt_sender_name.to_string())),
+            ..self
+        }
+    }
+
+    pub fn with_sender_avatar_id(self, sender_avatar_id: Option<u128>) -> Self {
+        Self {
+            sender_avatar_id,
+            ..self
+        }
+    }
+
+    // Notifications do not need to have all fields set, so they can remain
+    // with default values if not set.
     pub fn build(self) -> FcmData {
         FcmData {
-            title: self.title,
             body: self.body,
             image: self.image,
-            data: if self.data.is_empty() { None } else { Some(self.data) },
+            chat_id: self.chat_id,
+            sender_id: self.sender_id,
+            sender_name: self.sender_name.unwrap_or_default(),
+            sender_avatar_id: self.sender_avatar_id,
         }
     }
 }

--- a/backend/libraries/types/src/fcm_data.rs
+++ b/backend/libraries/types/src/fcm_data.rs
@@ -1,143 +1,152 @@
+use crate::{ChannelId, Chat, ChatId, CommunityId, MessageId, UserId};
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Values relevant for the FCM notifications
-#[derive(CandidType, Serialize, Deserialize, Clone, Default, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct FcmData {
+    #[serde(rename = "c")]
+    pub chat_id: Chat,
+    #[serde(rename = "t")]
+    pub thread_id: Option<MessageId>,
     #[serde(rename = "b")]
-    pub body: String,
+    pub body: Option<String>,
     #[serde(rename = "i")]
     pub image: Option<String>,
-    #[serde(rename = "c")]
-    pub chat_id: Option<String>,
     #[serde(rename = "s")]
-    pub sender_id: Option<String>,
+    pub sender_id: Option<UserId>,
     #[serde(rename = "n")]
-    pub sender_name: String,
+    pub sender_name: Option<String>,
     #[serde(rename = "a")]
-    pub sender_avatar_id: Option<u128>,
+    pub avatar_id: Option<u128>,
 }
 
 impl FcmData {
-    pub fn builder() -> FcmDataBuilder {
-        FcmDataBuilder::new()
-    }
-
-    pub fn as_data(&self) -> HashMap<String, String> {
-        let clone = self.clone();
-        let mut map = HashMap::new();
-
-        map.insert("body".into(), clone.body);
-        map.insert("sender_name".into(), clone.sender_name);
-
-        if let Some(image) = clone.image {
-            map.insert("image".into(), image);
-        }
-
-        if let Some(chat_id) = clone.chat_id {
-            map.insert("chat_id".into(), chat_id);
-        }
-
-        if let Some(sender_id) = clone.sender_id {
-            map.insert("sender_id".into(), sender_id);
-        }
-
-        if let Some(sender_avatar_id) = clone.sender_avatar_id {
-            map.insert("sender_avatar_id".into(), sender_avatar_id.to_string());
-        }
-
-        map
-    }
-}
-
-#[derive(Default)]
-pub struct FcmDataBuilder {
-    body: String,
-    image: Option<String>,
-    chat_id: Option<String>,
-    sender_id: Option<String>,
-    sender_name: Option<String>,
-    sender_avatar_id: Option<u128>,
-}
-
-impl FcmDataBuilder {
-    fn new() -> Self {
+    fn default(chat_id: Chat) -> Self {
         Self {
-            // TODO i18n?
-            body: "You have a notification...".to_string(),
-            ..Self::default()
+            chat_id,
+            thread_id: None,
+            body: None,
+            image: None,
+            sender_id: None,
+            sender_name: None,
+            avatar_id: None,
         }
     }
 
-    /// When we know what the body is, and we can take ownership of the value
-    pub fn with_body(self, body: String) -> Self {
-        Self { body, ..self }
+    pub fn for_direct_chat(direct_chat_id: ChatId) -> Self {
+        Self::default(Chat::Direct(direct_chat_id))
     }
 
-    /// When the wanted value for the body is an Option, but we have an alternative
-    /// value we can provide. Borrows the arg values, then creates copies to
-    /// reduce boilerplate.
-    pub fn with_alt_body(self, body: &Option<String>, alt_body: &str) -> Self {
+    pub fn for_group_chat(group_chat_id: ChatId) -> Self {
+        Self::default(Chat::Group(group_chat_id))
+    }
+
+    pub fn for_community_chat(community_id: CommunityId, channel_id: ChannelId) -> Self {
+        Self::default(Chat::Channel(community_id, channel_id))
+    }
+
+    pub fn set_thread_id(self, thread_id: MessageId) -> Self {
         Self {
-            body: body.clone().unwrap_or(alt_body.to_string()),
+            thread_id: Some(thread_id),
             ..self
         }
     }
 
-    /// Image for the notification
-    pub fn with_optional_image(self, image: Option<String>) -> Self {
+    pub fn set_body(self, body: String) -> Self {
+        Self {
+            body: Some(body),
+            ..self
+        }
+    }
+
+    pub fn set_body_with_alt(self, body: &Option<String>, alt_body: &str) -> Self {
+        Self {
+            body: if body.is_some() { body.clone() } else { Some(alt_body.into()) },
+            ..self
+        }
+    }
+
+    pub fn set_optional_image(self, image: Option<String>) -> Self {
         Self { image, ..self }
     }
 
-    pub fn with_chat_id(self, chat_id: String) -> Self {
-        Self {
-            chat_id: Some(chat_id),
-            ..self
-        }
-    }
-
-    pub fn with_sender_id(self, sender_id: String) -> Self {
+    pub fn set_sender_id(self, sender_id: UserId) -> Self {
         Self {
             sender_id: Some(sender_id),
             ..self
         }
     }
 
-    /// Set sender name when we know what it will be!
-    pub fn with_sender_name(self, sender_name: String) -> Self {
+    pub fn set_sender_name(self, sender_name: String) -> Self {
         Self {
             sender_name: Some(sender_name),
             ..self
         }
     }
 
-    /// If wanted title value is optional, also provide alternative title!
-    /// Borrows the arg values, then creates copies to reduce boilerplate.
-    pub fn with_alt_sender_name(self, sender_name: &Option<String>, alt_sender_name: &str) -> Self {
+    pub fn set_sender_name_with_alt(self, sender_name: &Option<String>, alt_sender_name: &str) -> Self {
         Self {
-            sender_name: sender_name.clone().or_else(|| Some(alt_sender_name.to_string())),
+            sender_name: if sender_name.is_some() { sender_name.clone() } else { Some(alt_sender_name.into()) },
             ..self
         }
     }
 
-    pub fn with_sender_avatar_id(self, sender_avatar_id: Option<u128>) -> Self {
-        Self {
-            sender_avatar_id,
-            ..self
-        }
+    pub fn set_avatar_id(self, avatar_id: Option<u128>) -> Self {
+        Self { avatar_id, ..self }
     }
 
-    // Notifications do not need to have all fields set, so they can remain
-    // with default values if not set.
-    pub fn build(self) -> FcmData {
-        FcmData {
-            body: self.body,
-            image: self.image,
-            chat_id: self.chat_id,
-            sender_id: self.sender_id,
-            sender_name: self.sender_name.unwrap_or_default(),
-            sender_avatar_id: self.sender_avatar_id,
+    pub fn as_data(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+
+        match self.chat_id {
+            Chat::Channel(community_id, channel_id) => {
+                map.insert("type".into(), "community".into());
+                map.insert("community_id".into(), community_id.to_string());
+                map.insert("channel_id".into(), channel_id.to_string());
+            }
+            Chat::Direct(chat_id) => {
+                map.insert("type".into(), "direct".into());
+                map.insert("sender_id".into(), chat_id.to_string());
+            }
+            Chat::Group(chat_id) => {
+                map.insert("type".into(), "group".into());
+                map.insert("chat_id".into(), chat_id.to_string());
+            }
         }
+
+        // For group and community chats also add sender to the data! For
+        // direct chats sender is already known.
+        match self.chat_id {
+            Chat::Direct(_) => {}
+            _ => {
+                if let Some(sender_id) = &self.sender_id {
+                    map.insert("sender_id".into(), sender_id.to_string());
+                }
+            }
+        }
+
+        if let Some(thread_id) = self.thread_id {
+            map.insert("thread_id".into(), thread_id.to_string());
+        }
+
+        if let Some(body) = &self.body {
+            map.insert("body".into(), body.clone());
+        }
+
+        if let Some(image) = &self.image {
+            map.insert("image".into(), image.clone());
+        }
+
+        if let Some(sender_name) = &self.sender_name {
+            map.insert("sender_name".into(), sender_name.clone());
+        }
+
+        if let Some(avatar_id) = self.avatar_id {
+            map.insert("avatar_id".into(), avatar_id.to_string());
+        }
+
+        map
     }
 }

--- a/backend/libraries/types/src/notifications.rs
+++ b/backend/libraries/types/src/notifications.rs
@@ -30,7 +30,7 @@ pub struct UserNotification {
 
     // Values relevant for the FCM notifications
     #[serde(default, rename = "f")]
-    pub fcm_data: FcmData,
+    pub fcm_data: Option<FcmData>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -152,7 +152,7 @@ pub struct UserNotificationEnvelope {
     #[serde(rename = "t")]
     pub timestamp: TimestampMillis,
     #[serde(default, rename = "f")]
-    pub fcm_data: FcmData,
+    pub fcm_data: Option<FcmData>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]

--- a/backend/notification_pusher/core/src/lib.rs
+++ b/backend/notification_pusher/core/src/lib.rs
@@ -71,7 +71,7 @@ pub enum PushNotification {
 
 #[derive(Debug)]
 pub struct FcmNotification {
-    fcm_data: FcmData,
+    fcm_data: Option<FcmData>,
     fcm_token: FcmToken,
     metadata: NotificationMetadata,
 }

--- a/backend/notification_pusher/core/src/user_notifications/pusher.rs
+++ b/backend/notification_pusher/core/src/user_notifications/pusher.rs
@@ -132,7 +132,7 @@ impl Pusher {
         let fcm_data = fcm_notification_to_push.fcm_data;
         let mut message = FcmMessage::new();
 
-        message.set_data(Some(fcm_data.as_data()));
+        message.set_data(fcm_data.map(|d| d.as_data()));
         message.set_target(Target::Token(fcm_notification_to_push.fcm_token.0));
 
         let res = self.fcm_service.send_notification(message).await;

--- a/backend/notification_pusher/core/src/user_notifications/pusher.rs
+++ b/backend/notification_pusher/core/src/user_notifications/pusher.rs
@@ -1,7 +1,7 @@
 use crate::metrics::write_metrics;
 use crate::{FcmNotification, NotificationToPush, UserNotificationToPush, timestamp};
 use async_channel::{Receiver, Sender};
-use fcm_service::{FcmMessage, FcmNotification as ExternalFcmNotification, FcmService, Target};
+use fcm_service::{FcmMessage, FcmService, Target};
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -131,25 +131,9 @@ impl Pusher {
     async fn process_fcm_notification_to_push(&self, fcm_notification_to_push: Box<FcmNotification>) -> bool {
         let fcm_data = fcm_notification_to_push.fcm_data;
         let mut message = FcmMessage::new();
-        let mut notification = ExternalFcmNotification::new();
 
-        let mut android_notification = fcm_service::AndroidNotification::new();
-        // We can route messages to different channels, which can have different setups
-        android_notification.set_channel_id(Some("oc_messages".into()));
-        // TODO add url for the sender avatar, then we can do:
-        // android_notification.set_icon(fcm_data.sender_icon)
-
-        let mut android_cfg = fcm_service::AndroidConfig::new();
-        android_cfg.set_notification(Some(android_notification));
-
-        notification.set_title(fcm_data.title);
-        notification.set_body(fcm_data.body);
-        notification.set_image(fcm_data.image);
-        // TODO add any additional data to the notification
-
-        message.set_notification(Some(notification));
+        message.set_data(Some(fcm_data.as_data()));
         message.set_target(Target::Token(fcm_notification_to_push.fcm_token.0));
-        message.set_android(Some(android_cfg));
 
         let res = self.fcm_service.send_notification(message).await;
         if res.is_err() {

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -46,10 +46,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:scheme="http" />
                 <data android:host="oc.app" />
-                
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.oc.app
 
+import android.content.Intent
 import android.util.Log
 import android.os.Bundle
 import com.ocplugin.app.NotificationsHelper
@@ -15,6 +16,18 @@ class MainActivity : TauriActivity() {
             NotificationsHelper.createNotificationChannel(this)
         } catch (e: Exception) {
             Log.e("TEST_OC", "Error occurred $e")
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        
+        Log.d("TEST_OC", "NotificationClick: Received intent with extras ${intent.extras}}")
+
+        intent.extras?.getString("notification_payload")?.let { payload ->
+            Log.d("TEST_OC", "NotificationClick: Received payload: $payload")
+
+            // TODO Emit to Tauri frontend
         }
     }
 }

--- a/frontend/src-tauri/gen/android/tauri.settings.gradle
+++ b/frontend/src-tauri/gen/android/tauri.settings.gradle
@@ -2,8 +2,8 @@
 include ':tauri-android'
 project(':tauri-android').projectDir = new File("/Users/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-2.5.1/mobile/android")
 include ':tauri-plugin-deep-link'
-project(':tauri-plugin-deep-link').projectDir = new File("/Users/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-plugin-deep-link-2.2.1/android")
+project(':tauri-plugin-deep-link').projectDir = new File("/Users/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-plugin-deep-link-2.3.0/android")
 include ':tauri-plugin-notification'
-project(':tauri-plugin-notification').projectDir = new File("/Users/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-plugin-notification-2.2.2/android")
+project(':tauri-plugin-notification').projectDir = new File("/Users/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-plugin-notification-2.2.3/android")
 include ':tauri-plugin-oc'
 project(':tauri-plugin-oc').projectDir = new File("/Users/ivan/projects/open-chat/frontend/tauri-plugin-oc/android")

--- a/frontend/tauri-plugin-oc/android/build.gradle.kts
+++ b/frontend/tauri-plugin-oc/android/build.gradle.kts
@@ -24,10 +24,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
+    kotlinOptions { jvmTarget = "11" }
 }
 
 dependencies {
@@ -36,7 +36,7 @@ dependencies {
     implementation("com.google.android.material:material:1.7.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     implementation(project(":tauri-android"))
 
     implementation("androidx.credentials:credentials:1.5.0")
@@ -45,5 +45,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
     implementation("androidx.browser:browser:1.8.0")
-    implementation("com.google.firebase:firebase-messaging:24.1.1")
+    implementation("com.google.firebase:firebase-messaging:24.1.2")
+    implementation("io.coil-kt.coil3:coil:3.2.0")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:3.2.0")
 }

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsHelper.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsHelper.kt
@@ -3,69 +3,134 @@ package com.ocplugin.app
 import android.app.NotificationChannel
 import android.app.NotificationChannelGroup
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.Person
+import androidx.core.graphics.drawable.IconCompat
+import coil3.BitmapImage
 import com.google.firebase.messaging.FirebaseMessaging
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.bitmapConfig
+import kotlinx.coroutines.CoroutineScope
+
+// All functions are used, though outside the plugin codebase
+@Suppress("UNUSED")
 object NotificationsHelper {
     private const val MESSAGES_CHANNEL_ID = "oc_messages"
     private const val MESSAGES_GROUP_ID = "oc_messages_group"
 
-    fun showNotification(context: Context, title: String, content: String) {
+    fun showNotification(context: Context, data: Map<String, String>) {
+        // For debugging purposes
+        // for ((key, value) in data) {
+        //    Log.d("TEST_OC", "Key: $key, Value: $value")
+        // }
+
+        // TODO replace with actual default
+        val defaultAvatar = "https://oc.app/assets/ckbtc_nobackground.png"
+
+        CoroutineScope(Dispatchers.Main).launch {
+            // Coil will cache the images in memory and using disk LRU cache.
+            // TODO add support for loading circular avatars / or make circular bitmap once image is loaded
+            val avatarBitmap = loadBitmapFromUrl(context, data["sender_avatar_id"] ?: defaultAvatar)
+
+            Log.d("TEST_OC", "Avatar bitmap: $avatarBitmap")
+
+            showNotificationWithAvatar(context, data, avatarBitmap)
+        }
+    }
+
+    fun showNotificationWithAvatar(context: Context, data: Map<String, String>, avatar: Bitmap?) {
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        Log.d("TEST_OC", "Notification received, and now we're rendering it!")
-        val notification =
-                NotificationCompat.Builder(context, MESSAGES_CHANNEL_ID)
-                        .setSmallIcon(android.R.drawable.ic_dialog_info)
-                        .setContentTitle(title)
-                        .setContentText(content)
-                        // Auto cancel removes the notification when the user taps it
-                        .setAutoCancel(true)
-                        .build()
+        // Build pending intent with the notification data that we will read once the user taps on
+        // the notification.
+        val packageName = context.packageName
+        val mainActivityClass = Class.forName("$packageName.MainActivity")
+        val intent = Intent(context, mainActivityClass).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            data.forEach { (key, value) -> putExtra(key, value) }
+        }
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+        // Build the user style notification specific for chat like apps!
+        val sender = buildChatNotificationSender(data["sender_name"], avatar)
+
+        val style = NotificationCompat
+            .MessagingStyle(sender)
+            .addMessage(data["body"] ?: "", System.currentTimeMillis(), sender)
+
+        val notification = NotificationCompat.Builder(context, MESSAGES_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setStyle(style)
+            // Auto cancel removes the notification when the user taps it
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
 
         manager.notify(System.currentTimeMillis().toInt(), notification)
     }
 
+    fun buildChatNotificationSender(senderName: String?, avatar: Bitmap?): Person {
+        val sender = Person.Builder()
+            .setName(senderName ?: "OpenChat")
+
+        if (avatar != null) {
+            val avatarIcon = IconCompat.createWithBitmap(avatar)
+            sender.setIcon(avatarIcon)
+        }
+
+        return sender.build()
+    }
+
+    // From Android 8+ having notification channels is required. This function creates the notifications
+    // channel if it doesn't already exist. This method is called from the Tauri app MainActivity
+    // on app start.
     fun createNotificationChannel(context: Context) {
         val notificationManager: NotificationManager =
-                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channelName = "Message Notifications" // Choose a user-visible name
             val channelDescription = "Message notifications channel for OC" // Optional description
-            val importance =
-                    NotificationManager
-                            .IMPORTANCE_HIGH // Or IMPORTANCE_DEFAULT, IMPORTANCE_LOW, etc. HIGH
-            // enables banners.
+
+            // Or IMPORTANCE_DEFAULT, IMPORTANCE_LOW, etc. HIGH enables banners!
+            val importance = NotificationManager.IMPORTANCE_HIGH
 
             // Create group!
             val messagesGroup = NotificationChannelGroup(MESSAGES_GROUP_ID, "Message Group")
             notificationManager.createNotificationChannelGroup(messagesGroup)
 
             // Create the channel!
-            val channel =
-                    NotificationChannel(MESSAGES_CHANNEL_ID, channelName, importance).apply {
-                        description = channelDescription
-                        enableLights(true)
-                        enableVibration(true)
-                        setShowBadge(true)
-                        group = MESSAGES_GROUP_ID
-                    }
+            val channel = NotificationChannel(MESSAGES_CHANNEL_ID, channelName, importance).apply {
+                description = channelDescription
+                enableLights(true)
+                enableVibration(true)
+                setShowBadge(true)
+                group = MESSAGES_GROUP_ID
+            }
 
             // Register the channel with the system
             notificationManager.createNotificationChannel(channel)
-            Log.d(
-                    "TEST_OC",
-                    "Notification channel created (if not existed already): $MESSAGES_CHANNEL_ID"
-            )
+            Log.d("TEST_OC", "Notification channel created (if not existed already): $MESSAGES_CHANNEL_ID")
         }
     }
 
+    // Cache the current FCM token into a singleton object, so that it can be queried. The UI
+    // will query for the FCM token when the user logs in, or if the user is already logged in
+    // when the app starts.
     fun cacheFCMToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             if (!task.isSuccessful) {
@@ -78,6 +143,37 @@ object NotificationsHelper {
             Log.d("TEST_OC", "FCM Token: $token")
             // Cache token locally so that we can query it!
             OpenChatPlugin.fcmToken = token
+        }
+    }
+
+    // A coroutine based function for loading avatars off main thread, uses lightweight Coil
+    // library.
+    suspend fun loadBitmapFromUrl(context: Context, url: String): Bitmap? {
+        return withContext(Dispatchers.IO) {
+            try {
+                // TODO for global caching reuse image loader
+                val loader = ImageLoader(context)
+                val request = ImageRequest.Builder(context)
+                    .data(url)
+                    .bitmapConfig(Bitmap.Config.ARGB_8888) // Needed to convert to Bitmap
+                    .build()
+
+                val result = loader.execute(request)
+                if (result is SuccessResult) {
+                    val image = result.image
+                    if (image is BitmapImage) {
+                        image.bitmap
+                    } else {
+                        null
+                    }
+                } else {
+                    Log.e("TEST_OC", "Avatar result: $result")
+                    null
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
         }
     }
 }

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatNotificationService.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatNotificationService.kt
@@ -24,21 +24,21 @@ class OpenChatNotificationService : FirebaseMessagingService() {
     // notification manager, and displayed according to the channel settings for which the
     // notification was pushed.
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        remoteMessage.notification?.let {
-            Log.d("TEST_OC", "Notification received from ${remoteMessage.from}: ${it.body}")
+        Log.d("TEST_OC", "REMOTE MESSAGE RECEIVED: $remoteMessage")
 
-            // Keeping this here for debugging purposes!
-            // NotificationsHelper.showNotification(this, it.title ?: "Title", it.body ?: "Body")
+        remoteMessage.data.let {
+            // If the app is in the background, or closed, show the notification
+            NotificationsHelper.showNotification(this, it)
 
+            // TODO if the app is in the foreground, send to UI code
             // Push the new notification to the UI by raising an event!
             // This is less relevant at the moment, since the UI service worker can handle web push
             // notification, but will be important if we decide to switch over to pure Firebase
-            // solution.
-            // TODO add data, image, and any other required properties!
-            OpenChatPlugin.triggerRef("push-notification", JSObject().apply {
-                put("title", it.title ?: "Title")
-                put("body", it.body ?: "Body")
-            })
+            // solution.es!
+            // OpenChatPlugin.triggerRef("push-notification", JSObject().apply {
+            //   put("title", it.title ?: "Title")
+            //   put("body", it.body ?: "Body")
+            // })
         }
     }
 }


### PR DESCRIPTION
If notifications do not have "notification" data set, only attached data in a HashMap structure, the Firebase service will not auto handle the recieved notification if the app is in the background or not running.

This PR introduces changes to the FCM data on the backend to denote specific parts of the info that we require. We've also modified the native app code to allow for handling of notifications.

As an added bonus, we also have a preparation for a user avatar to be shown in the notification, for now it's only a placeholder.

![image](https://github.com/user-attachments/assets/5ae4f297-a80a-46a4-a0f0-155a915dd679)
