### PR TITLE
Don't trigger build+test when only markdown files change

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -2,6 +2,8 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**/*.md'
 
 name: Backend linting and unit tests
 


### PR DESCRIPTION
### Change Summary
Currently, the `Backend linting and unit tests` CI workflow will run even when a push changes **only markdown files** (e.g., README.md). 

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus speeding up the project's CI and saving compute resources 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`67caf1c9`](https://github.com/open-chat-labs/open-chat/commit/67caf1c991bbc3f06b65141b4ff56532cac95bae) changed these files: `backend/canisters/user_index/CHANGELOG.md` and, when pushed, triggered [this](https://github.com/open-chat-labs/open-chat/actions/runs/9371553889/) workflow run, which ran for ~30 CPU minutes. With the proposed changes, these 30 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general 🌱. 

Note that this is a single example out of (a minimum of) 48 examples over the last few months; a lower estimate for the accumulated gain is **22 CPU hours**, but the actual number could be much **higher** because we could only look at a subset of the data.


### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like to **ignore other file types** or apply the filter to **other workflows*, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch