### PR TITLE
Cancel CI Runs When a More Recent Run is Triggered

### DIFF
--- a/.github/workflows/candid.yaml
+++ b/.github/workflows/candid.yaml
@@ -3,6 +3,11 @@ on:
     branches:
       - master
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 name: Validate candid files
 
 jobs:


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **Validate candid files** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

### Example
Here is an example of the behaviour described above: the commit `1c2907a` triggered [this](https://github.com/open-chat-labs/open-chat/actions/runs/9305060306/) workflow run, and shortly after the commit `f4aca9e`, that happened on top of the first commit, triggered [this](https://github.com/open-chat-labs/open-chat/actions/runs/9305063106/) workflow. Both workflows ran till the end, spending approximately 3 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~3 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **7.6 CPU hours** over the last few months.

Note that there are other workflows in your repo in which we could add it if you wish, we started from this because this has been observed to accumulate a lot of wasted resources.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch