### PR TITLE
Added script to build Android app release version & tweaks

### DIFF
--- a/frontend/app/build_android.sh
+++ b/frontend/app/build_android.sh
@@ -1,0 +1,33 @@
+export NODE_ENV=production
+
+export OC_APP_TYPE=android
+export OC_BLOB_URL_PATTERN=https://{canisterId}.raw.icp0.io/{blobType}
+export OC_NODE_ENV=$NODE_ENV
+export OC_BUILD_ENV=$NODE_ENV
+export OC_WEBAUTHN_ORIGIN=oc.app
+
+export OC_BITCOIN_MAINNET_ENABLED=true
+export OC_IC_URL=https://icp-api.io
+export OC_DFX_NETWORK=ic
+
+export OC_INTERNET_IDENTITY_CANISTER_ID=rdmx6-jaaaa-aaaaa-aaadq-cai
+export OC_INTERNET_IDENTITY_URL=https://identity.internetcomputer.org
+export OC_NFID_URL=https://nfid.one/authenticate/?applicationName=OpenChat
+export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=
+export OC_VIDEO_BRIDGE_URL=https://d7ufu5rwdb6eb.cloudfront.net
+export OC_WALLET_CONNECT_PROJECT_ID=adf8b4a7c5514a8229981aabdee2e246
+
+export OC_II_DERIVATION_ORIGIN=https://6hsbt-vqaaa-aaaaf-aaafq-cai.ic0.app
+# export OC_CUSTOM_DOMAINS=oc.app,webtest.oc.app
+export OC_CANISTER_URL_PATH=https://{canisterId}.raw.icp0.io
+export OC_WEBSITE_VERSION=2.0.0-mobile-rc1
+
+# This is injected by the CI env
+export OC_ROLLBAR_ACCESS_TOKEN="this-is-a-fake-token"
+export OC_USERGEEK_APIKEY="this-is-a-fake-apikey"
+export OC_METERED_APIKEY="this-is-a-fake-apikey"
+
+npx rollup -c
+
+cp -r ./public/* ./build

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -11,6 +11,7 @@
         "build:docker": "sh ./build_docker.sh",
         "dev": "sh ./build_dev.sh",
         "dev:mobile": "sh ./build_mobile.sh",
+        "android:release": "sh ./build_android.sh",
         "start": "sirv public --no-clear",
         "validate": "svelte-check --threshold error",
         "lint": "eslint ./src --fix",

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -204,7 +204,7 @@
 
         if (client.isNativeAndroid()) {
             // Inform the native android app that svelte code is ready! SetTimeout
-            // delays the fn execution until the call stack is empty, just to 
+            // delays the fn execution until the call stack is empty, just to
             // make sure anything else non-async that needs to run is done.
             //
             // Once Svelte app is ready, native code can start pushing events.
@@ -587,6 +587,10 @@
         incomingVideoCall.set(undefined);
         page(routeForChatIdentifier("none", chatId));
         videoCallElement?.startOrJoinVideoCall(chatId, callType, true);
+    }
+
+    if (client.isNativeAndroid()) {
+        document.body.classList.add("native-android");
     }
 </script>
 

--- a/frontend/app/src/styles/global.scss
+++ b/frontend/app/src/styles/global.scss
@@ -428,3 +428,50 @@ a {
         }
     }
 }
+
+// TODO get the status bar height programatically from the device
+body.native-android {
+    --status-bar-height: 36px; // This is the height we'll take as relevant!
+
+    // Prevent pinch-zooming on Android devices
+    // Note: tested meta viewport `user-scalable=no`, but seems like Tauri
+    // webview does not respect it
+    touch-action: pan-x pan-y;
+    height: 100%;
+
+    // Status bar on Android devices
+    &:before {
+        content: "";
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: var(--status-bar-height);
+        background-color: #14151b;
+        z-index: 1;
+    }
+
+    // We need to adjust the main content to account for the status bar height!
+    // This is a workaround for the Android status bar issue
+    // where the content is pushed down by the status bar height.
+    &:not(.landing-page) > main {
+        margin-top: var(--status-bar-height);
+        height: calc(100vh - var(--status-bar-height));
+    }
+
+    &.landing-page {
+        &:before {
+            background-color: #1b1c20;
+        }
+
+        > .wrapper {
+            top: var(--status-bar-height);
+        }
+    
+        > .main {
+            margin-top: var(--status-bar-height);
+            padding-top: var(--status-bar-height);
+            height: calc(100vh - var(--status-bar-height));
+        }
+    }  
+}

--- a/frontend/openchat-agent/package.json
+++ b/frontend/openchat-agent/package.json
@@ -9,6 +9,7 @@
         "dev": "npm run clean && tsc -w",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on lib/index.js",
+        "android:release": "npm run build",
         "clean": "rm -rf lib",
         "typecheck": "tsc --noEmit",
         "typecheck:watch": "tsc --noEmit -w",

--- a/frontend/openchat-client/package.json
+++ b/frontend/openchat-client/package.json
@@ -10,6 +10,7 @@
         "dev": "npm run clean && tsc -w",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on lib/index.js",
+        "android:release": "npm run build",
         "clean": "rm -rf lib",
         "typecheck": "tsc --noEmit",
         "typecheck:watch": "tsc --noEmit -w",

--- a/frontend/openchat-service-worker/package.json
+++ b/frontend/openchat-service-worker/package.json
@@ -9,6 +9,7 @@
         "dev": "rollup -cw",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on lib/service_worker.js",
+        "android:release": "npm run build",
         "clean": "rm -f lib/service_worker.js",
         "typecheck": "tsc --noEmit",
         "lint": "eslint ./src --fix"

--- a/frontend/openchat-shared/package.json
+++ b/frontend/openchat-shared/package.json
@@ -9,6 +9,7 @@
         "dev": "npm run clean && tsc -w",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on lib/index.js",
+        "android:release": "npm run build",
         "clean": "rm -rf lib",
         "typecheck": "tsc --noEmit",
         "typecheck:watch": "tsc --noEmit -w",

--- a/frontend/openchat-worker/package.json
+++ b/frontend/openchat-worker/package.json
@@ -9,6 +9,7 @@
         "dev": "rollup -cw",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on lib/worker.js",
+        "android:release": "npm run build",
         "clean": "rm -f lib/worker.js",
         "typecheck": "tsc --noEmit",
         "lint": "eslint ./src --fix",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
         "changelog": "auto-changelog --tag-pattern '-website' --file-pattern '^frontend'",
         "verify": "dotenv -- turbo run verify --cache-dir .turbo",
         "tauri": "tauri",
-        "mobile": "cargo tauri android dev",
+        "mobile": "cargo tauri android dev --no-watch",
+        "android:release": "npm ci && dotenv -- turbo run android:release --cache-dir .turbo",
         "dev:mobile": "npm ci && dotenv -- turbo run dev:mobile --cache-dir .turbo"
     },
     "author": "julian.jelfs@gmail.com",

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -17,6 +17,10 @@ val tauriProperties = Properties().apply {
 android {
     compileSdk = 35
     namespace = "com.oc.app"
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "com.oc.app"
@@ -24,6 +28,14 @@ android {
         targetSdk = 35
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
+    }
+    signingConfigs {
+        create("debugRelease") {
+            storeFile = file(System.getProperty("user.home") + "/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
     }
     buildTypes {
         getByName("debug") {
@@ -39,6 +51,7 @@ android {
             }
         }
         getByName("release") {
+            signingConfig = signingConfigs.getByName("debugRelease")
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
@@ -48,10 +61,14 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         buildConfig = true
+    }
+    lint {
+        disable += "NullSafeMutableLiveData"
+        checkReleaseBuilds = false // Optional: skip all lint on release builds
     }
 }
 
@@ -72,3 +89,17 @@ dependencies {
 }
 
 apply(from = "tauri.build.gradle.kts")
+
+android.applicationVariants.all {
+    if (buildType.name == "release") {
+        outputs.all {
+            val outputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            // val buildTypeName = buildType.name.capitalize()
+            // val flavorName = if (flavorName.isNotEmpty()) flavorName.capitalize() else ""
+            // val versionName = versionName
+            // val versionCode = versionCode
+
+            outputImpl.outputFileName = "openchat-release.apk"
+        }
+    }
+}

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -24,10 +24,11 @@
         android:usesCleartextTraffic="${usesCleartextTraffic}"
         tools:ignore="MissingTvBanner">
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+        android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:launchMode="singleTop"
             android:label="@string/main_activity_title"
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
@@ -7,11 +7,23 @@ import app.tauri.plugin.JSObject
 import com.ocplugin.app.NotificationsHelper
 import com.ocplugin.app.OpenChatPlugin
 
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.os.Build
+import android.view.WindowManager
+import android.view.ViewTreeObserver
+import android.widget.FrameLayout
+
 class MainActivity : TauriActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)        
+        super.onCreate(savedInstanceState)
+        
         try {
+            // Makes sure inputs are visible on soft keyboard toggle
+            handleViewportSizeOnSoftKeyboardToggle()
+            
             // Cache FCM token, and create notification channel
             NotificationsHelper.cacheFCMToken()
             NotificationsHelper.createNotificationChannel(this)
@@ -45,4 +57,60 @@ class MainActivity : TauriActivity() {
             }
         }
     }
+    
+    // Handle viewport resize when soft keyboard pops or hides
+    //
+    // Setting `android:windowSoftInputMode="adjustResize"` in the AndroidManifest.xml does not
+    // seem to work in this case. This is a workaround, that seem to work well for now, until
+    // we start implementation of the new UI, and fix the issue.
+    private fun handleViewportSizeOnSoftKeyboardToggle() {
+        val root = findViewById<View>(android.R.id.content)
+        
+        // Difference between visible and full height, which is a sum of heights of status bar
+        // and bottom navigation bar.
+        var heightDelta: Int? = null
+
+        root.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                val webView = findWebView(root)
+                
+                if (webView != null) {
+                    val rect = android.graphics.Rect()
+                    root.getWindowVisibleDisplayFrame(rect)
+                    
+                    val visibleHeight = rect.height()
+                    val fullHeight = root.rootView.height
+
+                    if (heightDelta == null) {
+                        heightDelta = fullHeight - visibleHeight
+                        Log.d("TEST_OC", "Full vs visible height offset: $heightDelta")
+                    }
+
+                    val keyboardHeight = fullHeight - visibleHeight - heightDelta
+                    // Assume keyboard is visible if the difference is greater than 200
+                    val isKeyboardVisible = keyboardHeight > 200
+                    
+                    webView.post {
+                        val newHeight = if (isKeyboardVisible) fullHeight - keyboardHeight else fullHeight
+                        webView.layoutParams?.height = newHeight
+                        webView.requestLayout()
+                    }
+                }
+            }
+        })
+    }
+
+    private fun findWebView(view: View): WebView? {
+        if (view is WebView) return view
+
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val child = view.getChildAt(i)
+                val result = findWebView(child)
+                if (result != null) return result
+            }
+        }
+        return null
+    }
+
 }

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
         "frontendDist": "../app/build",
         "devUrl": "http://localhost:5003",
         "beforeDevCommand": "echo 'Make sure dev server is running'",
-        "beforeBuildCommand": "echo '`npm run build:mobile` not setup yet' && exit 1"
+        "beforeBuildCommand": "echo 'BUILDING ANDROID APK' && npm run android:release"
     },
     "app": {
         "windows": [

--- a/frontend/tauri-plugin-oc/android/build.gradle.kts
+++ b/frontend/tauri-plugin-oc/android/build.gradle.kts
@@ -18,16 +18,16 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro"
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions { jvmTarget = "11" }
+    kotlinOptions { jvmTarget = "17" }
 }
 
 dependencies {

--- a/frontend/tauri-plugin-oc/package.json
+++ b/frontend/tauri-plugin-oc/package.json
@@ -20,6 +20,7 @@
         "dev": "npm run clean && rollup -cw",
         "dev:mobile": "npm run dev",
         "wait": "npm run clean && wait-on dist-js/index.js",
+        "android:release": "npm run build",
         "clean": "rm -rf dist-js",
         "prepublishOnly": "npm run build",
         "pretest": "npm run build"

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -77,6 +77,14 @@
             "persistent": true,
             "dependsOn": ["^wait"]
         },
+        "android:release": {
+            "outputs": ["lib/**", "build/**"],
+            "dependsOn": [
+                "^android:release",
+                "openchat-service-worker#build",
+                "openchat-worker#build"
+            ]
+        },
         "wait": {
             "cache": false
         },


### PR DESCRIPTION
Added a script which builds a release version of the Android app. The build process uses a debug key/certificate to sign the app, since it matches the one set in the app's assetlinks.json. This allows verification agains the app's domain.

Actual app release will be signed with a dedicated key/certificate.

Included a few tweaks
- Resize viewport on keyboard show/hide
- Add status bar offset to the top (needs a bit of improvement)
- Disabled pinch-to-zoom for the native app