### PR TITLE
Fix SVG upload

### DIFF
--- a/frontend/openchat-client/src/utils/media.ts
+++ b/frontend/openchat-client/src/utils/media.ts
@@ -113,6 +113,7 @@ export function changeDimensions(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const context = canvas.getContext("2d")!;
     context.drawImage(original, 0, 0, canvas.width, canvas.height);
+    const resultMimeType = mimeType === "image/jpeg" ? "image/jpeg" : "image/png";
 
     return new Promise((resolve) => {
         canvas.toBlob((blob) => {
@@ -127,7 +128,7 @@ export function changeDimensions(
                 });
                 reader.readAsArrayBuffer(blob);
             }
-        }, mimeType);
+        }, resultMimeType);
     });
 }
 
@@ -196,6 +197,7 @@ export async function messageContentFromFile(
 
             const mimeType = file.type;
             const isImage = /^image/.test(mimeType);
+            const isSVG = mimeType === "image/svg+xml";
             const isGif = isImage && /gif/.test(mimeType);
             const isVideo = /^video/.test(mimeType);
             const isAudio = /^audio/.test(mimeType);
@@ -226,7 +228,7 @@ export async function messageContentFromFile(
 
                 content = {
                     kind: "image_content",
-                    mimeType: mimeType,
+                    mimeType: isSVG ? "image/png" : mimeType,
                     width: extract.dimensions.width,
                     height: extract.dimensions.height,
                     blobData: new Uint8Array(data),


### PR DESCRIPTION
SVG upload is currently broken because canvas.toBlob does not support the svg mime type. However, we should not be uploading svgs anyway because they are dangerous. The existing `changeDimensions` function already effectively rasterizes the svg, we just need to change the mimeType to png to make it a) work and b) work safely. 