### PR TITLE
make the link expander a tiny bit easier to click on mobile

### DIFF
--- a/frontend/app/src/components/home/TextContent.svelte
+++ b/frontend/app/src/components/home/TextContent.svelte
@@ -87,5 +87,11 @@
 <style lang="scss">
     .expand {
         cursor: pointer;
+
+        @include mobile() {
+            padding: 0 $sp3;
+            border-radius: var(--rd);
+            background-color: rgba(226, 226, 226, 0.2);
+        }
     }
 </style>


### PR DESCRIPTION
This irritates me constantly. 

<img width="421" height="190" alt="image" src="https://github.com/user-attachments/assets/cb6e934b-2213-49b6-9b41-61b88114c9c0" />

fixes #8336 