### PR TITLE
Make how we retrieve display names consistent

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - On uninstall unsubscribe bot from community events ([#8330](https://github.com/open-chat-labs/open-chat/pull/8330))
 - Call to remove member will also remove any invite ([#8332](https://github.com/open-chat-labs/open-chat/pull/8332))
 
-## [[2.0.1829](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1829-community)] - 2025-07-09
+## [[2.0.1828](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1828-community)] - 2025-07-09
 
 ### Added
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Call to remove member will also remove any invite ([#8332](https://github.com/open-chat-labs/open-chat/pull/8332))
 
-## [[2.0.1828](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1828-group)] - 2025-07-09
+## [[2.0.1829](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1829-group)] - 2025-07-09
 
 ### Added
 

--- a/frontend/app/src/components/UserPill.svelte
+++ b/frontend/app/src/components/UserPill.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { OpenChat, UserOrUserGroup } from "openchat-client";
-    import { AvatarSize, selectedCommunityMembersStore } from "openchat-client";
+    import { AvatarSize, selectedChatWebhooksStore, selectedCommunityMembersStore } from "openchat-client";
     import { getContext } from "svelte";
     import Close from "svelte-material-icons/Close.svelte";
     import Avatar from "./Avatar.svelte";
@@ -25,7 +25,7 @@
     let displayName = $derived(
         userOrGroup.kind === "user_group" || userOrGroup.kind === "everyone"
             ? undefined
-            : client.getDisplayName(userOrGroup, $selectedCommunityMembersStore),
+            : client.getDisplayName(userOrGroup.userId, $selectedCommunityMembersStore, $selectedChatWebhooksStore),
     );
 </script>
 

--- a/frontend/app/src/components/home/ChannelOrCommunityMembers.svelte
+++ b/frontend/app/src/components/home/ChannelOrCommunityMembers.svelte
@@ -15,7 +15,6 @@
         selectedCommunityInvitedUsersStore,
         selectedCommunityLapsedMembersStore,
         selectedCommunityMembersStore,
-        type UserSummary,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
@@ -32,8 +31,8 @@
         community: CommunitySummary;
         selectedTab?: "community" | "channel";
         onClose: () => void;
-        onBlockCommunityUser?: (args: { userId: string }) => void;
-        onUnblockCommunityUser: (user: UserSummary) => void;
+        onBlockCommunityUser?: (userId: string) => void;
+        onUnblockCommunityUser: (userId: string) => void;
         onRemoveCommunityMember?: (userId: string) => void;
         onChangeCommunityRole?: (args: {
             userId: string;
@@ -42,8 +41,8 @@
         }) => void;
         onCancelCommunityInvite: (userId: string) => void;
         onShowInviteCommunityUsers: () => void;
-        onBlockGroupUser: (args: { userId: string }) => void;
-        onUnblockGroupUser: (user: UserSummary) => void;
+        onBlockGroupUser: (userId: string) => void;
+        onUnblockGroupUser: (userId: string) => void;
         onRemoveGroupMember: (userId: string) => void;
         onChangeGroupRole: (args: {
             userId: string;

--- a/frontend/app/src/components/home/ChatEvent.svelte
+++ b/frontend/app/src/components/home/ChatEvent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { findSender } from "@src/utils/user";
+    import { findUser } from "@src/utils/user";
     import {
         allUsersStore,
         currentUserIdStore,
@@ -163,7 +163,7 @@
 
     let sender = $derived(
         event.event.kind === "message"
-            ? findSender(event.event.sender, $allUsersStore, $selectedChatWebhooksStore)
+            ? findUser(event.event.sender, $allUsersStore, $selectedChatWebhooksStore)
             : undefined,
     );
 </script>

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -23,6 +23,7 @@
         screenWidth,
         ScreenWidth,
         selectedChatBlockedUsersStore,
+        selectedChatWebhooksStore,
         selectedCommunityMembersStore,
         type SenderContext,
         translationsStore,
@@ -484,7 +485,7 @@
         (!inert || canRevealDeleted || canRevealBlocked) && !readonly && !ephemeral,
     );
     let canUndelete = $derived(msg.deleted && msg.content.kind !== "deleted_content");
-    let senderDisplayName = $derived(client.getDisplayName(sender, $selectedCommunityMembersStore));
+    let senderDisplayName = $derived(client.getDisplayName(msg.sender, $selectedCommunityMembersStore, $selectedChatWebhooksStore));
     let tips = $derived(msg.tips ? Object.entries(msg.tips) : []);
     let canBlockUser = $derived(canBlockUsers && !$selectedChatBlockedUsersStore.has(msg.sender));
     let edited = $derived(

--- a/frontend/app/src/components/home/DeletedContent.svelte
+++ b/frontend/app/src/components/home/DeletedContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {
         OPENCHAT_BOT_USER_ID,
+        selectedChatWebhooksStore,
         selectedCommunityMembersStore,
         type DeletedContent,
         type OpenChat,
@@ -25,7 +26,7 @@
         `${client.toLongDateString(date)} @ ${client.toShortTimeString(date)}`,
     );
     let username = $derived(
-        client.getDisplayNameById(content.deletedBy, $selectedCommunityMembersStore),
+        client.getDisplayName(content.deletedBy, $selectedCommunityMembersStore, $selectedChatWebhooksStore)
     );
 </script>
 

--- a/frontend/app/src/components/home/DeletedContent.svelte
+++ b/frontend/app/src/components/home/DeletedContent.svelte
@@ -26,7 +26,7 @@
         `${client.toLongDateString(date)} @ ${client.toShortTimeString(date)}`,
     );
     let username = $derived(
-        client.getDisplayName(content.deletedBy, $selectedCommunityMembersStore, $selectedChatWebhooksStore)
+        client.getDisplayName(content.deletedBy, $selectedCommunityMembersStore, $selectedChatWebhooksStore),
     );
 </script>
 

--- a/frontend/app/src/components/home/MentionPicker.svelte
+++ b/frontend/app/src/components/home/MentionPicker.svelte
@@ -204,7 +204,7 @@
                                 {:else}
                                     <span class="display-name">
                                         {client.getDisplayName(
-                                            item,
+                                            item.userId,
                                             $selectedCommunityMembersStore,
                                         )}
                                     </span>

--- a/frontend/app/src/components/home/RepliesTo.svelte
+++ b/frontend/app/src/components/home/RepliesTo.svelte
@@ -7,6 +7,7 @@
         currentUserIdStore,
         OpenChat,
         routeForChatIdentifier,
+        selectedChatWebhooksStore,
         selectedCommunityMembersStore,
     } from "openchat-client";
     import page from "page";
@@ -38,7 +39,7 @@
     let displayName = $derived(
         me
             ? client.toTitleCase($_("you"))
-            : client.getDisplayNameById(repliesTo.senderId, $selectedCommunityMembersStore),
+            : client.getDisplayName(repliesTo.senderId, $selectedCommunityMembersStore, $selectedChatWebhooksStore),
     );
 
     function getUrl() {

--- a/frontend/app/src/components/home/ReplyingTo.svelte
+++ b/frontend/app/src/components/home/ReplyingTo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { CreatedUser, EnhancedReplyContext, OpenChat } from "openchat-client";
-    import { iconSize, selectedCommunityMembersStore } from "openchat-client";
+    import { iconSize, selectedChatWebhooksStore, selectedCommunityMembersStore } from "openchat-client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import Close from "svelte-material-icons/Close.svelte";
@@ -25,7 +25,7 @@
     let displayName = $derived(
         me
             ? client.toTitleCase($_("you"))
-            : client.getDisplayName(replyingTo.sender, $selectedCommunityMembersStore),
+            : client.getDisplayName(replyingTo.sender?.userId, $selectedCommunityMembersStore, $selectedChatWebhooksStore),
     );
 </script>
 

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -280,12 +280,12 @@
             });
     }
 
-    async function onBlockGroupUser(args: { userId: string }) {
+    async function onBlockGroupUser(userId: string) {
         if (
             $selectedChatIdStore !== undefined &&
             ($selectedChatIdStore.kind === "group_chat" || $selectedChatIdStore.kind === "channel")
         ) {
-            const success = await client.blockUser($selectedChatIdStore, args.userId);
+            const success = await client.blockUser($selectedChatIdStore, userId);
             if (success) {
                 toastStore.showSuccessToast(i18nKey("blockUserSucceeded"));
             } else {
@@ -294,11 +294,11 @@
         }
     }
 
-    async function onBlockCommunityUser(args: { userId: string }) {
+    async function onBlockCommunityUser(userId: string) {
         if ($selectedCommunitySummaryStore !== undefined) {
             const success = await client.blockCommunityUser(
                 $selectedCommunitySummaryStore.id,
-                args.userId,
+                userId,
             );
             if (success) {
                 toastStore.showSuccessToast(i18nKey("blockUserSucceeded"));
@@ -308,12 +308,12 @@
         }
     }
 
-    async function onUnblockGroupUser(user: UserSummary) {
+    async function onUnblockGroupUser(userId: string) {
         if (
             $selectedChatIdStore !== undefined &&
             ($selectedChatIdStore.kind === "group_chat" || $selectedChatIdStore.kind === "channel")
         ) {
-            const success = await client.unblockUser($selectedChatIdStore, user.userId);
+            const success = await client.unblockUser($selectedChatIdStore, userId);
             if (success) {
                 toastStore.showSuccessToast(i18nKey("unblockUserSucceeded"));
             } else {
@@ -322,11 +322,11 @@
         }
     }
 
-    async function onUnblockCommunityUser(user: UserSummary) {
+    async function onUnblockCommunityUser(userId: string) {
         if ($selectedCommunitySummaryStore !== undefined) {
             const success = await client.unblockCommunityUser(
                 $selectedCommunitySummaryStore.id,
-                user.userId,
+                userId,
             );
             if (success) {
                 toastStore.showSuccessToast(i18nKey("unblockUserSucceeded"));

--- a/frontend/app/src/components/home/VideoCallContent.svelte
+++ b/frontend/app/src/components/home/VideoCallContent.svelte
@@ -7,6 +7,7 @@
         currentUserIdStore,
         publish,
         selectedChatSummaryStore,
+        selectedChatWebhooksStore,
         selectedCommunityMembersStore,
         type VideoCallContent,
     } from "openchat-client";
@@ -28,7 +29,7 @@
 
     let { content, messageIndex, timestamp, senderId }: Props = $props();
 
-    let displayName = $derived(client.getDisplayNameById(senderId, $selectedCommunityMembersStore));
+    let displayName = $derived(client.getDisplayName(senderId, $selectedCommunityMembersStore, $selectedChatWebhooksStore));
     let inCall = $derived(
         $activeVideoCall !== undefined &&
             $selectedChatSummaryStore !== undefined &&

--- a/frontend/app/src/components/home/activity/ActivityEvent.svelte
+++ b/frontend/app/src/components/home/activity/ActivityEvent.svelte
@@ -39,7 +39,7 @@
         if (chat !== undefined) {
             switch (chat.kind) {
                 case "direct_chat":
-                    parts.push(client.getDisplayNameById(chat.them.userId));
+                    parts.push(client.getDisplayName(chat.them.userId));
                     break;
                 case "group_chat":
                     parts.push(chat.name);

--- a/frontend/app/src/components/home/communities/details/UserGroup.svelte
+++ b/frontend/app/src/components/home/communities/details/UserGroup.svelte
@@ -112,17 +112,17 @@
         );
     }
 
-    function addUserToGroup(user: UserSummary) {
+    function addUserToGroup(userId: string) {
         searchTermEntered = "";
-        added.add(user.userId);
-        removed.delete(user.userId);
-        changeUsers(() => userGroup.members.add(user.userId));
+        added.add(userId);
+        removed.delete(userId);
+        changeUsers(() => userGroup.members.add(userId));
     }
 
-    function removeUserFromGroup(user: UserSummary) {
-        removed.add(user.userId);
-        added.delete(user.userId);
-        changeUsers(() => userGroup.members.delete(user.userId));
+    function removeUserFromGroup(userId: string) {
+        removed.add(userId);
+        added.delete(userId);
+        changeUsers(() => userGroup.members.delete(userId));
     }
 
     function changeUsers(fn: () => void) {
@@ -181,7 +181,7 @@
                     items={matchedUsers}>
                     {#snippet children(item)}
                         <User
-                            onClick={() => addUserToGroup(item)}
+                            onClick={() => addUserToGroup(item.userId)}
                             user={item}
                             me={false}
                             profile={false}
@@ -207,7 +207,7 @@
             <div class="user">
                 <User {user} me={false}>
                     {#if canManageUserGroups}
-                        <div onclick={() => removeUserFromGroup(user)} class="delete">
+                        <div onclick={() => removeUserFromGroup(user.userId)} class="delete">
                             <DeleteOutline size={$iconSize} color={"var(--icon-txt)"} />
                         </div>
                     {/if}

--- a/frontend/app/src/components/home/groupdetails/BlockedUser.svelte
+++ b/frontend/app/src/components/home/groupdetails/BlockedUser.svelte
@@ -16,7 +16,7 @@
         canUnblockUser?: boolean;
         searchTerm?: string;
         me?: boolean;
-        onUnblockUser: (user: UserSummary) => void;
+        onUnblockUser: (userId: string) => void;
     }
 
     let {
@@ -39,7 +39,7 @@
                 {/snippet}
                 {#snippet menuItems()}
                     <Menu>
-                        <MenuItem onclick={() => onUnblockUser(user)}>
+                        <MenuItem onclick={() => onUnblockUser(user.userId)}>
                             {#snippet icon()}
                                 <Cancel size={$iconSize} color={"var(--icon-inverted-txt)"} />
                             {/snippet}

--- a/frontend/app/src/components/home/groupdetails/DirectChatDetails.svelte
+++ b/frontend/app/src/components/home/groupdetails/DirectChatDetails.svelte
@@ -173,7 +173,7 @@
         </HoverIcon>
     {/if}
     <h4>
-        <Translatable resourceKey={i18nKey(`Direct chat with ${client.getDisplayName(user)}`)} />
+        <Translatable resourceKey={i18nKey(`Direct chat with ${client.getDisplayName(chat.them.userId)}`)} />
     </h4>
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/app/src/components/home/groupdetails/Member.svelte
+++ b/frontend/app/src/components/home/groupdetails/Member.svelte
@@ -37,7 +37,7 @@
         searchTerm?: string;
         onRemoveMember?: (userId: string) => void;
         onChangeRole?: (args: { userId: string; newRole: MemberRole; oldRole: MemberRole }) => void;
-        onBlockUser?: (args: { userId: string }) => void;
+        onBlockUser?: (userId: string) => void;
     }
 
     let {
@@ -88,7 +88,7 @@
     }
 
     function blockUser() {
-        onBlockUser?.({ userId: member.userId });
+        onBlockUser?.(member.userId);
     }
 </script>
 

--- a/frontend/app/src/components/home/groupdetails/Members.svelte
+++ b/frontend/app/src/components/home/groupdetails/Members.svelte
@@ -63,9 +63,9 @@
         onClose: () => void;
         onShowInviteUsers: () => void;
         onChangeRole?: (args: { userId: string; newRole: MemberRole; oldRole: MemberRole }) => void;
-        onBlockUser?: (args: { userId: string }) => void;
+        onBlockUser?: (userId: string) => void;
         onRemoveMember?: (userId: string) => void;
-        onUnblockUser: (user: UserSummary) => void;
+        onUnblockUser: (userId: string) => void;
         onCancelInvite: (userId: string) => void;
     }
 

--- a/frontend/app/src/components/home/groupdetails/User.svelte
+++ b/frontend/app/src/components/home/groupdetails/User.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { OpenChat } from "openchat-client";
-    import { AvatarSize, selectedCommunityMembersStore } from "openchat-client";
+    import { AvatarSize, selectedChatWebhooksStore, selectedCommunityMembersStore } from "openchat-client";
     import type { UserSummary } from "openchat-shared";
     import { getContext, type Snippet } from "svelte";
     import { i18nKey } from "../../../i18n/i18n";
@@ -36,7 +36,7 @@
 
     let hovering = $state(false);
 
-    let displayName = $derived(client.getDisplayName(user, $selectedCommunityMembersStore));
+    let displayName = $derived(client.getDisplayName(user.userId, $selectedCommunityMembersStore, $selectedChatWebhooksStore));
 
     function click(ev: Event) {
         if (profile) {

--- a/frontend/app/src/components/home/pinned/PinnedMessage.svelte
+++ b/frontend/app/src/components/home/pinned/PinnedMessage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { findSender } from "@src/utils/user";
+    import { findUser } from "@src/utils/user";
     import type { CreatedUser, Message, MultiUserChatIdentifier, OpenChat } from "openchat-client";
     import {
         allUsersStore,
@@ -37,8 +37,8 @@
 
     let crypto = msg.content.kind === "crypto_content";
 
-    let sender = $derived(findSender(msg.sender, $allUsersStore, $selectedChatWebhooksStore));
-    let username = $derived(client.getDisplayName(sender, $selectedCommunityMembersStore));
+    let sender = $derived(findUser(msg.sender, $allUsersStore, $selectedChatWebhooksStore));
+    let username = $derived(client.getDisplayName(msg.sender, $selectedCommunityMembersStore, $selectedChatWebhooksStore));
     let deleted = $derived(msg.content.kind === "deleted_content");
     let fill = $derived(client.fillMessage(msg));
     let me = $derived(user.userId === senderId);

--- a/frontend/app/src/components/home/profile/TransactionEndpoint.svelte
+++ b/frontend/app/src/components/home/profile/TransactionEndpoint.svelte
@@ -37,7 +37,7 @@
                     size={AvatarSize.Tiny} />
             </div>
             <div class="name">
-                {client.getDisplayName(user)}
+                {client.getDisplayName(user.userId)}
             </div>
         </div>
     {:else if accounts[address] !== undefined}

--- a/frontend/app/src/components/home/profile/ViewUserProfile.svelte
+++ b/frontend/app/src/components/home/profile/ViewUserProfile.svelte
@@ -17,6 +17,7 @@
         selectedChatBlockedUsersStore,
         selectedChatMembersStore,
         selectedChatSummaryStore,
+        selectedChatWebhooksStore,
         selectedCommunityBlockedUsersStore,
         selectedCommunityMembersStore,
         selectedCommunitySummaryStore,
@@ -256,12 +257,9 @@
     );
     let displayName = $derived(
         client.getDisplayName(
-            {
-                userId,
-                username: profile?.username ?? "",
-                displayName: profile?.displayName,
-            },
+            userId,
             inGlobalContext ? undefined : $selectedCommunityMembersStore,
+            inGlobalContext ? undefined : $selectedChatWebhooksStore,
         ),
     );
     let canBlock = $derived(

--- a/frontend/app/src/utils/user.ts
+++ b/frontend/app/src/utils/user.ts
@@ -11,7 +11,7 @@ export function buildDisplayName(
     let name;
     switch (userType) {
         case "user": {
-            const summary = findSender(userId, users);
+            const summary = findUser(userId, users);
             name = summary?.displayName ?? summary?.username ?? get(_)("unknownUser");
             break;
         }
@@ -31,17 +31,17 @@ export function trimLeadingAtSymbol(term: string): string {
     return term.length > 0 && term[0] === "@" ? term.substring(1) : term;
 }
 
-export function findSender(
-    senderId: string,
+export function findUser(
+    userId: string,
     users: UserLookup,
     webhooks: ReadonlyMap<string, WebhookDetails> | undefined = undefined,
 ): UserSummary | undefined {
-    const user = users.get(senderId);
+    const user = users.get(userId);
     if (user !== undefined) {
         return user;
     }
 
-    const webhook = webhooks?.get(senderId);
+    const webhook = webhooks?.get(userId);
     if (webhook === undefined) {
         return undefined;
     }


### PR DESCRIPTION
The main change is to modify `getDisplayName` to take the userId, the community members and the webhooks, rather than the user (UserSummary) and the community members.