### PR TITLE
Fetch the index canister for all tokens that support ICRC106

### DIFF
--- a/backend/canisters/registry/api/src/lib.rs
+++ b/backend/canisters/registry/api/src/lib.rs
@@ -19,6 +19,8 @@ use ts_export::ts_export;
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct TokenDetails {
     pub ledger_canister_id: CanisterId,
+    #[ts(as = "Option::<ts_export::TSPrincipal>")]
+    pub index_canister_id: Option<CanisterId>,
     pub name: String,
     pub symbol: String,
     pub decimals: u8,

--- a/backend/canisters/registry/impl/src/jobs/check_for_updates_to_supported_standards.rs
+++ b/backend/canisters/registry/impl/src/jobs/check_for_updates_to_supported_standards.rs
@@ -1,8 +1,7 @@
 use crate::{mutate_state, read_state};
-use candid::Principal;
 use constants::HOUR_IN_MS;
 use std::time::Duration;
-use types::C2CError;
+use types::{C2CError, CanisterId};
 use utils::canister_timers::run_now_then_interval;
 
 pub fn start_job() {
@@ -27,9 +26,27 @@ async fn run_async() {
     futures::future::join_all(ledger_canister_ids.into_iter().map(get_supported_standards)).await;
 }
 
-async fn get_supported_standards(ledger: Principal) -> Result<(), C2CError> {
+async fn get_supported_standards(ledger: CanisterId) -> Result<(), C2CError> {
     let result = icrc_ledger_canister_c2c_client::icrc1_supported_standards(ledger).await?;
-    let standards = result.into_iter().map(|r| r.name).collect();
-    mutate_state(|state| state.data.tokens.set_standards(ledger, standards, state.env.now()));
+    let standards: Vec<_> = result.into_iter().map(|r| r.name).collect();
+    let supports_icrc106 = standards.iter().any(|s| s == "ICRC-106");
+
+    let should_fetch_index = mutate_state(|state| {
+        state.data.tokens.set_standards(ledger, standards, state.env.now());
+
+        supports_icrc106 && state.data.tokens.get(ledger).is_some_and(|t| t.index_canister_id.is_none())
+    });
+
+    if should_fetch_index {
+        if let Ok(Ok(index_canister_id)) = icrc_ledger_canister_c2c_client::icrc106_index_canister_principal(ledger).await {
+            mutate_state(|state| {
+                state
+                    .data
+                    .tokens
+                    .set_index_canister(ledger, index_canister_id, state.env.now())
+            });
+        }
+    }
+
     Ok(())
 }

--- a/backend/canisters/registry/impl/src/lib.rs
+++ b/backend/canisters/registry/impl/src/lib.rs
@@ -186,6 +186,7 @@ impl Data {
         );
         self.tokens.add(
             ledger_canister_id,
+            Some(index_canister_id),
             "Internet Computer".to_string(),
             "ICP".to_string(),
             8,

--- a/backend/canisters/registry/impl/src/model/tokens.rs
+++ b/backend/canisters/registry/impl/src/model/tokens.rs
@@ -16,6 +16,7 @@ impl Tokens {
     pub fn add(
         &mut self,
         ledger_canister_id: CanisterId,
+        index_canister_id: Option<CanisterId>,
         name: String,
         symbol: String,
         decimals: u8,
@@ -40,6 +41,7 @@ impl Tokens {
             let logo_id = logo_id(&logo);
             self.tokens.push(TokenDetails {
                 ledger_canister_id,
+                index_canister_id,
                 name,
                 symbol,
                 decimals,
@@ -115,6 +117,17 @@ impl Tokens {
                 } else {
                     false
                 }
+            },
+            now,
+        );
+    }
+
+    pub fn set_index_canister(&mut self, ledger_canister_id: CanisterId, index_canister_id: CanisterId, now: TimestampMillis) {
+        self.apply_update(
+            ledger_canister_id,
+            |t| {
+                t.index_canister_id = Some(index_canister_id);
+                true
             },
             now,
         );

--- a/backend/canisters/registry/impl/src/updates/add_token.rs
+++ b/backend/canisters/registry/impl/src/updates/add_token.rs
@@ -123,6 +123,7 @@ pub(crate) async fn add_token_impl(
     mutate_state(|state| {
         let now = state.env.now();
         let standards = standards.into_iter().map(|r| r.name).collect();
+        let index_canister_id = nervous_system.as_ref().map(|ns| ns.index_canister_id);
 
         if let Some(ns) = nervous_system {
             state.data.nervous_systems.add(ns, now);
@@ -131,6 +132,7 @@ pub(crate) async fn add_token_impl(
         let name = metadata_helper.name().to_string();
         state.data.tokens.add(
             ledger_canister_id,
+            index_canister_id,
             name.clone(),
             metadata_helper.symbol().to_string(),
             metadata_helper.decimals(),

--- a/backend/external_canisters/icrc_ledger/api/can.did
+++ b/backend/external_canisters/icrc_ledger/api/can.did
@@ -1,5 +1,6 @@
 // Copied from https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/ICRC-1.did
-// and from https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-2/ICRC-2.did
+// and https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-2/ICRC-2.did
+// and https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106/ICRC-106.md
 
 // Number of nanoseconds since the UNIX epoch in UTC timezone.
 type Timestamp = nat64;
@@ -86,6 +87,21 @@ type ICRC2_TransferFromError = variant {
     GenericError : record { error_code : nat; message : text };
 };
 
+type GetIndexPrincipalResult = variant {
+    Ok : principal;
+    Err : GetIndexPrincipalError;
+};
+
+type GetIndexPrincipalError = variant {
+    IndexPrincipalNotSet;
+
+    // Any error not covered by the above variants.
+    GenericError: record {
+       error_code: nat;
+       description: text;
+   };
+};
+
 service : {
     icrc1_metadata : () -> (vec record { text; Value }) query;
     icrc1_name : () -> (text) query;
@@ -98,4 +114,6 @@ service : {
 
     icrc2_approve : (ICRC2_ApproveArgs) -> (variant { Ok : nat; Err : ICRC2_ApproveError });
     icrc2_transfer_from : (ICRC2_TransferFromArgs) -> (variant { Ok : nat; Err : ICRC2_TransferFromError });
+
+    icrc106_get_index_principal : () -> GetIndexPrincipalsResult query;
 };

--- a/backend/external_canisters/icrc_ledger/api/src/queries/icrc106_index_canister_principal.rs
+++ b/backend/external_canisters/icrc_ledger/api/src/queries/icrc106_index_canister_principal.rs
@@ -1,0 +1,3 @@
+use types::CanisterId;
+
+pub type Response = Result<CanisterId, icrc_ledger_types::icrc106::errors::Icrc106Error>;

--- a/backend/external_canisters/icrc_ledger/api/src/queries/mod.rs
+++ b/backend/external_canisters/icrc_ledger/api/src/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod icrc106_index_canister_principal;
 pub mod icrc1_balance_of;
 pub mod icrc1_decimals;
 pub mod icrc1_fee;

--- a/backend/external_canisters/icrc_ledger/c2c_client/src/lib.rs
+++ b/backend/external_canisters/icrc_ledger/c2c_client/src/lib.rs
@@ -10,6 +10,7 @@ generate_candid_c2c_call_no_args!(icrc1_name);
 generate_candid_c2c_call_no_args!(icrc1_supported_standards);
 generate_candid_c2c_call_no_args!(icrc1_symbol);
 generate_candid_c2c_call_no_args!(icrc1_total_supply);
+generate_candid_c2c_call_no_args!(icrc106_index_canister_principal);
 
 // Updates
 generate_candid_c2c_call!(icrc2_approve);

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -2153,7 +2153,7 @@ async function verifyAccountLinkingCode(
     code: string,
     tempKey: CryptoKeyPair,
 ): Promise<VerifyAccountLinkingCodeResponse> {
-    let ecdsaIdentity = await ECDSAKeyIdentity.fromKeyPair(tempKey);
+    const ecdsaIdentity = await ECDSAKeyIdentity.fromKeyPair(tempKey);
     const identityAgent = await IdentityAgent.create(ecdsaIdentity, identityCanister, icUrl, false);
 
     return await identityAgent.verifyAccountLinkingCode(code);


### PR DESCRIPTION
This will allow us to show the transaction history for non-SNS tokens