### PR TITLE
Remove `token_standard` from token details

### DIFF
--- a/backend/canisters/registry/CHANGELOG.md
+++ b/backend/canisters/registry/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Expose `liquid_cycles_balance` in metrics ([#8350](https://github.com/open-chat-labs/open-chat/pull/8350))
 - Switch some endpoints over to using common response types ([#8450](https://github.com/open-chat-labs/open-chat/pull/8450))
+- Remove `token_standard` from token details ([#8479](https://github.com/open-chat-labs/open-chat/pull/8479))
 
 ## [[2.0.1781](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1781-registry)] - 2025-06-09
 

--- a/backend/canisters/registry/api/can.did
+++ b/backend/canisters/registry/api/can.did
@@ -3,7 +3,6 @@ import "../../../libraries/types/can.did";
 type AddTokenArgs = record {
     ledger_canister_id : CanisterId;
     payer : opt UserId;
-    token_standard : TokenStandard;
     info_url : text;
     transaction_url_format : text;
 };

--- a/backend/canisters/registry/api/src/lib.rs
+++ b/backend/canisters/registry/api/src/lib.rs
@@ -1,6 +1,5 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
 use types::{CanisterId, Milliseconds, TimestampMillis, UserId};
 
 mod lifecycle;
@@ -108,20 +107,4 @@ impl From<&NervousSystemDetails> for NervousSystemSummary {
 pub struct MessageFilterSummary {
     pub id: u64,
     pub regex: String,
-}
-
-#[derive(CandidType, Serialize, Deserialize, Debug)]
-// TODO uncomment the line below once candid is aware of the `rename_all` attribute
-// #[serde(rename_all = "lowercase")]
-pub enum TokenStandard {
-    #[serde(rename = "icrc1")]
-    ICRC1,
-}
-
-impl Display for TokenStandard {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ICRC1 => f.write_str("icrc1"),
-        }
-    }
 }

--- a/backend/canisters/registry/api/src/updates/add_token.rs
+++ b/backend/canisters/registry/api/src/updates/add_token.rs
@@ -1,4 +1,3 @@
-use crate::TokenStandard;
 use candid::{CandidType, Principal};
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
@@ -8,7 +7,6 @@ use types::{CanisterId, UserId};
 pub struct Args {
     pub ledger_canister_id: CanisterId,
     pub payer: Option<UserId>,
-    pub token_standard: TokenStandard,
     pub info_url: String,
     pub transaction_url_format: String,
 }
@@ -26,7 +24,6 @@ pub enum Response {
 pub struct HumanReadableArgs {
     ledger_canister_id: HumanReadablePrincipal,
     payer: Option<HumanReadablePrincipal>,
-    token_standard: String,
     info_url: String,
     transaction_url_format: String,
 }
@@ -38,7 +35,6 @@ impl ToHumanReadable for Args {
         HumanReadableArgs {
             ledger_canister_id: self.ledger_canister_id.into(),
             payer: self.payer.map(|user_id| Principal::from(user_id).into()),
-            token_standard: self.token_standard.to_string(),
             info_url: self.info_url.clone(),
             transaction_url_format: self.transaction_url_format.clone(),
         }

--- a/backend/integration_tests/src/registry_tests.rs
+++ b/backend/integration_tests/src/registry_tests.rs
@@ -6,7 +6,6 @@ use crate::{CanisterIds, TestEnv, User, client};
 use candid::Principal;
 use constants::{CHAT_LEDGER_CANISTER_ID, CHAT_TRANSFER_FEE};
 use pocket_ic::PocketIc;
-use registry_canister::TokenStandard;
 use std::ops::Deref;
 use std::time::Duration;
 use testing::rng::{random_principal, random_string};
@@ -34,7 +33,6 @@ fn add_token_succeeds() {
         &registry_canister::add_token::Args {
             ledger_canister_id: test_data.ledger_canister_id,
             payer: Some(test_data.user.user_id),
-            token_standard: TokenStandard::ICRC1,
             info_url: info_url.clone(),
             transaction_url_format: transaction_url_format.clone(),
         },
@@ -111,7 +109,6 @@ fn update_token_succeeds() {
         &registry_canister::add_token::Args {
             ledger_canister_id: test_data.ledger_canister_id,
             payer: Some(test_data.user.user_id),
-            token_standard: TokenStandard::ICRC1,
             info_url: info_url.clone(),
             transaction_url_format: transaction_url_format.clone(),
         },

--- a/frontend/app/src/utils/sns.ts
+++ b/frontend/app/src/utils/sns.ts
@@ -1,4 +1,3 @@
- 
 import { IDL } from "@dfinity/candid";
 import { Principal } from "@dfinity/principal";
 import { type ExternalBot } from "openchat-client";
@@ -17,7 +16,6 @@ export function createAddTokenPayload(
                 IDL.Record({
                     info_url: IDL.Text,
                     payer: IDL.Opt(IDL.Principal),
-                    token_standard: IDL.Variant({ icrc1: IDL.Null }),
                     ledger_canister_id: IDL.Principal,
                     transaction_url_format: IDL.Text,
                 }),
@@ -26,7 +24,6 @@ export function createAddTokenPayload(
                 {
                     info_url: infoUrl,
                     payer: [Principal.fromText(userId)],
-                    token_standard: { icrc1: null },
                     ledger_canister_id: Principal.fromText(ledgerCanisterId),
                     transaction_url_format: transactionUrlFormat,
                 },

--- a/scripts/deploy-test-chat-ledger.sh
+++ b/scripts/deploy-test-chat-ledger.sh
@@ -38,7 +38,6 @@ dfx --identity $IDENTITY canister install test_chat_ledger --wasm ./wasms/icrc_l
 dfx --identity $IDENTITY canister call registry add_token "(record {
     ledger_canister_id = principal \"2ouva-viaaa-aaaaq-aaamq-cai\";
     payer = null;
-    token_standard = variant { icrc1 };
     info_url = \"https://dashboard.internetcomputer.org/sns/3e3x2-xyaaa-aaaaq-aaalq-cai\";
     transaction_url_format = \"https://dashboard.internetcomputer.org/sns/3e3x2-xyaaa-aaaaq-aaalq-cai/transactions/{transaction_index}\";
 })"

--- a/scripts/proposals/add_token_to_registry.sh
+++ b/scripts/proposals/add_token_to_registry.sh
@@ -3,9 +3,8 @@
 # Extract the args or use defaults
 TOKEN_NAME=$1
 LEDGER_CANISTER_ID=$2
-TOKEN_STANDARD=$3
-INFO_URL=$4
-TRANSACTION_URL_FORMAT=$5
+INFO_URL=$3
+TRANSACTION_URL_FORMAT=$4
 
 # Set current directory to the scripts root
 SCRIPT=$(readlink -f "$0")
@@ -18,7 +17,6 @@ SUMMARY="The Registry is not currently in use. But once it is enabled, only thos
 # add_token args
 ARGS="(record {
     ledger_canister_id=principal \"$LEDGER_CANISTER_ID\";
-    token_standard=variant { \"$TOKEN_STANDARD\" };
     info_url=\"$INFO_URL\";
     transaction_url_format=\"$TRANSACTION_URL_FORMAT\";
 })"


### PR DESCRIPTION
This is no longer used, we instead call `icrc1_supported_standards`