### PR TITLE
Updated notification formatting

### DIFF
--- a/backend/notification_pusher/aws/CHANGELOG.md
+++ b/backend/notification_pusher/aws/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+- Updated formatting for the native notifications pushed for group/community/channel events ([8485](https://github.com/open-chat-labs/open-chat/pull/8485))
+
 ### Fixed
 
 - Configure a default crypto provider in the notification pusher ([8440](https://github.com/open-chat-labs/open-chat/pull/8440))


### PR DESCRIPTION
Updated the context of the notifications. Group and community are now indicated as a part of the notification.

<img width="1080" height="261" alt="image" src="https://github.com/user-attachments/assets/f764ecd8-fd1e-4877-a16e-05c6aa597c17" />
