### PR TITLE
Bump Registry cache version

### DIFF
--- a/frontend/openchat-agent/src/utils/registryCache.ts
+++ b/frontend/openchat-agent/src/utils/registryCache.ts
@@ -1,7 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import type { RegistryValue } from "openchat-shared";
 
-const CACHE_VERSION = 17;
+const CACHE_VERSION = 18;
 const KEY = "registry";
 
 let db: RegistryDatabase | undefined;


### PR DESCRIPTION
We need to do this before we can enable any OneSec tokens