### PR TITLE
Fix android app build and notification dismissal

### DIFF
--- a/frontend/app/build_android.sh
+++ b/frontend/app/build_android.sh
@@ -29,6 +29,8 @@ export OC_WEBSITE_VERSION=2.0.0-mobile-rc1
 export OC_ROLLBAR_ACCESS_TOKEN="this-is-a-fake-token"
 export OC_USERGEEK_APIKEY="this-is-a-fake-apikey"
 export OC_METERED_APIKEY="this-is-a-fake-apikey"
+export OC_ONESEC_FORWARDER_CANISTER="this-is-a-fake-canister-id"
+export OC_ONESEC_MINTER_CANISTER="this-is-a-fake-canister-id"
 
 npx rollup -c
 

--- a/frontend/app/build_docker.sh
+++ b/frontend/app/build_docker.sh
@@ -27,5 +27,7 @@ export OC_VIDEO_BRIDGE_URL=http://localhost:5050
 export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5
 export OC_WEBAUTHN_ORIGIN=localhost
 export OC_WEBSITE_VERSION=200.20.2
+export OC_ONESEC_FORWARDER_CANISTER="this-is-a-fake-canister-id"
+export OC_ONESEC_MINTER_CANISTER="this-is-a-fake-canister-id"
 
 npx rollup -c

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -77,5 +77,7 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".NotificationDismissReceiver" />
     </application>
 </manifest>

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : TauriActivity() {
         // Payload should be json string
         if (notificationPayload != null) {
             ProcessLifecycleOwner.get().lifecycleScope.launch {
-                NotificationsManager.releaseNotificationsAfterTap(this@MainActivity, notificationPayload)
+                NotificationsManager.releaseNotificationsAfterTapOrDismissed(this@MainActivity, notificationPayload, true)
             }
         }
     }

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/NotificationDismissReceiver.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/NotificationDismissReceiver.kt
@@ -1,0 +1,24 @@
+package com.oc.app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.ocplugin.app.NotificationsManager
+import kotlinx.coroutines.launch
+
+class NotificationDismissReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        
+        // TODO This code is exactly the same as in the MainActivity!!!!
+        val notificationPayload = intent.getStringExtra("notificationPayload")
+
+        // Payload should be json string
+        if (notificationPayload != null) {
+            ProcessLifecycleOwner.get().lifecycleScope.launch {
+                NotificationsManager.releaseNotificationsAfterTapOrDismissed(context, notificationPayload, false)
+            }
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/android/src/main/java/IntentsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/IntentsManager.kt
@@ -48,6 +48,24 @@ object IntentsManager {
             pendingIntentFlags)
     }
 
+    fun buildDeleteIntentNotification(context: Context, notification: Notification): PendingIntent {
+        val packageName = context.packageName
+        val dismissReceiverClass = Class.forName("$packageName.NotificationDismissReceiver")
+        val payload = NotificationCompanion.toJSObject(notification).toString()
+        val intent = Intent(context, dismissReceiverClass).apply {
+            putExtra("notificationPayload", payload)
+        }
+
+        val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        return PendingIntent.getBroadcast(
+            context,
+            notification.id.toInt(),
+            intent,
+            pendingIntentFlags,
+        )
+    }
+
     // Build notification shortcut intent
     //
     //


### PR DESCRIPTION
Native app wouldn't run properly since the build was missing some of the new vars. Also added a bit of code to manage dismissed notifications. Not releasing dismissed notifications caused issues with the summary notification showing incorrect numbers for new messages.