### PR TITLE
Add summary text to the summary notification on the lock screen

### DIFF
--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
@@ -242,6 +242,14 @@ object NotificationsManager {
             val messages = "$activeNotifications message${if (activeNotifications > 1) "s" else ""}"
             val summary = if (activeContexts > 1) "$messages, from $activeContexts chats" else messages
 
+            val publicSummary = NotificationCompat.Builder(context, SUMMARY_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification_small)
+                .setContentTitle(title)
+                .setContentText(summary)  // this will show on lock screen
+                .setGroup(NOTIFICATIONS_GROUP_KEY)
+                .setGroupSummary(true)
+                .build()
+
             val summaryNotification = NotificationCompat.Builder(context, SUMMARY_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification_small)
                 .setContentTitle(title)
@@ -255,8 +263,9 @@ object NotificationsManager {
                 .setGroupSummary(true)
                 .setAutoCancel(true)
                 .setSilent(true)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setPublicVersion(publicSummary)
                 .build()
 
             Log.d(LOG_TAG, "#### Set summary notification: $summary")


### PR DESCRIPTION
Notification on the lock screen will show text "2 messages, from 2 chats", as long as there's more than one active notification.