### PR TITLE
only remember heights & prevent overflow

### DIFF
--- a/frontend/app/src/components/home/LinkPreviews.svelte
+++ b/frontend/app/src/components/home/LinkPreviews.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { previewDimensionsObserver } from "@utils/previewDimensionsObserver";
+    import { previewHeightObserver } from "@utils/previewHeightObserver";
     import {
         eventListScrolling,
         iconSize,
@@ -201,23 +201,22 @@
         const toUnobserve: Element[] = [];
         for (const preview of previews) {
             if (preview.container) {
-                previewDimensionsObserver.observe(preview.container, preview.url);
+                previewHeightObserver.observe(preview.container, preview.url);
                 toUnobserve.push(preview.container);
 
-                const dimensions = previewDimensionsObserver.getDimensions(preview.url);
-                if (dimensions) {
-                    preview.container.style.setProperty("min-height", `${dimensions[0]}px`);
-                    preview.container.style.setProperty("min-width", `${dimensions[1]}px`);
+                const height = previewHeightObserver.getHeight(preview.url);
+                if (height) {
+                    preview.container.style.setProperty("min-height", `${height}px`);
                 }
                 if (preview.kind === "generic") {
-                    // If we have dimensions for this preview then display the container immediately, else hide it
+                    // If we have a recorded height for this preview then display the container immediately, else hide it
                     // until we have fetched the preview (if any)
-                    const display = dimensions ? "flex" : "none";
+                    const display = height ? "flex" : "none";
                     preview.container.style.setProperty("display", display);
                 }
             }
         }
-        return () => toUnobserve.forEach((e) => previewDimensionsObserver.unobserve(e));
+        return () => toUnobserve.forEach((e) => previewHeightObserver.unobserve(e));
     });
 
     $effect(() => {
@@ -320,6 +319,7 @@
             flex: 1;
             border-inline-start: $sp2 solid var(--currentChat-msg-separator);
             padding-inline-start: 12px;
+            max-width: 100%;
 
             &.me {
                 border-color: var(--currentChat-msg-me-separator);

--- a/frontend/app/src/utils/previewHeightObserver.ts
+++ b/frontend/app/src/utils/previewHeightObserver.ts
@@ -2,9 +2,9 @@ import { dimensionsWidth } from "openchat-client";
 
 const MAX_HEIGHT = 1000;
 
-class PreviewDimensionsObserver {
+class PreviewHeightObserver {
     #observer: ResizeObserver;
-    #dimensions: Map<string, [number, number]> = new Map();
+    #heights: Map<string, number> = new Map();
     #elementUrls: Map<Element, string> = new Map();
 
     constructor() {
@@ -14,16 +14,16 @@ class PreviewDimensionsObserver {
                 if (0 < element.clientHeight && element.clientHeight <= MAX_HEIGHT) {
                     const url = this.#elementUrls.get(e.target);
                     if (url) {
-                        this.#dimensions.set(url, [element.clientHeight, element.clientWidth]);
+                        this.#heights.set(url, element.clientHeight);
                     }
                 }
             }
         });
-        dimensionsWidth.subscribe((_) => this.#dimensions.clear());
+        dimensionsWidth.subscribe((_) => this.#heights.clear());
     }
 
-    getDimensions(url: string): [number, number] | undefined {
-        return this.#dimensions.get(url);
+    getHeight(url: string): number | undefined {
+        return this.#heights.get(url);
     }
 
     observe(element: Element, url: string) {
@@ -37,4 +37,4 @@ class PreviewDimensionsObserver {
     }
 }
 
-export const previewDimensionsObserver = new PreviewDimensionsObserver();
+export const previewHeightObserver = new PreviewHeightObserver();


### PR DESCRIPTION
Change the preview observer so that it only tracks height. Seems like width should always be flexible (and this was definitely causing problems with right panel resizing). 

Also add width: 100% to the preview to prevent weird overflow of some preview types. 