### PR TITLE
return Vec<Chat> rather than Vec<ChatId>

### DIFF
--- a/backend/canisters/user/api/src/queries/initial_state.rs
+++ b/backend/canisters/user/api/src/queries/initial_state.rs
@@ -44,7 +44,7 @@ pub struct SuccessResult {
     pub btc_address: Option<String>,
     pub one_sec_address: Option<String>,
     pub premium_items: Vec<u32>,
-    pub pinned_chats: Vec<ChatId>,
+    pub pinned_chats: Vec<Chat>,
 }
 
 #[ts_export(user, initial_state)]

--- a/backend/canisters/user/api/src/queries/updates.rs
+++ b/backend/canisters/user/api/src/queries/updates.rs
@@ -56,7 +56,7 @@ pub struct SuccessResult {
     pub btc_address: Option<String>,
     pub one_sec_address: Option<String>,
     pub premium_items: Option<Vec<u32>>,
-    pub pinned_chats: Option<Vec<ChatId>>,
+    pub pinned_chats: Option<Vec<Chat>>,
 }
 
 #[ts_export(user, updates)]

--- a/backend/canisters/user/impl/src/model/direct_chats.rs
+++ b/backend/canisters/user/impl/src/model/direct_chats.rs
@@ -3,7 +3,7 @@ use chat_events::{ChatInternal, ChatMetricsInternal};
 use oc_error_codes::OCErrorCode;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use types::{ChatId, MessageIndex, TimestampMillis, Timestamped, UserId, UserType};
+use types::{Chat, ChatId, MessageIndex, TimestampMillis, Timestamped, UserId, UserType};
 
 #[derive(Serialize, Default)]
 pub struct DirectChats {
@@ -90,8 +90,18 @@ impl DirectChats {
         &self.pinned.value
     }
 
+    pub fn pinned_chats(&self) -> HashMap<Chat, TimestampMillis> {
+        self.pinned.value.iter().map(|(k, v)| (Chat::Direct(*k), *v)).collect()
+    }
+
     pub fn pinned_if_updated(&self, since: TimestampMillis) -> Option<HashMap<ChatId, TimestampMillis>> {
         self.pinned.if_set_after(since).map(|ids| ids.to_owned())
+    }
+
+    pub fn pinned_chats_if_updated(&self, since: TimestampMillis) -> Option<HashMap<Chat, TimestampMillis>> {
+        self.pinned
+            .if_set_after(since)
+            .map(|ids| ids.iter().map(|(k, v)| (Chat::Direct(*k), *v)).collect())
     }
 
     pub fn any_updated(&self, since: TimestampMillis) -> bool {

--- a/backend/canisters/user/impl/src/model/group_chats.rs
+++ b/backend/canisters/user/impl/src/model/group_chats.rs
@@ -2,7 +2,7 @@ use crate::model::group_chat::GroupChat;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use types::{CanisterId, ChatId, MessageIndex, TimestampMillis, Timestamped};
+use types::{CanisterId, Chat, ChatId, MessageIndex, TimestampMillis, Timestamped};
 
 #[derive(Serialize, Default)]
 pub struct GroupChats {
@@ -56,8 +56,18 @@ impl GroupChats {
         &self.pinned.value
     }
 
+    pub fn pinned_chats(&self) -> HashMap<Chat, TimestampMillis> {
+        self.pinned.value.iter().map(|(k, v)| (Chat::Group(*k), *v)).collect()
+    }
+
     pub fn pinned_if_updated(&self, since: TimestampMillis) -> Option<HashMap<ChatId, TimestampMillis>> {
         self.pinned.if_set_after(since).map(|ids| ids.to_owned())
+    }
+
+    pub fn pinned_chats_if_updated(&self, since: TimestampMillis) -> Option<HashMap<Chat, TimestampMillis>> {
+        self.pinned
+            .if_set_after(since)
+            .map(|ids| ids.iter().map(|(k, v)| (Chat::Group(*k), *v)).collect())
     }
 
     pub fn removed_since(&self, timestamp: TimestampMillis) -> Vec<ChatId> {

--- a/backend/canisters/user/impl/src/queries/initial_state.rs
+++ b/backend/canisters/user/impl/src/queries/initial_state.rs
@@ -14,8 +14,10 @@ fn initial_state_impl(state: &RuntimeState) -> Response {
     let my_user_id: UserId = state.env.canister_id().into();
     let avatar_id = state.data.avatar.value.as_ref().map(|a| a.id);
     let blocked_users = state.data.blocked_users.value.iter().copied().collect();
-
-    let merged_pinned = sorted_pinned(&merge_maps(state.data.direct_chats.pinned(), state.data.group_chats.pinned()));
+    let merged_pinned = sorted_pinned(&merge_maps(
+        &state.data.direct_chats.pinned_chats(),
+        &state.data.group_chats.pinned_chats(),
+    ));
 
     let direct_chats = DirectChatsInitial {
         summaries: state.data.direct_chats.iter().map(|d| d.to_summary(my_user_id)).collect(),

--- a/backend/canisters/user/impl/src/queries/updates.rs
+++ b/backend/canisters/user/impl/src/queries/updates.rs
@@ -101,12 +101,12 @@ fn updates_impl(updates_since: TimestampMillis, state: &RuntimeState) -> Respons
         }
     }
 
-    let direct_pinned = state.data.direct_chats.pinned_if_updated(updates_since);
-    let group_pinned = state.data.group_chats.pinned_if_updated(updates_since);
+    let direct_pinned = state.data.direct_chats.pinned_chats_if_updated(updates_since);
+    let group_pinned = state.data.group_chats.pinned_chats_if_updated(updates_since);
     let merged_pinned = match (&direct_pinned, &group_pinned) {
         (Some(direct), Some(group)) => Some(sorted_pinned(&merge_maps(direct, group))),
-        (Some(direct), None) => Some(sorted_pinned(&merge_maps(direct, state.data.group_chats.pinned()))),
-        (None, Some(group)) => Some(sorted_pinned(&merge_maps(state.data.direct_chats.pinned(), group))),
+        (Some(direct), None) => Some(sorted_pinned(&merge_maps(direct, &state.data.group_chats.pinned_chats()))),
+        (None, Some(group)) => Some(sorted_pinned(&merge_maps(&state.data.direct_chats.pinned_chats(), group))),
         _ => None,
     };
 
@@ -114,7 +114,11 @@ fn updates_impl(updates_since: TimestampMillis, state: &RuntimeState) -> Respons
         added: direct_chats_added,
         updated: direct_chats_updated,
         removed: state.data.direct_chats.removed_since(updates_since),
-        pinned: direct_pinned.map(|m| sorted_pinned(&m)),
+        pinned: state
+            .data
+            .direct_chats
+            .pinned_if_updated(updates_since)
+            .map(|m| sorted_pinned(&m)),
     };
 
     let group_chats_removed = state.data.group_chats.removed_since(updates_since);
@@ -132,7 +136,11 @@ fn updates_impl(updates_since: TimestampMillis, state: &RuntimeState) -> Respons
         added: group_chats_added,
         updated: group_chats_updated,
         removed: group_chats_removed,
-        pinned: group_pinned.map(|m| sorted_pinned(&m)),
+        pinned: state
+            .data
+            .group_chats
+            .pinned_if_updated(updates_since)
+            .map(|m| sorted_pinned(&m)),
     };
 
     let communities_removed = state.data.communities.removed_since(updates_since);


### PR DESCRIPTION
Otherwise we can't tell the difference between the merged chatIds on the client. 