### PR TITLE
Set notification priority on the server side

### DIFF
--- a/backend/notification_pusher/core/src/user_notifications/pusher.rs
+++ b/backend/notification_pusher/core/src/user_notifications/pusher.rs
@@ -1,7 +1,7 @@
 use crate::metrics::write_metrics;
 use crate::{FcmNotification, NotificationToPush, UserNotificationToPush, timestamp};
 use async_channel::{Receiver, Sender};
-use fcm_service::{FcmMessage, FcmService, Target};
+use fcm_service::{AndroidConfig, FcmMessage, FcmService, Target};
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -132,8 +132,13 @@ impl Pusher {
         let fcm_data = fcm_notification_to_push.fcm_data;
         let mut message = FcmMessage::new();
 
+        // Should affect only android devices...
+        let mut android_config = AndroidConfig::new();
+        android_config.set_priority(Some(fcm_service::Priority::High));
+
         message.set_data(fcm_data.map(|d| d.as_data()));
         message.set_target(Target::Token(fcm_notification_to_push.fcm_token.0));
+        message.set_android(Some(android_config));
 
         let res = self.fcm_service.send_notification(message).await;
         if res.is_err() {

--- a/frontend/tauri-plugin-oc/android/build.gradle.kts
+++ b/frontend/tauri-plugin-oc/android/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("com.google.android.material:material:1.12.0")
+    implementation("com.google.android.material:material:1.13.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
@@ -62,11 +62,11 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
     implementation("androidx.browser:browser:1.9.0")
-    implementation("com.google.firebase:firebase-messaging:25.0.0")
+    implementation("com.google.firebase:firebase-messaging:25.0.1")
     implementation("io.coil-kt.coil3:coil:3.2.0")
     implementation("io.coil-kt.coil3:coil-network-okhttp:3.2.0")
 
-    val roomVersion = "2.7.2"
+    val roomVersion = "2.8.1"
     implementation("androidx.room:room-runtime:$roomVersion")
     ksp("androidx.room:room-compiler:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
@@ -138,6 +138,7 @@ object NotificationsManager {
             .setContentText(message)
             .setGroup(NOTIFICATIONS_GROUP_KEY)
             .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setContentIntent(
                 IntentsManager.buildPendingIntentForNotification(context, notification)
             )


### PR DESCRIPTION
Notifications pusher will now set the priority for the android notifications to high. On the android side, added priority to the notification when it's created device-side, which may have an effect with some OEMs.