### PR TITLE
Set `me` for message previews based on linked message rather than parent

### DIFF
--- a/frontend/app/src/components/home/LinkPreviews.svelte
+++ b/frontend/app/src/components/home/LinkPreviews.svelte
@@ -265,7 +265,6 @@
                 {:else if preview.kind === "message"}
                     <MessagePreviewComponent
                         url={preview.url}
-                        {me}
                         chatId={preview.chatId}
                         threadRootMessageIndex={preview.threadRootMessageIndex}
                         messageIndex={preview.messageIndex}


### PR DESCRIPTION
Without this, when you send a message with a message link, the preview will display the sender of the linked message as "You" regardless of who actually sent it