### PR TITLE
Parallelise building binaries within `generate-typebox-types.sh`

### DIFF
--- a/scripts/generate-typebox-types.sh
+++ b/scripts/generate-typebox-types.sh
@@ -6,11 +6,33 @@ cd $SCRIPT_DIR/..
 
 rm -rf ./tsBindings
 
-for canister_path in ./backend/canisters/*/
-do
-  canister_path=${canister_path%*/}
-  canister_name=${canister_path##*/}
+canister_names=(
+  community
+  group
+  group_index
+  identity
+  local_user_index
+  notifications_index
+  online_users
+  proposals_bot
+  registry
+  storage_bucket
+  storage_index
+  translations
+  user
+  user_index
+)
 
+build_command_args=""
+for canister_name in "${canister_names[@]}"; do
+  build_command_args+=" --bin ${canister_name}_canister";
+done
+
+echo Building binaries
+cargo build $build_cmd_args
+
+echo Running binaries
+for canister_name in "${canister_names[@]}"; do
   cargo run -p ${canister_name}_canister > /dev/null
 done
 


### PR DESCRIPTION
I also trimmed down the list of canisters to only those that expose typebox types, so now it is roughly 5x faster to run after a clean