### PR TITLE
Optimise cache primer to avoid querying for events it already has

### DIFF
--- a/frontend/openchat-agent/src/services/localUserIndex/localUserIndex.client.ts
+++ b/frontend/openchat-agent/src/services/localUserIndex/localUserIndex.client.ts
@@ -24,7 +24,13 @@ import type {
     Tally,
     VerifiedCredentialArgs,
 } from "openchat-shared";
-import { MAX_MISSING, premiumPrices, toBigInt32, UnsupportedValueError } from "openchat-shared";
+import {
+    max,
+    MAX_MISSING,
+    premiumPrices,
+    toBigInt32,
+    UnsupportedValueError,
+} from "openchat-shared";
 import {
     BotInstallationLocation as ApiBotInstallationLocation,
     LocalUserIndexAccessTokenV2Args,
@@ -67,7 +73,7 @@ import {
     getCachedEventsByIndex,
     getCachedEventsWindowByMessageIndex,
     setCachedEvents,
-    setCachePrimerTimestamp,
+    setCachePrimerEventIndex,
 } from "../../utils/caching";
 import {
     identity,
@@ -167,10 +173,10 @@ export class LocalUserIndexClient extends MultiCanisterMsgpackAgent {
                     result: cached,
                 };
                 if (cachePrimer && request.latestKnownUpdate !== undefined) {
-                    setCachePrimerTimestamp(
+                    setCachePrimerEventIndex(
                         this.db,
                         request.context.chatId,
-                        request.latestKnownUpdate,
+                        max(cached.events, (e) => e.index),
                     );
                 }
             }
@@ -194,10 +200,10 @@ export class LocalUserIndexClient extends MultiCanisterMsgpackAgent {
                         request.context.threadRootMessageIndex,
                     );
                     if (cachePrimer) {
-                        setCachePrimerTimestamp(
+                        setCachePrimerEventIndex(
                             this.db,
                             request.context.chatId,
-                            batchResponse.timestamp,
+                            max(response.result.events, (e) => e.index),
                         );
                     }
                 }

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -226,7 +226,7 @@ import {
     clearCache,
     deleteEventsForChatOrCommunity,
     getActivityFeedEvents,
-    getCachePrimerTimestamps,
+    getCachePrimerEventIndexes,
     getCachedBots,
     getCachedChats,
     getCachedExternalAchievements,
@@ -1799,11 +1799,11 @@ export class OpenChatAgent extends EventTarget {
             if (this._cachePrimer === undefined) {
                 // Set up the cache primer on the first iteration but don't process anything yet, since we want OC's
                 // initialization to be as fast as possible and so don't want resources going to the CachePrimer yet.
-                getCachePrimerTimestamps(this.db).then(
-                    (ts) =>
+                getCachePrimerEventIndexes(this.db).then(
+                    (idx) =>
                         (this._cachePrimer = new CachePrimer(
                             state.userCanisterLocalUserIndex,
-                            ts,
+                            idx,
                             (localUserIndex, requests) =>
                                 this._localUserIndexClient.chatEvents(
                                     localUserIndex,

--- a/frontend/openchat-shared/src/utils/array.ts
+++ b/frontend/openchat-shared/src/utils/array.ts
@@ -6,3 +6,14 @@ export function retain<T>(arr: T[], filter: (val: T) => boolean) {
         }
     }
 }
+
+export function max<T>(arr: T[], mapper: (val: T) => number): number {
+    let max = 0;
+    for (const item of arr) {
+        const value = mapper(item);
+        if (value > max) {
+            max = value;
+        }
+    }
+    return max;
+}


### PR DESCRIPTION
Prior to this PR, when a new message comes in, the cache primer will attempt to load on event window around that message. It first tries to get the events from the cache, but because this is a new message it won't be in the cache, so it counts as a total miss, meaning the cache primer will query for a full page of events, when all it needs is a single event.

Now, if a chat has been updated, we check how many events the cache primer is missing (chat.latestEventIndex - eventIndexLoadedUpTo), then if that is less than a page, we request the events in ascending order from the first missing event (this has the added benefit that if there are more messages on the backend that we don't know about, they will also be returned), else we fallback to the previous method of loading an event window.