### PR TITLE
Fix another race condition where chats could fail to load

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -6596,7 +6596,7 @@ export class OpenChat {
                         if (resp !== undefined) {
                             await this.#handleChatsResponse(
                                 updateRegistryTask,
-                                !chatsInitialisedStore.value,
+                                initialLoad,
                                 resp as UpdatesResult,
                             );
                         }


### PR DESCRIPTION
Prior to this change, the `initialLoad` flag was being passed in to the args after reading from the store, then passed into the response handler by again reading from the store, during this time the store value could have changed which causes things to go wrong.