### PR TITLE
Cap batch size when getting proposal tallies to avoid instruction limit

### DIFF
--- a/frontend/openchat-agent/src/utils/cachePrimer.ts
+++ b/frontend/openchat-agent/src/utils/cachePrimer.ts
@@ -18,6 +18,7 @@ import {
     type UpdatedEvent,
     userIdsFromEvents,
 } from "openchat-shared";
+import { chunk } from "./list";
 import { mapOptional } from "./mapping";
 
 const BATCH_SIZE = 20;
@@ -372,7 +373,9 @@ export class CachePrimer {
     private async processProposalTallies() {
         try {
             for (const [localUserIndex, chatIds] of this.#proposalChats) {
-                await this.updateProposalTallies(localUserIndex, chatIds);
+                for (const batch of chunk(chatIds, 10)) {
+                    await this.updateProposalTallies(localUserIndex, batch);
+                }
             }
         } finally {
             setTimeout(() => this.processProposalTallies(), ONE_MINUTE_MILLIS);


### PR DESCRIPTION
I saw errors in console where queries to get updated proposal tallies would exceed the instruction limit. This caps the number of chats per query to ensure that doesn't happen