### PR TITLE
Fix message entry box being hidden by keyboard after cold start

### DIFF
--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -161,8 +161,11 @@
                 navBarHeight: data.navHeightDp,
             });
 
-            keyboard.visible = data.isKeyboardOpen;
+            // Set currentHeight BEFORE visible so that when keyboard.visible = true
+            // triggers reactive effects (e.g. input tray height), keyboard.height is
+            // already the correct value rather than the cold-start estimate.
             keyboard.currentHeight = data.keyboardHeightDp;
+            keyboard.visible = data.isKeyboardOpen;
             data.isKeyboardOpen
                 ? document.body.classList.add("keyboard-visible")
                 : document.body.classList.remove("keyboard-visible");

--- a/frontend/app/src/stores/keyboard.svelte.ts
+++ b/frontend/app/src/stores/keyboard.svelte.ts
@@ -112,6 +112,36 @@ if (window && IS_NATIVE_APP) {
     window.addEventListener("focusout", () => {
         lastFocusedInput = undefined;
     });
+
+    // Use visualViewport as a real-time backup for keyboard height detection.
+    // On cold start the first time the keyboard appears, expectWindowInsetChange
+    // may fire after a delay, while keyboard.height is still the initial estimate
+    // which can be too small, leaving the input tray shorter than the keyboard.
+    // visualViewport.height always reflects the actual visible area (keyboard
+    // excluded) even in native apps with disableViewportResize(), so we can use
+    // the difference to keep keyboard.height accurate in real time.
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", () => {
+            const kbHeight = Math.round(
+                window.innerHeight - (window.visualViewport?.height ?? window.innerHeight),
+            );
+            // Only update stored height when keyboard height looks valid (> 100px to avoid
+            // triggering on minor viewport changes unrelated to the keyboard).
+            if (kbHeight > 100) {
+                height = kbHeight;
+                localStorage.setItem(STORAGE_KEY, kbHeight.toString());
+            }
+
+            // Re-scroll into view whenever the viewport resizes while the keyboard
+            // is visible. On cold start the height starts as an estimate and/or the
+            // viewport may not have resized yet when the initial scroll fires, leaving
+            // the input tray hidden behind the keyboard. Rescrolling here ensures the
+            // input is visible once the layout has settled.
+            if (visible) {
+                scrollIntoViewLastFocused();
+            }
+        });
+    }
 }
 
 export const keyboard = {

--- a/frontend/app/src/utils/polls.ts
+++ b/frontend/app/src/utils/polls.ts
@@ -37,7 +37,7 @@ export function votedFor(content: PollContent, idx: number): boolean {
 }
 
 export function voteCount(content: PollContent, idx: number): number {
-    let total = content.votes.total;
+    const total = content.votes.total;
     switch (total.kind) {
         case "anonymous_poll_votes":
             return total.votes[idx] ?? 0;


### PR DESCRIPTION
After cold start, the first time I click in the message entry box the keyboard will appear but the window doesn't scroll, so the message entry box remains hidden underneath the keyboard.
I explained the scenario to Claude and included this image and it came up with this fix which appears to be working on webtest.

<img width="585" height="1266" alt="IMG_2129" src="https://github.com/user-attachments/assets/367ea14e-93d3-432b-945b-55748b0db521" />
