### PR TITLE
fix(android): prevent longpress from freezing WebView on image messages

### DIFF
--- a/frontend/app/src/actions/longpress.ts
+++ b/frontend/app/src/actions/longpress.ts
@@ -1,9 +1,14 @@
- 
 import { eventListLastScrolled } from "openchat-client";
 import { get } from "svelte/store";
 import { isTouchDevice, mobileOperatingSystem } from "../utils/devices";
 
 const SCROLL_PROXIMITY = 750;
+
+// On Android, Chromium WebView starts a native drag-and-drop session on
+// longpress of images, which leaves the WebView stuck and swallowing taps.
+// This attribute pairs with a global rule in global.scss that suppresses
+// the native drag/callout on the target and its descendants.
+const ANDROID_DRAG_FIX_ATTR = "data-longpress-android";
 
 function suppressNextClick() {
     if (mobileOperatingSystem !== "iOS") return;
@@ -58,6 +63,10 @@ export function longpress(node: HTMLElement, onlongpress: (e: TouchEvent) => voi
     }
 
     if (isTouchDevice) {
+        if (mobileOperatingSystem === "Android") {
+            node.setAttribute(ANDROID_DRAG_FIX_ATTR, "");
+        }
+
         node.addEventListener("touchend", clearLongPressTimer);
         node.addEventListener("touchmove", onTouchMove);
         node.addEventListener("touchstart", onTouchStart);

--- a/frontend/app/src/components_mobile/home/ImageContent.svelte
+++ b/frontend/app/src/components_mobile/home/ImageContent.svelte
@@ -200,6 +200,7 @@
                 <img
                     bind:this={imgElement}
                     bind:clientWidth={imageWidth}
+                    draggable="false"
                     onerror={onError}
                     class="image"
                     class:me

--- a/frontend/app/src/styles/global.scss
+++ b/frontend/app/src/styles/global.scss
@@ -535,6 +535,20 @@ svelte-virtual-list-viewport {
     }
 }
 
+// On Android, Chromium WebView starts a native drag-and-drop session on
+// longpress of images (and selectable content), backed by a DropDataProvider
+// ContentProvider. Tauri doesn't register that provider, so the session fails
+// to attach data and the WebView gets stuck — subsequent taps stop dispatching
+// to JS. The `longpress` action tags its target with this attribute on Android
+// so the rule below suppresses the native drag/callout for the target and any
+// descendant (including lazy-loaded images).
+[data-longpress-android],
+[data-longpress-android] * {
+    -webkit-touch-callout: none;
+    -webkit-user-drag: none;
+}
+
+
 /* KEYFRAMES */
 
 @keyframes fade-in {


### PR DESCRIPTION
On Android, Chromium WebView starts a native drag-and-drop session when long-pressing an <img>, backed by a DropDataProvider ContentProvider that Tauri doesn't register. The failed session leaves the WebView stuck and swallowing subsequent taps. The longpress action now tags its target with data-longpress-android, and a global rule disables -webkit-user-drag and -webkit-touch-callout on the target and its descendants so the JS menu can open and close cleanly.