### PR TITLE
Add `wasm-sizes.sh` script to display zipped, unzipped & code section sizes

### DIFF
--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT")
+cd "$SCRIPT_DIR/.."
+
+WASMS_DIR="./wasms"
+
+# Python snippet to extract the code section (ID=10) size from a wasm binary
+READ_CODE_SIZE=$(cat <<'PYEOF'
+import sys, struct
+
+def read_leb128(data, pos):
+    result = 0
+    shift = 0
+    while True:
+        b = data[pos]
+        pos += 1
+        result |= (b & 0x7F) << shift
+        shift += 7
+        if not (b & 0x80):
+            return result, pos
+
+wasm = open(sys.argv[1], 'rb').read()
+# Skip magic (4 bytes) + version (4 bytes)
+pos = 8
+code_size = None
+while pos < len(wasm):
+    section_id = wasm[pos]
+    pos += 1
+    section_size, pos = read_leb128(wasm, pos)
+    if section_id == 10:
+        code_size = section_size
+        break
+    pos += section_size
+print(code_size if code_size is not None else 0)
+PYEOF
+)
+
+human_readable() {
+    local bytes=$1
+    if   (( bytes >= 1048576 )); then printf "%.2f MB" "$(echo "scale=2; $bytes/1048576" | bc)"
+    elif (( bytes >= 1024 ));    then printf "%.2f KB" "$(echo "scale=2; $bytes/1024" | bc)"
+    else printf "%d B" "$bytes"
+    fi
+}
+
+printf "%-35s %12s %12s %18s\n" "CANISTER" "ZIPPED" "UNZIPPED" "CODE SECTION"
+printf "%-35s %12s %12s %18s\n" "-------" "------" "--------" "------------"
+
+for gz_file in "$WASMS_DIR"/*.wasm.gz; do
+    canister=$(basename "$gz_file" .wasm.gz)
+
+    zipped_bytes=$(stat -f%z "$gz_file")
+
+    tmp_wasm=$(mktemp /tmp/wasm_sizes_XXXXXX.wasm)
+    gunzip -c "$gz_file" > "$tmp_wasm"
+    unzipped_bytes=$(stat -f%z "$tmp_wasm")
+
+    code_bytes=$(python3 -c "$READ_CODE_SIZE" "$tmp_wasm")
+    rm -f "$tmp_wasm"
+
+    printf "%-35s %12s %12s %18s\n" \
+        "$canister" \
+        "$(human_readable $zipped_bytes)" \
+        "$(human_readable $unzipped_bytes)" \
+        "$(human_readable $code_bytes)"
+done
+

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -8,7 +8,7 @@ WASMS_DIR="./wasms"
 
 # Python snippet to extract the code section (ID=10) size from a wasm binary
 READ_CODE_SIZE=$(cat <<'PYEOF'
-import sys, struct
+import sys
 
 def read_leb128(data, pos):
     result = 0

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -39,10 +39,16 @@ PYEOF
 
 human_readable() {
     local bytes=$1
-    if   (( bytes >= 1048576 )); then printf "%.2f MB" "$(echo "scale=2; $bytes/1048576" | bc)"
-    elif (( bytes >= 1024 ));    then printf "%.2f KB" "$(echo "scale=2; $bytes/1024" | bc)"
-    else printf "%d B" "$bytes"
-    fi
+    python3 -c '
+import sys
+bytes = int(sys.argv[1])
+if bytes >= 1048576:
+    print(f"{bytes / 1048576:.2f} MB", end="")
+elif bytes >= 1024:
+    print(f"{bytes / 1024:.2f} KB", end="")
+else:
+    print(f"{bytes} B", end="")
+' "$bytes"
 }
 
 file_size_bytes() {

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -55,6 +55,9 @@ file_size_bytes() {
     wc -c < "$1" | tr -d '[:space:]'
 }
 
+tmp_wasm=$(mktemp /tmp/wasm_sizes_XXXXXX.wasm)
+trap 'rm -f "$tmp_wasm"' EXIT
+
 printf "%-35s %12s %12s %18s\n" "CANISTER" "ZIPPED" "UNZIPPED" "CODE SECTION"
 printf "%-35s %12s %12s %18s\n" "-------" "------" "--------" "------------"
 
@@ -63,12 +66,10 @@ for gz_file in "$WASMS_DIR"/*.wasm.gz; do
 
     zipped_bytes=$(file_size_bytes "$gz_file")
 
-    tmp_wasm=$(mktemp /tmp/wasm_sizes_XXXXXX.wasm)
     gunzip -c "$gz_file" > "$tmp_wasm"
     unzipped_bytes=$(file_size_bytes "$tmp_wasm")
 
     code_bytes=$(python3 -c "$READ_CODE_SIZE" "$tmp_wasm")
-    rm -f "$tmp_wasm"
 
     printf "%-35s %12s %12s %18s\n" \
         "$canister" \

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -45,17 +45,21 @@ human_readable() {
     fi
 }
 
+file_size_bytes() {
+    wc -c < "$1" | tr -d '[:space:]'
+}
+
 printf "%-35s %12s %12s %18s\n" "CANISTER" "ZIPPED" "UNZIPPED" "CODE SECTION"
 printf "%-35s %12s %12s %18s\n" "-------" "------" "--------" "------------"
 
 for gz_file in "$WASMS_DIR"/*.wasm.gz; do
     canister=$(basename "$gz_file" .wasm.gz)
 
-    zipped_bytes=$(stat -f%z "$gz_file")
+    zipped_bytes=$(file_size_bytes "$gz_file")
 
     tmp_wasm=$(mktemp /tmp/wasm_sizes_XXXXXX.wasm)
     gunzip -c "$gz_file" > "$tmp_wasm"
-    unzipped_bytes=$(stat -f%z "$tmp_wasm")
+    unzipped_bytes=$(file_size_bytes "$tmp_wasm")
 
     code_bytes=$(python3 -c "$READ_CODE_SIZE" "$tmp_wasm")
     rm -f "$tmp_wasm"

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT")
@@ -75,10 +76,10 @@ for gz_file in "${gz_files[@]}"; do
 
     zipped_bytes=$(file_size_bytes "$gz_file")
 
-    gunzip -c "$gz_file" > "$tmp_wasm"
+    gunzip -c "$gz_file" > "$tmp_wasm" || { echo "ERROR: failed to decompress $gz_file" >&2; exit 1; }
     unzipped_bytes=$(file_size_bytes "$tmp_wasm")
 
-    code_bytes=$(python3 -c "$READ_CODE_SIZE" "$tmp_wasm")
+    code_bytes=$(python3 -c "$READ_CODE_SIZE" "$tmp_wasm") || { echo "ERROR: failed to parse wasm for $canister" >&2; exit 1; }
 
     printf "%-35s %12s %12s %18s\n" \
         "$canister" \

--- a/scripts/wasm-sizes.sh
+++ b/scripts/wasm-sizes.sh
@@ -55,13 +55,22 @@ file_size_bytes() {
     wc -c < "$1" | tr -d '[:space:]'
 }
 
+shopt -s nullglob
+gz_files=("$WASMS_DIR"/*.wasm.gz)
+shopt -u nullglob
+
+if (( ${#gz_files[@]} == 0 )); then
+    echo "No .wasm.gz files found in $WASMS_DIR" >&2
+    exit 1
+fi
+
 tmp_wasm=$(mktemp /tmp/wasm_sizes_XXXXXX.wasm)
 trap 'rm -f "$tmp_wasm"' EXIT
 
 printf "%-35s %12s %12s %18s\n" "CANISTER" "ZIPPED" "UNZIPPED" "CODE SECTION"
 printf "%-35s %12s %12s %18s\n" "-------" "------" "--------" "------------"
 
-for gz_file in "$WASMS_DIR"/*.wasm.gz; do
+for gz_file in "${gz_files[@]}"; do
     canister=$(basename "$gz_file" .wasm.gz)
 
     zipped_bytes=$(file_size_bytes "$gz_file")


### PR DESCRIPTION
Sample output:

```
CANISTER                                  ZIPPED     UNZIPPED       CODE SECTION
-------                                   ------     --------       ------------
airdrop_bot                            786.03 KB      3.07 MB            2.88 MB
community                                2.56 MB     11.67 MB           11.21 MB
cycles_dispenser                       351.69 KB   1007.31 KB          848.47 KB
escrow                                 442.60 KB      1.38 MB            1.22 MB
event_relay                            374.53 KB      1.07 MB          937.31 KB
event_store                            375.96 KB      1.26 MB          988.88 KB
group                                    2.22 MB      9.78 MB            9.35 MB
group_index                              1.12 MB      4.99 MB            4.75 MB
icp_ledger                             704.41 KB      1.76 MB            1.44 MB
icrc_ledger                            579.00 KB      1.23 MB          926.55 KB
identity                               579.55 KB      1.81 MB            1.62 MB
local_user_index                         2.59 MB     10.95 MB           10.14 MB
market_maker                           425.50 KB      1.24 MB            1.08 MB
neuron_controller                      442.97 KB      1.31 MB            1.14 MB
notifications_index                    422.74 KB      1.30 MB            1.14 MB
online_users                           407.24 KB      1.20 MB            1.04 MB
openchat_installer                     413.10 KB      1.17 MB            1.00 MB
proposal_validation                    182.92 KB    538.33 KB          473.11 KB
proposals_bot                          788.65 KB      2.75 MB            2.52 MB
registry                               703.99 KB      2.19 MB            1.84 MB
sign_in_with_email                     448.74 KB      1.28 MB            1.00 MB
sign_in_with_ethereum                  438.36 KB      1.27 MB          958.73 KB
sign_in_with_solana                    429.44 KB      1.23 MB          926.57 KB
sns_wasm                               622.35 KB      1.99 MB            1.82 MB
storage_bucket                         472.41 KB      1.44 MB            1.27 MB
storage_index                          520.75 KB      1.56 MB            1.38 MB
translations                           416.26 KB      1.25 MB            1.09 MB
user                                     2.43 MB     11.03 MB           10.72 MB
user_index                               2.13 MB      8.38 MB            7.52 MB
```