### PR TITLE
Split UserIndexEvent enum to avoid exceeding function complexity limit

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Allow specifying which inner composite gate to check ([#8987](https://github.com/open-chat-labs/open-chat/pull/8987))
+- Split UserIndexEvent enum to avoid exceeding function complexity limit ([#9022](https://github.com/open-chat-labs/open-chat/pull/9022))
 
 ## [[2.0.1948](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1948-local_user_index)] - 2026-01-14
 

--- a/backend/canisters/local_user_index/api/src/lib.rs
+++ b/backend/canisters/local_user_index/api/src/lib.rs
@@ -23,18 +23,23 @@ pub use queries::*;
 pub use updates::*;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum UserIndexEvent {
-    UsernameChanged(UsernameChanged),
-    DisplayNameChanged(DisplayNameChanged),
-    PhoneNumberConfirmed(PhoneNumberConfirmed),
-    StorageUpgraded(StorageUpgraded),
-    UserRegistered(UserRegistered),
+pub enum UserIndexBotEvent {
     BotRegistered(BotRegistered),
     BotPublished(BotPublished),
     BotUpdated(BotUpdated),
     BotRemoved(BotRemoved),
     BotUninstall(BotInstallationLocation, UserId),
     BotUpdateInstallation(BotInstallationLocation, BotDefinitionUpdate),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum UserIndexEvent {
+    UsernameChanged(UsernameChanged),
+    DisplayNameChanged(DisplayNameChanged),
+    PhoneNumberConfirmed(PhoneNumberConfirmed),
+    StorageUpgraded(StorageUpgraded),
+    UserRegistered(UserRegistered),
+    BotEvent(Box<UserIndexBotEvent>),
     PlatformOperatorStatusChanged(PlatformOperatorStatusChanged),
     PlatformModeratorStatusChanged(PlatformModeratorStatusChanged),
     MaxConcurrentCanisterUpgradesChanged(MaxConcurrentCanisterUpgradesChanged),

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
@@ -4,7 +4,7 @@ use canister_api_macros::update;
 use canister_time::now_millis;
 use canister_tracing_macros::trace;
 use local_user_index_canister::c2c_notify_user_index_events::*;
-use local_user_index_canister::{UserIndexEvent, UserRegistered};
+use local_user_index_canister::{UserIndexBotEvent, UserIndexEvent, UserRegistered};
 use p256_key_pair::P256KeyPair;
 use stable_memory_map::StableMemoryMap;
 use std::cell::LazyCell;
@@ -91,43 +91,70 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
             );
         }
         UserIndexEvent::UserRegistered(ev) => handle_user_registered(ev, **now, state),
-        UserIndexEvent::BotRegistered(ev) => {
-            state.data.bots.add(
-                ev.user_principal,
-                ev.bot_id,
-                ev.owner_id,
-                ev.name.clone(),
-                ev.commands,
-                ev.endpoint,
-                ev.autonomous_config,
-                ev.default_subscriptions,
-                ev.permitted_install_location,
-                ev.data_encoding,
-            );
-
-            let this_canister_id = state.env.canister_id();
-            if ev.notification_canister == this_canister_id {
-                // This local_user_index canister has been nominated to notify the bot
-                state.push_bot_notification(
-                    BotNotification {
-                        event: BotEvent::Lifecycle(BotLifecycleEvent::Registered(BotRegisteredEvent {
-                            bot_id: ev.bot_id,
-                            bot_name: ev.name,
-                        })),
-                        recipients: vec![ev.bot_id],
-                        timestamp: **now,
-                    },
-                    this_canister_id,
-                    **now,
+        UserIndexEvent::BotEvent(ev) => match *ev {
+            UserIndexBotEvent::BotRegistered(ev) => {
+                state.data.bots.add(
+                    ev.user_principal,
+                    ev.bot_id,
+                    ev.owner_id,
+                    ev.name.clone(),
+                    ev.commands,
+                    ev.endpoint,
+                    ev.autonomous_config,
+                    ev.default_subscriptions,
+                    ev.permitted_install_location,
+                    ev.data_encoding,
                 );
+
+                let this_canister_id = state.env.canister_id();
+                if ev.notification_canister == this_canister_id {
+                    // This local_user_index canister has been nominated to notify the bot
+                    state.push_bot_notification(
+                        BotNotification {
+                            event: BotEvent::Lifecycle(BotLifecycleEvent::Registered(BotRegisteredEvent {
+                                bot_id: ev.bot_id,
+                                bot_name: ev.name,
+                            })),
+                            recipients: vec![ev.bot_id],
+                            timestamp: **now,
+                        },
+                        this_canister_id,
+                        **now,
+                    );
+                }
             }
-        }
-        UserIndexEvent::BotPublished(ev) => {
-            state.data.bots.publish(ev.bot_id);
-        }
-        UserIndexEvent::BotUpdated(ev) => {
-            state.data.bots.update(ev.bot_id, ev.owner_id, ev.endpoint, ev.definition);
-        }
+            UserIndexBotEvent::BotPublished(ev) => {
+                state.data.bots.publish(ev.bot_id);
+            }
+            UserIndexBotEvent::BotUpdated(ev) => {
+                state.data.bots.update(ev.bot_id, ev.owner_id, ev.endpoint, ev.definition);
+            }
+            UserIndexBotEvent::BotRemoved(ev) => {
+                state.data.bots.remove(&ev.user_id);
+            }
+            UserIndexBotEvent::BotUninstall(location, bot_id) => match location {
+                BotInstallationLocation::Community(community_id) => {
+                    state.push_event_to_community(community_id.into(), CommunityEvent::BotRemoved(bot_id), **now);
+                }
+                BotInstallationLocation::Group(group_id) => {
+                    state.push_event_to_group(group_id.into(), GroupEvent::BotRemoved(bot_id), **now);
+                }
+                BotInstallationLocation::User(user_id) => {
+                    state.push_event_to_user(user_id.into(), UserEvent::BotRemoved(bot_id), **now);
+                }
+            },
+            UserIndexBotEvent::BotUpdateInstallation(location, ev) => match location {
+                BotInstallationLocation::Community(community_id) => {
+                    state.push_event_to_community(community_id.into(), CommunityEvent::BotUpdated(ev), **now);
+                }
+                BotInstallationLocation::Group(group_id) => {
+                    state.push_event_to_group(group_id.into(), GroupEvent::BotUpdated(ev), **now);
+                }
+                BotInstallationLocation::User(user_id) => {
+                    state.push_event_to_user(user_id.into(), UserEvent::BotUpdated(Box::new(ev)), **now);
+                }
+            },
+        },
         UserIndexEvent::PlatformOperatorStatusChanged(ev) => {
             state
                 .data
@@ -223,9 +250,6 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
                 .global_users
                 .update_user_principal(update.old_principal, update.new_principal);
         }
-        UserIndexEvent::BotRemoved(ev) => {
-            state.data.bots.remove(&ev.user_id);
-        }
         UserIndexEvent::DeleteUser(ev) => {
             if state.data.local_users.contains(&ev.user_id) {
                 state.data.users_to_delete_queue.push_back(UserToDelete {
@@ -297,28 +321,6 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
                 state.data.global_users.insert_unique_person_proof(user.user_id, proof);
             }
         }
-        UserIndexEvent::BotUninstall(location, bot_id) => match location {
-            BotInstallationLocation::Community(community_id) => {
-                state.push_event_to_community(community_id.into(), CommunityEvent::BotRemoved(bot_id), **now);
-            }
-            BotInstallationLocation::Group(group_id) => {
-                state.push_event_to_group(group_id.into(), GroupEvent::BotRemoved(bot_id), **now);
-            }
-            BotInstallationLocation::User(user_id) => {
-                state.push_event_to_user(user_id.into(), UserEvent::BotRemoved(bot_id), **now);
-            }
-        },
-        UserIndexEvent::BotUpdateInstallation(location, ev) => match location {
-            BotInstallationLocation::Community(community_id) => {
-                state.push_event_to_community(community_id.into(), CommunityEvent::BotUpdated(ev), **now);
-            }
-            BotInstallationLocation::Group(group_id) => {
-                state.push_event_to_group(group_id.into(), GroupEvent::BotUpdated(ev), **now);
-            }
-            BotInstallationLocation::User(user_id) => {
-                state.push_event_to_user(user_id.into(), UserEvent::BotUpdated(Box::new(ev)), **now);
-            }
-        },
         UserIndexEvent::UserBlocked(user_id, blocked) => {
             state.data.blocked_users.insert((blocked, user_id), ());
         }

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Skip serializing fields with default values when fetching user data ([#8847](https://github.com/open-chat-labs/open-chat/pull/8847))
 - Store `hide_online_status` against each user ([#8848](https://github.com/open-chat-labs/open-chat/pull/8848))
+- Split UserIndexEvent enum to avoid exceeding function complexity limit ([#9022](https://github.com/open-chat-labs/open-chat/pull/9022))
 
 ## [[2.0.1947](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1947-user_index)] - 2026-01-14
 

--- a/backend/canisters/user_index/impl/src/jobs/sync_events_to_local_user_index_canisters.rs
+++ b/backend/canisters/user_index/impl/src/jobs/sync_events_to_local_user_index_canisters.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 use std::time::Duration;
 use tracing::trace;
 use types::CanisterId;
-use utils::canister::delay_if_should_retry_failed_c2c_call;
+// use utils::canister::delay_if_should_retry_failed_c2c_call;
 
 thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
@@ -61,8 +61,11 @@ async fn process_batch(batch: Vec<(CanisterId, Vec<LocalUserIndexEvent>)>) {
 
 async fn sync_events(canister_id: CanisterId, events: Vec<LocalUserIndexEvent>) {
     let args = local_user_index_canister::c2c_notify_user_index_events::Args { events: events.clone() };
-    if let Err(error) = local_user_index_canister_c2c_client::c2c_notify_user_index_events(canister_id, &args).await
-        && delay_if_should_retry_failed_c2c_call(error.reject_code(), error.message()).is_some()
+    if let Err(_error) = local_user_index_canister_c2c_client::c2c_notify_user_index_events(canister_id, &args).await
+    // Temporarily commenting this out, so that if the LocalUserIndex fails to deserialize the
+    // events we will retry them, this is because we have changed the events in a backwards
+    // incompatible way
+    // && delay_if_should_retry_failed_c2c_call(error.reject_code(), error.message()).is_some()
     {
         mutate_state(|state| {
             state

--- a/backend/canisters/user_index/impl/src/updates/publish_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/publish_bot.rs
@@ -2,7 +2,7 @@ use crate::guards::caller_is_governance_principal;
 use crate::{RuntimeState, mutate_state};
 use canister_api_macros::{proposal, update};
 use canister_tracing_macros::trace;
-use local_user_index_canister::{BotPublished, UserIndexEvent};
+use local_user_index_canister::{BotPublished, UserIndexBotEvent, UserIndexEvent};
 use user_index_canister::publish_bot::{Args, Response};
 
 #[proposal(guard = "caller_is_governance_principal")]
@@ -26,7 +26,12 @@ fn publish_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
         return Response::NotFound;
     }
 
-    state.push_event_to_all_local_user_indexes(UserIndexEvent::BotPublished(BotPublished { bot_id: args.bot_id }), None);
+    state.push_event_to_all_local_user_indexes(
+        UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotPublished(BotPublished {
+            bot_id: args.bot_id,
+        }))),
+        None,
+    );
 
     Response::Success
 }

--- a/backend/canisters/user_index/impl/src/updates/register_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/register_bot.rs
@@ -7,7 +7,7 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use constants::{ONE_GB, USER_LIMIT};
 use event_store_producer::EventBuilder;
-use local_user_index_canister::{BotRegistered, UserIndexEvent};
+use local_user_index_canister::{BotRegistered, UserIndexBotEvent, UserIndexEvent};
 use rand::Rng;
 use std::collections::HashMap;
 use storage_index_canister::add_or_update_users::UserConfig;
@@ -82,7 +82,7 @@ fn register_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
     let notification_canister = state.get_random_local_user_index_canister();
 
     state.push_event_to_all_local_user_indexes(
-        UserIndexEvent::BotRegistered(BotRegistered {
+        UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotRegistered(BotRegistered {
             bot_id,
             owner_id,
             user_principal: args.principal,
@@ -94,7 +94,7 @@ fn register_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
             default_subscriptions: args.definition.default_subscriptions.clone(),
             data_encoding: args.definition.data_encoding.unwrap_or_default(),
             notification_canister,
-        }),
+        }))),
         None,
     );
 

--- a/backend/canisters/user_index/impl/src/updates/remove_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/remove_bot.rs
@@ -3,7 +3,7 @@ use crate::{RuntimeState, jobs, mutate_state, read_state};
 use canister_api_macros::{proposal, update};
 use canister_tracing_macros::trace;
 use constants::OPENCHAT_BOT_USER_ID;
-use local_user_index_canister::{BotRemoved, UserIndexEvent};
+use local_user_index_canister::{BotRemoved, UserIndexBotEvent, UserIndexEvent};
 use types::UserId;
 use user_index_canister::remove_bot::{Response::*, *};
 
@@ -49,18 +49,18 @@ fn remove_bot_impl(args: Args, deleted_by: Option<UserId>, state: &mut RuntimeSt
     state.delete_user(args.bot_id, deleted_by.is_some());
 
     state.push_event_to_all_local_user_indexes(
-        UserIndexEvent::BotRemoved(BotRemoved {
+        UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotRemoved(BotRemoved {
             user_id: args.bot_id,
             deleted_by: deleted_by.unwrap_or(OPENCHAT_BOT_USER_ID),
-        }),
+        }))),
         None,
     );
 
     for (location, details) in bot.installations.iter() {
-        state
-            .data
-            .user_index_event_sync_queue
-            .push(details.local_user_index, UserIndexEvent::BotUninstall(*location, args.bot_id));
+        state.data.user_index_event_sync_queue.push(
+            details.local_user_index,
+            UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotUninstall(*location, args.bot_id))),
+        );
     }
 
     jobs::sync_events_to_local_user_index_canisters::try_run_now(state);

--- a/backend/canisters/user_index/impl/src/updates/update_bot.rs
+++ b/backend/canisters/user_index/impl/src/updates/update_bot.rs
@@ -6,7 +6,7 @@ use crate::{
 use candid::Principal;
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
-use local_user_index_canister::{BotUpdated, UserIndexEvent};
+use local_user_index_canister::{BotUpdated, UserIndexBotEvent, UserIndexEvent};
 use types::{BotDefinitionUpdate, OptionUpdate};
 use url::Url;
 use user_index_canister::update_bot::{Response::*, *};
@@ -79,12 +79,12 @@ fn update_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
         let bot = state.data.users.get_bot(&args.bot_id).unwrap();
 
         state.push_event_to_all_local_user_indexes(
-            UserIndexEvent::BotUpdated(BotUpdated {
+            UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotUpdated(BotUpdated {
                 bot_id: args.bot_id,
                 owner_id: bot.owner,
                 endpoint: bot.endpoint.clone(),
                 definition,
-            }),
+            }))),
             None,
         );
 
@@ -94,7 +94,10 @@ fn update_bot_impl(args: Args, state: &mut RuntimeState) -> Response {
             for (location, details) in bot.installations.iter() {
                 state.data.user_index_event_sync_queue.push(
                     details.local_user_index,
-                    UserIndexEvent::BotUpdateInstallation(*location, installation_update.clone()),
+                    UserIndexEvent::BotEvent(Box::new(UserIndexBotEvent::BotUpdateInstallation(
+                        *location,
+                        installation_update.clone(),
+                    ))),
                 );
             }
         }


### PR DESCRIPTION
UserIndex must go out before LocalUserIndex