### PR TITLE
feat: enable saving downloaded media to device on native apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7569,6 +7569,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-android-fs",
  "tauri-plugin-deep-link",
  "tauri-plugin-devtools",
  "tauri-plugin-notification",
@@ -10707,6 +10708,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_async"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b815ef8e053247ad785b136d233ee9c9872eeda5319f2719d57cac88270c3dd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10974,6 +10986,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-android-fs"
+version = "28.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e49f103e69e0f35e10983961135128e7fa5d38ec4517efecb0e6582d4c1d8"
+dependencies = [
+ "base64 0.22.1",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sync_async",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11022,6 +11053,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation 0.3.1",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.16",
+ "toml 0.9.5",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11052,6 +11107,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
+ "tauri-plugin-android-fs",
  "thiserror 2.0.16",
  "tokio",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,7 @@ subenum = "1.1.2"
 syn = "2"
 tauri = { version = "2.11.1", features = ["protocol-asset"] }
 tauri-build = "2.5.3"
+tauri-plugin-android-fs = "28.1.0"
 tauri-plugin-devtools = "2.0.1"
 tauri-plugin-deep-link = "2.4.6"
 tauri-plugin-notification = "2.3.3"

--- a/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
@@ -53,6 +53,8 @@
     import { copyToClipboard } from "../../utils/urls";
     import Bitcoin from "../icons/Bitcoin.svelte";
     import Translatable from "../Translatable.svelte";
+    import { saveMediaToDevice } from "tauri-plugin-oc-api";
+    import { getProxyAdjustedBlobUrl } from "../../utils/media";
 
     const client = getContext<OpenChat>("client");
 
@@ -197,42 +199,124 @@
         );
     }
 
-    function downloadName(url: string, disposition: string | null) {
-        let filename: string = msg.content.kind;
-        if (disposition && disposition.includes("filename=")) {
-            filename = disposition.split("filename=")[1].split(";")[0].replace(/"/g, "");
-        } else {
-            filename = new URL(url).pathname.split("/").pop() || filename;
+    // Simple MIME -> extension mapping - add more as required!
+    const MIME_EXTENSION_MAP: Record<string, string> = {
+        "image/jpeg": "jpg",
+        "image/png": "png",
+        "image/gif": "gif",
+        "image/webp": "webp",
+        "video/mp4": "mp4",
+        "video/webm": "webm",
+        "audio/mpeg": "mp3",
+        "audio/ogg": "ogg",
+        "audio/wav": "wav",
+        "application/pdf": "pdf",
+    };
+
+    function getExtensionFromMime(mime: string): string | null {
+        return MIME_EXTENSION_MAP[mime] || null;
+    }
+
+    function getFilenameFromResponse(res: Response, url: string, mimeType: string): string {
+        const disposition = res.headers.get("content-disposition");
+
+        // Primary... try from content-disposition
+        if (disposition) {
+            // Try modern filename* (UTF-8)
+            const utf8Match = /filename\*=UTF-8''(.+?)(?:;|$)/i.exec(disposition);
+            if (utf8Match) {
+                try {
+                    return decodeURIComponent(utf8Match[1].trim());
+                } catch {}
+            }
+
+            // Try regular filename=
+            const filenameMatch = /filename\s*=\s*["']?([^"';]+)["']?/i.exec(disposition);
+            if (filenameMatch) {
+                return filenameMatch[1].trim();
+            }
         }
 
+        // Fallback... extract from URL if available
+        try {
+            const urlObj = new URL(url);
+            let filename = urlObj.pathname.split("/").pop()?.split("?")[0] || "";
+            if (filename) return filename;
+        } catch {}
+
+        // Default...
+        const defaultName = `${msg.content.kind}_download_${Date.now()}`;
+        const ext = getExtensionFromMime(mimeType);
+        return ext ? `${defaultName}.${ext}` : defaultName;
+    }
+
+    type DownloadMeta = { mimeType: string; contentKind: "image" | "video" | "file" };
+
+    function getDownloadMeta(res: Response): DownloadMeta | undefined {
         switch (msg.content.kind) {
-            case "audio_content":
-            case "video_content":
             case "image_content":
-                return msg.content.caption?.split(" ")?.join("_").slice(0, 100) ?? filename;
+                return { mimeType: msg.content.mimeType, contentKind: "image" };
+            case "giphy_content":
+                return { mimeType: "image/gif", contentKind: "image" };
+            case "video_content":
+                return { mimeType: msg.content.mimeType, contentKind: "video" };
             case "file_content":
-                return msg.content.name;
+                return { mimeType: msg.content.mimeType, contentKind: "file" };
             default:
-                return filename;
+                const mime = res.headers.get("content-type")?.split(";")[0].trim();
+                return mime ? { mimeType: mime, contentKind: "file" } : undefined;
         }
     }
 
-    async function download(url: string) {
-        if (!url) return;
-
+    async function download(urlArg: string) {
         try {
-            const res = await fetch(url);
-            if (!res.ok) {
-                console.error("Unable to download media", res.status, res.statusText);
-                toastStore.showFailureToast(i18nKey("Unable to download media"));
+            const url = getProxyAdjustedBlobUrl(urlArg);
+
+            if (!url) {
+                throw new Error("Cannot download this content!");
             }
-            const blob = await res.blob();
-            const objectUrl = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = objectUrl;
-            a.download = downloadName(url, res.headers.get("content-disposition"));
-            a.click();
-            URL.revokeObjectURL(objectUrl);
+
+            const res = await fetch(url);
+
+            const meta = getDownloadMeta(res);
+            if (!meta) {
+                throw new Error("Unknown download mime type or kind!");
+            }
+            const { mimeType, contentKind } = meta;
+
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status} ${res.statusText}`);
+            }
+
+            const filename =
+                msg.content.kind === "file_content"
+                    ? msg.content.name
+                    : getFilenameFromResponse(res, url, mimeType);
+
+            if (client.isNativeApp()) {
+                // This should work for a device, by using a tauri command
+                // to save the file bytes to the correct location.
+                await saveMediaToDevice({
+                    kind: contentKind,
+                    filename,
+                    // TODO: sending raw bytes to rust may be memory heavy for
+                    // large videos, since bytes get serialised via Tauri's IPC.
+                    // Consider fetching from URL in Rust command!
+                    data: new Uint8Array(await res.arrayBuffer()),
+                    mimeType,
+                });
+            } else {
+                const blob = await res.blob();
+                const objectUrl = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = objectUrl;
+                a.download = filename;
+                a.click();
+                URL.revokeObjectURL(objectUrl);
+            }
+
+            // TODO expand this and show the path where the file was saved!
+            toastStore.showSuccessToast(i18nKey("File downloaded!"));
         } catch (err) {
             console.error("Unable to download media", err);
             toastStore.showFailureToast(i18nKey("Unable to download media"));

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { workspace = true, features = [] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tauri = { workspace = true, features = ["protocol-asset"] }
+tauri-plugin-android-fs = { workspace = true }
 tauri-plugin-deep-link = { workspace = true }
 tauri-plugin-devtools = { workspace = true }
 tauri-plugin-notification = { workspace = true }

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -86,4 +86,7 @@
 
         <receiver android:name=".NotificationDismissReceiver" />
     </application>
+    <!-- ANDROID FS PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
+    
+    <!-- ANDROID FS PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
 </manifest>

--- a/frontend/src-tauri/gen/android/app/tauri.build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/tauri.build.gradle.kts
@@ -3,6 +3,7 @@ val implementation by configurations
 dependencies {
   implementation("androidx.lifecycle:lifecycle-process:2.10.0")
   implementation(project(":tauri-android"))
+  implementation(project(":tauri-plugin-android-fs"))
   implementation(project(":tauri-plugin-deep-link"))
   implementation(project(":tauri-plugin-notification"))
   implementation(project(":tauri-plugin-oc"))

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_oc::init())
+        .plugin(tauri_plugin_android_fs::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/frontend/tauri-plugin-oc/Cargo.toml
+++ b/frontend/tauri-plugin-oc/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+tauri-plugin-android-fs = { workspace = true }
 futures-util = "0.3"
 zip = "2.2.2"
 semver = "1.0"

--- a/frontend/tauri-plugin-oc/build.rs
+++ b/frontend/tauri-plugin-oc/build.rs
@@ -15,6 +15,7 @@ const COMMANDS: &[&str] = &[
     "load_recent_media",
     "enable_viewport_resize",
     "disable_viewport_resize",
+    "save_media",
 ];
 
 fn main() {

--- a/frontend/tauri-plugin-oc/guest-js/commands/saveMedia.ts
+++ b/frontend/tauri-plugin-oc/guest-js/commands/saveMedia.ts
@@ -1,0 +1,12 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type SaveMediaRequest = {
+    kind: string;
+    filename: string;
+    data: Uint8Array;
+    mimeType: string;
+};
+
+export async function saveMediaToDevice(payload: SaveMediaRequest): Promise<void> {
+    return invoke<void>("plugin:oc|save_media", { payload });
+}

--- a/frontend/tauri-plugin-oc/guest-js/index.ts
+++ b/frontend/tauri-plugin-oc/guest-js/index.ts
@@ -12,6 +12,7 @@ export {
     RecentMedia,
     RecentMediaResponse,
 } from "./commands/loadRecentMedia";
+export { saveMediaToDevice, type SaveMediaRequest } from "./commands/saveMedia";
 export { enableViewportResize } from "./commands/enableViewportResize";
 export { disableViewportResize } from "./commands/disableViewportResize";
 export * from "./models/credentials";

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/save_media.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/save_media.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-save-media"
+description = "Enables the save_media command without any pre-configured scope."
+commands.allow = ["save_media"]
+
+[[permission]]
+identifier = "deny-save-media"
+description = "Denies the save_media command without any pre-configured scope."
+commands.deny = ["save_media"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
@@ -20,6 +20,7 @@ Default permissions for the plugin
 - `allow-load-recent-media`
 - `allow-enable-viewport-resize`
 - `allow-disable-viewport-resize`
+- `allow-save-media`
 
 ## Permission Table
 
@@ -338,6 +339,32 @@ Enables the restart_app command without any pre-configured scope.
 <td>
 
 Denies the restart_app command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:allow-save-media`
+
+</td>
+<td>
+
+Enables the save_media command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-save-media`
+
+</td>
+<td>
+
+Denies the save_media command without any pre-configured scope.
 
 </td>
 </tr>

--- a/frontend/tauri-plugin-oc/permissions/default.toml
+++ b/frontend/tauri-plugin-oc/permissions/default.toml
@@ -17,4 +17,5 @@ permissions = [
     "allow-load-recent-media",
     "allow-enable-viewport-resize",
     "allow-disable-viewport-resize",
+    "allow-save-media",
 ]

--- a/frontend/tauri-plugin-oc/permissions/schemas/schema.json
+++ b/frontend/tauri-plugin-oc/permissions/schemas/schema.json
@@ -439,6 +439,18 @@
           "markdownDescription": "Denies the restart_app command without any pre-configured scope."
         },
         {
+          "description": "Enables the save_media command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-save-media",
+          "markdownDescription": "Enables the save_media command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the save_media command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-save-media",
+          "markdownDescription": "Denies the save_media command without any pre-configured scope."
+        },
+        {
           "description": "Enables the show_notification command without any pre-configured scope.",
           "type": "string",
           "const": "allow-show-notification",
@@ -487,10 +499,10 @@
           "markdownDescription": "Denies the svelte_ready command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`"
         }
       ]
     }

--- a/frontend/tauri-plugin-oc/src/commands.rs
+++ b/frontend/tauri-plugin-oc/src/commands.rs
@@ -106,3 +106,75 @@ pub(crate) async fn enable_viewport_resize<R: Runtime>(app: AppHandle<R>) -> Res
 pub(crate) async fn disable_viewport_resize<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     app.oc().toggle_viewport_resize(false)
 }
+
+// This command is only used to save files to local public storage.
+//
+// Note: this command is not handled by kotlin code.
+
+#[command]
+pub(crate) async fn save_media<R: Runtime>(
+    _app: AppHandle<R>,
+    payload: SaveMediaRequest,
+) -> Result<()> {
+    let SaveMediaRequest {
+        kind,
+        filename,
+        data,
+        mime_type,
+    } = payload;
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    let _ = (&kind, &filename, &data, &mime_type);
+
+    #[cfg(target_os = "android")]
+    {
+        use tauri_plugin_android_fs::{
+            AndroidFsExt, PublicDir, PublicGeneralPurposeDir, PublicImageDir, PublicVideoDir,
+        };
+        let api = _app.android_fs_async();
+        let storage = api.public_storage();
+
+        storage.request_permission().await?;
+
+        let pub_dir = match kind.as_str() {
+            "image" => PublicDir::Image(PublicImageDir::Pictures),
+            "video" => PublicDir::Video(PublicVideoDir::Movies),
+            _ => PublicDir::GeneralPurpose(PublicGeneralPurposeDir::Download),
+        };
+
+        println!("OC_LOG: Download file: {:?}, {:?}", pub_dir, filename);
+
+        storage
+            .write_new(None, pub_dir, &filename, Some(&mime_type), &data)
+            .await?;
+    }
+
+    // iOS saves to app's sandbox, to save to public camera roll we need to use
+    // Photos framework on the Swift side, and add NSPhotoLibraryAddUsageDescription
+    // to Info.plist
+    #[cfg(target_os = "ios")]
+    {
+        use std::fs;
+        use std::path::Path;
+
+        let safe_filename = Path::new(&filename)
+            .file_name()
+            .ok_or_else(|| crate::Error::IOSInvalidFileName)?;
+
+        let base_dir = _app.path().document_dir()?;
+        let sub_dir = match kind.as_str() {
+            "image" => base_dir.join("Pictures"),
+            "video" => base_dir.join("Videos"),
+            _ => base_dir.clone(),
+        };
+
+        if !sub_dir.exists() {
+            fs::create_dir_all(&sub_dir).map_err(crate::Error::Io)?;
+        }
+
+        let file_path = sub_dir.join(safe_filename);
+        fs::write(&file_path, &data).map_err(crate::Error::Io)?;
+    }
+
+    Ok(())
+}

--- a/frontend/tauri-plugin-oc/src/error.rs
+++ b/frontend/tauri-plugin-oc/src/error.rs
@@ -6,6 +6,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    AndroidFs(#[from] tauri_plugin_android_fs::Error),
+
+    #[error("iOS: downloading a file, invalid file name")]
+    IOSInvalidFileName,
+
     #[cfg(mobile)]
     #[error(transparent)]
     PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),

--- a/frontend/tauri-plugin-oc/src/lib.rs
+++ b/frontend/tauri-plugin-oc/src/lib.rs
@@ -54,6 +54,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         commands::load_recent_media,
         commands::enable_viewport_resize,
         commands::disable_viewport_resize,
+        commands::save_media,
     ]);
 
     // Only register the custom protocol handler when not in debug mode

--- a/frontend/tauri-plugin-oc/src/models.rs
+++ b/frontend/tauri-plugin-oc/src/models.rs
@@ -86,3 +86,12 @@ pub struct RecentMedia {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct EmptyPayload;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveMediaRequest {
+    pub kind: String,
+    pub filename: String,
+    pub data: Vec<u8>,
+    pub mime_type: String,
+}


### PR DESCRIPTION
- Add a save_media Tauri command in tauri-plugin-oc that writes file bytes to the Android public storage (Pictures/Movies/Downloads) and to the iOS app sandbox.
- Wire the new tauri-plugin-android-fs plugin into the workspace, the Tauri app, and the Android Gradle config.
- Expose saveMediaToDevice from the plugin's JS surface and register the matching allow-save-media permission.
- Refactor download in ChatMessageOptions.svelte to resolve a typed { mimeType, contentKind } via a helper, branch on client.isNativeApp(), and call saveMediaToDevice on native or fall back to the browser anchor download on web.
- Replace the brittle content-disposition parser with getFilenameFromResponse, supporting RFC 5987 filename*=UTF-8'', quoted filename=, URL fallback, and a MIME-derived extension.
- Show a success toast on completed downloads and surface a clearer failure message when the MIME type or content kind cannot be resolved.