### PR TITLE
refactor: small follow-ups to the media download flow

### DIFF
--- a/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
@@ -277,17 +277,15 @@
             }
 
             const res = await fetch(url);
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status} ${res.statusText}`);
+            }
 
             const meta = getDownloadMeta(res);
             if (!meta) {
                 throw new Error("Unknown download mime type or kind!");
             }
             const { mimeType, contentKind } = meta;
-
-            if (!res.ok) {
-                throw new Error(`HTTP ${res.status} ${res.statusText}`);
-            }
-
             const filename =
                 msg.content.kind === "file_content"
                     ? msg.content.name

--- a/frontend/tauri-plugin-oc/Cargo.toml
+++ b/frontend/tauri-plugin-oc/Cargo.toml
@@ -6,17 +6,17 @@ exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
 links = "tauri-plugin-oc"
 
 [dependencies]
+futures-util = "0.3"
+mime_guess = "2.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+semver = "1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
-thiserror = { workspace = true }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 tauri-plugin-android-fs = { workspace = true }
-futures-util = "0.3"
-zip = "2.2.2"
-semver = "1.0"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
-mime_guess = "2.0"
+zip = "2.2.2"
 
 [build-dependencies]
 tauri-plugin = { version = "2.4.0", features = ["build"] }

--- a/frontend/tauri-plugin-oc/src/commands.rs
+++ b/frontend/tauri-plugin-oc/src/commands.rs
@@ -144,8 +144,10 @@ pub(crate) async fn save_media<R: Runtime>(
 
         println!("OC_LOG: Download file: {:?}, {:?}", pub_dir, filename);
 
+        let mime = (!mime_type.trim().is_empty()).then_some(mime_type.as_str());
+
         storage
-            .write_new(None, pub_dir, &filename, Some(&mime_type), &data)
+            .write_new(None, pub_dir, &filename, mime, &data)
             .await?;
     }
 
@@ -154,8 +156,8 @@ pub(crate) async fn save_media<R: Runtime>(
     // to Info.plist
     #[cfg(target_os = "ios")]
     {
-        use std::fs;
         use std::path::Path;
+        use tokio::fs;
 
         let safe_filename = Path::new(&filename)
             .file_name()
@@ -168,12 +170,11 @@ pub(crate) async fn save_media<R: Runtime>(
             _ => base_dir.clone(),
         };
 
-        if !sub_dir.exists() {
-            fs::create_dir_all(&sub_dir).map_err(crate::Error::Io)?;
-        }
+        // create_dir_all is idempotent
+        fs::create_dir_all(&sub_dir).await?;
 
         let file_path = sub_dir.join(safe_filename);
-        fs::write(&file_path, &data).map_err(crate::Error::Io)?;
+        fs::write(&file_path, &data).await?;
     }
 
     Ok(())

--- a/frontend/tauri-plugin-oc/src/error.rs
+++ b/frontend/tauri-plugin-oc/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     #[error(transparent)]
     AndroidFs(#[from] tauri_plugin_android_fs::Error),
 
-    #[error("iOS: downloading a file, invalid file name")]
+    #[error("iOS: invalid file name for download")]
     IOSInvalidFileName,
 
     #[cfg(mobile)]


### PR DESCRIPTION
- Move the HTTP res.ok check before MIME/kind resolution in download so failed responses fail fast without unnecessary work.
- Switch the iOS save_media branch to async tokio::fs for create_dir_all and write, and drop the redundant exists() check since create_dir_all is idempotent.
- Treat an empty mime_type as absent on the Android save_media branch, passing None to write_new instead of an empty string.
- Sort the tauri-plugin-oc Cargo.toml dependencies alphabetically and tighten the wording of the IOSInvalidFileName error message.