### PR TITLE
Rehydrate message previews during agent message loading

### DIFF
--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -681,7 +681,8 @@
                                 {onRemovePreview}
                                 {onRegisterVote}
                                 {onExpandMessage}
-                                ogPreviews={msg.ogPreviews} />
+                                ogPreviews={msg.ogPreviews}
+                                messagePreviews={msg.messagePreviews} />
 
                             {#if !inert}
                                 <TimeAndTicks

--- a/frontend/app/src/components/home/ChatMessageContent.svelte
+++ b/frontend/app/src/components/home/ChatMessageContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { MessageContent, MessageContext, OgPreview } from "openchat-client";
+    import type { MessageContent, MessageContext, OgPreview, RehydratedMessagePreview } from "openchat-client";
     import { i18nKey } from "../../i18n/i18n";
     import AudioContent from "./AudioContent.svelte";
     import BlockedContent from "./BlockedContent.svelte";
@@ -48,6 +48,7 @@
         onRemovePreview?: (url: string) => void;
         onRegisterVote?: (vote: { type: "delete" | "register"; answerIndex: number }) => void;
         ogPreviews?: OgPreview[];
+        messagePreviews?: RehydratedMessagePreview[];
     }
 
     let {
@@ -74,6 +75,7 @@
         onRemovePreview,
         onRegisterVote,
         ogPreviews = [],
+        messagePreviews = [],
     }: Props = $props();
 </script>
 
@@ -87,7 +89,8 @@
         {edited}
         {blockLevelMarkdown}
         {onRemovePreview}
-        {ogPreviews} />
+        {ogPreviews}
+        {messagePreviews} />
 {:else if content.kind === "image_content"}
     <ImageContent
         {edited}

--- a/frontend/app/src/components/home/LinkPreviews.svelte
+++ b/frontend/app/src/components/home/LinkPreviews.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { classifyUrl, extractUrls, iconSize, type LinkPreview } from "openchat-client";
-    import type { OgPreview } from "openchat-shared";
+    import { iconSize } from "openchat-client";
+    import type { OgPreview, RehydratedMessagePreview } from "openchat-shared";
     import CloseIcon from "svelte-material-icons/Close.svelte";
     import { rtlStore } from "../../stores/rtl";
     import GenericPreviewComponent from "./GenericPreview.svelte";
     import MessagePreviewComponent from "./MessagePreview.svelte";
 
     interface Props {
-        text: string;
+        messagePreviews: RehydratedMessagePreview[];
         ogPreviews: OgPreview[];
         intersecting: boolean;
         pinned: boolean;
@@ -16,51 +16,40 @@
         onRemove?: (url: string) => void;
     }
 
-    let { text, ogPreviews, intersecting, me, onRemove }: Props = $props();
-
-    let ogPreviewMap = $derived(new Map(ogPreviews.map((p) => [p.url, p])));
-
-    let urls = $derived<LinkPreview[]>(
-        extractUrls(text).reduce((urls, url) => {
-            const u = ogPreviewMap.get(url) ?? classifyUrl(url);
-            if (u !== undefined) {
-                urls.push(u);
-            }
-            return urls;
-        }, [] as LinkPreview[]),
-    );
+    let { messagePreviews, ogPreviews, intersecting, me, onRemove }: Props = $props();
 
     let rtl = $rtlStore;
 
-    function removePreview(preview: LinkPreview | undefined) {
-        if (preview) {
-            onRemove?.(preview.url);
-        }
+    function removePreview(url: string) {
+        onRemove?.(url);
     }
 </script>
 
-{#each urls as p (p.url)}
-    <div class="preview" class:me>
-        {#if me && onRemove}
-            <div class="remove-wrapper" class:rtl>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div class="remove" onclick={() => removePreview(p)}>
-                    <CloseIcon viewBox="0 0 24 24" size={$iconSize} color={"var(--button-txt)"} />
-                </div>
+{#snippet remove(url: string)}
+    {#if me && onRemove}
+        <div class="remove-wrapper" class:rtl>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div class="remove" onclick={() => removePreview(url)}>
+                <CloseIcon viewBox="0 0 24 24" size={$iconSize} color={"var(--button-txt)"} />
             </div>
-        {/if}
+        </div>
+    {/if}
+{/snippet}
+
+{#each messagePreviews as p (p.url)}
+    <div class="preview" class:me>
+        {@render remove(p.url)}
         <div class="inner" class:me>
-            {#if p.kind === "message"}
-                <MessagePreviewComponent
-                    url={p.url}
-                    chatId={p.chatId}
-                    threadRootMessageIndex={p.threadRootMessageIndex}
-                    messageIndex={p.messageIndex}
-                    {intersecting} />
-            {:else if p.kind === "opengraph"}
-                <GenericPreviewComponent {me} ogPreview={p} />
-            {/if}
+            <MessagePreviewComponent preview={p} {intersecting} />
+        </div>
+    </div>
+{/each}
+{#each ogPreviews as p (p.url)}
+    <div class="preview" class:me>
+        {@render remove(p.url)}
+        <div class="inner" class:me>
+            <GenericPreviewComponent {me} ogPreview={p} />
         </div>
     </div>
 {/each}

--- a/frontend/app/src/components/home/MessagePreview.svelte
+++ b/frontend/app/src/components/home/MessagePreview.svelte
@@ -1,142 +1,92 @@
 <script lang="ts">
-    import { trackedEffect } from "@src/utils/effects.svelte";
     import {
         allUsersStore,
         AvatarSize,
         currentUserIdStore,
-        eventListScrolling,
-        isSuccessfulEventsResponse,
         OpenChat,
         selectedChatWebhooksStore,
         selectedCommunityMembersStore,
-        type MessageContent,
-        type MultiUserChatIdentifier,
-        type OgPreview,
+        type RehydratedMessagePreview,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import Avatar from "../Avatar.svelte";
     import ChatMessageContent from "./ChatMessageContent.svelte";
 
-    type Preview = {
-        content: MessageContent;
-        senderId: string;
-        me: boolean;
-        messageId: bigint;
-        edited: boolean;
-        displayName: string;
-        ogPreviews: OgPreview[];
-    };
-
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        url: string;
-        chatId: MultiUserChatIdentifier;
-        threadRootMessageIndex: number | undefined;
-        messageIndex: number;
+        preview: RehydratedMessagePreview;
         intersecting: boolean;
-        onRendered?: (url: string) => void;
     }
 
-    const { url, chatId, threadRootMessageIndex, messageIndex, intersecting, onRendered }: Props =
-        $props();
+    const { preview, intersecting }: Props = $props();
 
-    let previewPromise: Promise<Preview | undefined> | undefined = $state();
-    let rendered = $state(false);
-
-    async function loadPreview(): Promise<Preview | undefined> {
-        const result = await client.getMessagesByMessageIndex(chatId, threadRootMessageIndex, [
-            messageIndex,
-        ]);
-
-        if (!isSuccessfulEventsResponse(result)) {
-            return;
-        }
-
-        const message = result.events[0].event;
-        const me = message.sender === $currentUserIdStore;
-
-        return {
-            content: message.content,
-            senderId: message.sender,
-            me,
-            messageId: message.messageId,
-            edited: message.edited,
-            displayName: me
-                ? client.toTitleCase($_("you"))
-                : client.getDisplayName(
-                      message.sender,
-                      $selectedCommunityMembersStore,
-                      $selectedChatWebhooksStore,
-                  ),
-            ogPreviews: message.ogPreviews,
-        };
-    }
-
-    trackedEffect("message-preview", () => {
-        // make sure we only actually *load* the preview once
-        previewPromise = previewPromise ?? loadPreview();
-        previewPromise.then((preview) => {
-            if (preview && intersecting && !$eventListScrolling) {
-                rendered = true;
-                onRendered?.(url);
-            }
-        });
-    });
+    let me = $derived(preview.message.sender === $currentUserIdStore);
+    let displayName = $derived(
+        me
+            ? client.toTitleCase($_("you"))
+            : client.getDisplayName(
+                  preview.message.sender,
+                  $selectedCommunityMembersStore,
+                  $selectedChatWebhooksStore,
+              ),
+    );
 </script>
 
-{#if rendered}
-    {#await previewPromise then preview}
-        {#if preview}
-            <a href={url}>
-                <div
-                    class="wrapper"
-                    class:me={preview.me}
-                    class:p2pSwap={preview.content.kind === "p2p_swap_content"}>
-                    <div class="title">
-                        <Avatar
-                            url={client.userAvatarUrl($allUsersStore.get(preview.senderId))}
-                            userId={preview.senderId}
-                            size={AvatarSize.Tiny} />
-                        <h4
-                            class="username"
-                            class:text-content={preview.content.kind === "text_content"}>
-                            {preview.displayName}
-                        </h4>
-                    </div>
-                    <div class="inert">
-                        <ChatMessageContent
-                            me={preview.me}
-                            readonly
-                            messageContext={{
-                                chatId,
-                                threadRootMessageIndex,
-                            }}
-                            {intersecting}
-                            messageId={preview.messageId}
-                            {messageIndex}
-                            senderId={preview.senderId}
-                            edited={preview.edited}
-                            fill={false}
-                            failed={false}
-                            blockLevelMarkdown
-                            truncate
-                            reply
-                            content={preview.content}
-                            ogPreviews={preview.ogPreviews} />
-                    </div>
-                </div>
-            </a>
-        {/if}
-    {/await}
-{/if}
+<a href={preview.url}>
+    <div
+        class="wrapper"
+        class:me
+        class:p2pSwap={preview.message.content.kind === "p2p_swap_content"}>
+        <div class="title">
+            <Avatar
+                url={client.userAvatarUrl($allUsersStore.get(preview.message.sender))}
+                userId={preview.message.sender}
+                size={AvatarSize.Tiny} />
+            <h4
+                class="username"
+                class:text-content={preview.message.content.kind === "text_content"}>
+                {displayName}
+            </h4>
+        </div>
+        <div class="inert">
+            <ChatMessageContent
+                {me}
+                readonly
+                messageContext={{
+                    chatId: preview.chatId,
+                    threadRootMessageIndex: preview.threadRootMessageIndex,
+                }}
+                {intersecting}
+                messageId={preview.message.messageId}
+                messageIndex={preview.message.messageIndex}
+                senderId={preview.message.sender}
+                edited={preview.message.edited}
+                fill={false}
+                failed={false}
+                blockLevelMarkdown
+                truncate
+                reply
+                content={preview.message.content}
+                ogPreviews={preview.message.ogPreviews} />
+        </div>
+    </div>
+</a>
 
 <style lang="scss">
     .wrapper {
+        padding: $sp3;
+        border-radius: $sp3;
+        background-color: color-mix(in srgb, var(--currentChat-msg-bg), black 15%);
         overflow: hidden;
         @include nice-scrollbar();
         max-height: 300px;
+        margin-bottom: $sp2;
+
+        &.me {
+            background-color: color-mix(in srgb, var(--currentChat-msg-me-bg), black 15%);
+        }
 
         .inert {
             pointer-events: none;

--- a/frontend/app/src/components/home/TextContent.svelte
+++ b/frontend/app/src/components/home/TextContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Markdown from "@shared_components/Markdown.svelte";
-    import type { OgPreview, TextContent } from "openchat-client";
+    import type { OgPreview, RehydratedMessagePreview, TextContent } from "openchat-client";
     import { _ } from "svelte-i18n";
     import IntersectionObserver from "./IntersectionObserver.svelte";
     import LinkPreviews from "./LinkPreviews.svelte";
@@ -17,6 +17,7 @@
         blockLevelMarkdown: boolean;
         onRemovePreview?: (url: string) => void;
         ogPreviews?: OgPreview[];
+        messagePreviews?: RehydratedMessagePreview[];
     }
 
     let {
@@ -29,6 +30,7 @@
         blockLevelMarkdown,
         onRemovePreview,
         ogPreviews = [],
+        messagePreviews = [],
     }: Props = $props();
 
     function truncateText(text: string): string {
@@ -46,11 +48,11 @@
 <IntersectionObserver unobserveOnIntersect={false}>
     {#snippet children(intersecting)}
         <LinkPreviews
-            text={content.text}
             {me}
             {pinned}
             {fill}
             {ogPreviews}
+            {messagePreviews}
             {intersecting}
             onRemove={onRemovePreview} />
     {/snippet}

--- a/frontend/app/src/components_mobile/home/ChatMessage.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessage.svelte
@@ -790,7 +790,8 @@
                                     {onRemovePreview}
                                     {onRegisterVote}
                                     {onExpandMessage}
-                                    ogPreviews={msg.ogPreviews} />
+                                    ogPreviews={msg.ogPreviews}
+                                    messagePreviews={msg.messagePreviews} />
                             {/snippet}
                         </MessageBubble>
                     </MenuTrigger>

--- a/frontend/app/src/components_mobile/home/ChatMessageContent.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessageContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { MessageContent, MessageContext, OgPreview } from "openchat-client";
+    import type { MessageContent, MessageContext, OgPreview, RehydratedMessagePreview } from "openchat-client";
     import { i18nKey } from "../../i18n/i18n";
     import AudioContent from "./AudioContent.svelte";
     import BlockedContent from "./BlockedContent.svelte";
@@ -51,6 +51,7 @@
         onRemovePreview?: (url: string) => void;
         onRegisterVote?: (vote: { type: "delete" | "register"; answerIndex: number }) => void;
         ogPreviews?: OgPreview[];
+        messagePreviews?: RehydratedMessagePreview[];
     }
 
     let {
@@ -79,6 +80,7 @@
         onRemovePreview,
         onRegisterVote,
         ogPreviews = [],
+        messagePreviews = [],
     }: Props = $props();
 </script>
 
@@ -91,7 +93,8 @@
         {blockLevelMarkdown}
         {isPreview}
         {onRemovePreview}
-        {ogPreviews} />
+        {ogPreviews}
+        {messagePreviews} />
 {:else if content.kind === "image_content"}
     <ImageContent
         bind:contentWidth

--- a/frontend/app/src/components_mobile/home/LinkPreviews.svelte
+++ b/frontend/app/src/components_mobile/home/LinkPreviews.svelte
@@ -1,64 +1,53 @@
 <script lang="ts">
     import { rtlStore } from "@src/stores/rtl";
     import { ColourVars } from "component-lib";
-    import { classifyUrl, extractUrls, type LinkPreview } from "openchat-client";
-    import type { OgPreview } from "openchat-shared";
+    import type { OgPreview, RehydratedMessagePreview } from "openchat-shared";
     import CloseIcon from "svelte-material-icons/Close.svelte";
     import GenericPreviewComponent from "./GenericPreview.svelte";
     import MessagePreviewComponent from "./MessagePreview.svelte";
 
     interface Props {
-        text: string;
+        messagePreviews: RehydratedMessagePreview[];
         intersecting: boolean;
         me: boolean;
         onRemove?: (url: string) => void;
         ogPreviews: OgPreview[];
     }
 
-    let { text, intersecting, me, onRemove, ogPreviews = [] }: Props = $props();
+    let { messagePreviews, intersecting, me, onRemove, ogPreviews = [] }: Props = $props();
 
-    let ogPreviewMap = $derived(new Map(ogPreviews.map((p) => [p.url, p])));
-
-    let urls = $derived<LinkPreview[]>(
-        extractUrls(text).reduce((urls, url) => {
-            const u = ogPreviewMap.get(url) ?? classifyUrl(url);
-            if (u !== undefined) {
-                urls.push(u);
-            }
-            return urls;
-        }, [] as LinkPreview[]),
-    );
     let rtl = $rtlStore;
-    function removePreview(preview: LinkPreview | undefined) {
-        if (preview) {
-            onRemove?.(preview.url);
-        }
+
+    function removePreview(url: string) {
+        onRemove?.(url);
     }
 </script>
 
-{#each urls as p (p.url)}
-    <div class="preview" class:me>
-        {#if me && onRemove}
-            <div class="remove_wrapper" class:rtl>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div class="remove" onclick={() => removePreview(p)}>
-                    <CloseIcon viewBox="0 0 24 24" size="1.25rem" color={ColourVars.primaryLight} />
-                </div>
+{#snippet remove(url: string)}
+    {#if me && onRemove}
+        <div class="remove_wrapper" class:rtl>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div class="remove" onclick={() => removePreview(url)}>
+                <CloseIcon viewBox="0 0 24 24" size="1.25rem" color={ColourVars.primaryLight} />
             </div>
-        {/if}
+        </div>
+    {/if}
+{/snippet}
+
+{#each messagePreviews as p (p.url)}
+    <div class="preview" class:me>
+        {@render remove(p.url)}
         <div class="inner" class:me>
-            {#if p.kind === "message"}
-                <MessagePreviewComponent
-                    url={p.url}
-                    {me}
-                    chatId={p.chatId}
-                    threadRootMessageIndex={p.threadRootMessageIndex}
-                    messageIndex={p.messageIndex}
-                    {intersecting} />
-            {:else if p.kind === "opengraph"}
-                <GenericPreviewComponent {me} ogPreview={p} />
-            {/if}
+            <MessagePreviewComponent preview={p} {me} {intersecting} />
+        </div>
+    </div>
+{/each}
+{#each ogPreviews as p (p.url)}
+    <div class="preview" class:me>
+        {@render remove(p.url)}
+        <div class="inner" class:me>
+            <GenericPreviewComponent {me} ogPreview={p} />
         </div>
     </div>
 {/each}

--- a/frontend/app/src/components_mobile/home/MessagePreview.svelte
+++ b/frontend/app/src/components_mobile/home/MessagePreview.svelte
@@ -1,135 +1,78 @@
 <script lang="ts">
-    import { trackedEffect } from "@src/utils/effects.svelte";
     import { Avatar, Body } from "component-lib";
     import {
         allUsersStore,
         currentUserIdStore,
-        eventListScrolling,
-        isSuccessfulEventsResponse,
         OpenChat,
         selectedChatWebhooksStore,
         selectedCommunityMembersStore,
-        type MessageContent,
-        type MultiUserChatIdentifier,
-        type OgPreview,
+        type RehydratedMessagePreview,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import ChatMessageContent from "./ChatMessageContent.svelte";
 
-    type Preview = {
-        content: MessageContent;
-        senderId: string;
-        messageId: bigint;
-        edited: boolean;
-        displayName: string;
-        ogPreviews: OgPreview[];
-    };
-
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        url: string;
+        preview: RehydratedMessagePreview;
         me: boolean;
-        chatId: MultiUserChatIdentifier;
-        threadRootMessageIndex: number | undefined;
-        messageIndex: number;
         intersecting: boolean;
         onRendered?: (url: string) => void;
     }
 
-    let { url, me, chatId, threadRootMessageIndex, messageIndex, intersecting, onRendered }: Props =
-        $props();
+    const { preview, me, intersecting }: Props = $props();
 
-    let previewPromise: Promise<Preview | undefined> | undefined = $state();
-    let rendered = $state(false);
-    let senderIsMe = $state(false);
-
-    async function loadPreview(): Promise<Preview | undefined> {
-        let result = await client.getMessagesByMessageIndex(chatId, threadRootMessageIndex, [
-            messageIndex,
-        ]);
-
-        if (!isSuccessfulEventsResponse(result)) {
-            return;
-        }
-
-        let message = result.events[0].event;
-
-        senderIsMe = message.sender === $currentUserIdStore;
-
-        return {
-            content: message.content,
-            senderId: message.sender,
-            messageId: message.messageId,
-            edited: message.edited,
-            displayName: senderIsMe
-                ? client.toTitleCase($_("you"))
-                : client.getDisplayName(
-                      message.sender,
-                      $selectedCommunityMembersStore,
-                      $selectedChatWebhooksStore,
-                  ),
-            ogPreviews: message.ogPreviews,
-        };
-    }
-
-    trackedEffect("message-preview", () => {
-        // make sure we only actually *load* the preview once
-        previewPromise = previewPromise ?? loadPreview();
-        previewPromise.then((preview) => {
-            if (preview && intersecting && !$eventListScrolling) {
-                rendered = true;
-                onRendered?.(url);
-            }
-        });
-    });
+    let senderIsMe = $derived(preview.message.sender === $currentUserIdStore);
+    let displayName = $derived(
+        senderIsMe
+            ? client.toTitleCase($_("you"))
+            : client.getDisplayName(
+                  preview.message.sender,
+                  $selectedCommunityMembersStore,
+                  $selectedChatWebhooksStore,
+              ),
+    );
 </script>
 
-{#if rendered}
-    {#await previewPromise then preview}
-        {#if preview}
-            <a class="preview_link" href={url}>
-                <div
-                    class="wrapper"
-                    class:me
-                    class:sender_is_me={senderIsMe}
-                    class:p2pSwap={preview.content.kind === "p2p_swap_content"}>
-                    <div class="title">
-                        <Avatar
-                            url={client.userAvatarUrl($allUsersStore.get(preview.senderId))}
-                            size={"xs"} />
-                        <Body fontWeight="bold" colour={me ? "textPrimary" : "textSecondary"}>
-                            {preview.displayName}
-                        </Body>
-                    </div>
-                    <div class="inert">
-                        <ChatMessageContent
-                            me={senderIsMe}
-                            readonly
-                            messageContext={{
-                                chatId,
-                                threadRootMessageIndex,
-                            }}
-                            {intersecting}
-                            messageId={preview.messageId}
-                            {messageIndex}
-                            senderId={preview.senderId}
-                            edited={preview.edited}
-                            fill={false}
-                            failed={false}
-                            blockLevelMarkdown
-                            truncate={true}
-                            reply={false}
-                            isPreview={true}
-                            content={preview.content}
-                            ogPreviews={preview.ogPreviews} />
-                    </div>
-                </div>
-            </a>
-        {/if}
-    {/await}
-{/if}
+<a class="preview_link" href={preview.url}>
+    <div
+        class="wrapper"
+        class:me
+        class:sender_is_me={senderIsMe}
+        class:p2pSwap={preview.message.content.kind === "p2p_swap_content"}>
+        <div class="title">
+            <Avatar
+                url={client.userAvatarUrl($allUsersStore.get(preview.message.sender))}
+                size={"xs"} />
+            <Body fontWeight="bold" colour={me ? "textPrimary" : "textSecondary"}>
+                {displayName}
+            </Body>
+        </div>
+        <div class="inert">
+            <ChatMessageContent
+                me={senderIsMe}
+                readonly
+                messageContext={{
+                    chatId: preview.chatId,
+                    threadRootMessageIndex: preview.threadRootMessageIndex,
+                }}
+                {intersecting}
+                messageId={preview.message.messageId}
+                messageIndex={preview.message.messageIndex}
+                senderId={preview.message.sender}
+                edited={preview.message.edited}
+                fill={false}
+                failed={false}
+                blockLevelMarkdown
+                truncate={true}
+                reply={false}
+                isPreview={true}
+                content={preview.message.content}
+                ogPreviews={preview.message.ogPreviews} />
+        </div>
+    </div>
+</a>
 
 <style lang="scss">
     .preview_link {

--- a/frontend/app/src/components_mobile/home/MessagePreview.svelte
+++ b/frontend/app/src/components_mobile/home/MessagePreview.svelte
@@ -18,7 +18,6 @@
         preview: RehydratedMessagePreview;
         me: boolean;
         intersecting: boolean;
-        onRendered?: (url: string) => void;
     }
 
     const { preview, me, intersecting }: Props = $props();

--- a/frontend/app/src/components_mobile/home/TextContent.svelte
+++ b/frontend/app/src/components_mobile/home/TextContent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Markdown from "@shared_components/Markdown.svelte";
     import { ChatCaption, ChatText, Column } from "component-lib";
-    import type { OgPreview, TextContent } from "openchat-client";
+    import type { OgPreview, RehydratedMessagePreview, TextContent } from "openchat-client";
     import { type Snippet } from "svelte";
     import { lowBandwidth } from "../../stores/settings";
     import IntersectionObserver from "./IntersectionObserver.svelte";
@@ -21,6 +21,7 @@
         suppressLinks?: boolean;
         onRemovePreview?: (url: string) => void;
         ogPreviews?: OgPreview[];
+        messagePreviews?: RehydratedMessagePreview[];
     }
 
     let {
@@ -35,6 +36,7 @@
         suppressLinks = false,
         onRemovePreview,
         ogPreviews = [],
+        messagePreviews = [],
     }: Props = $props();
 
     let textContent = $derived<TextContent | undefined>("kind" in content ? content : undefined);
@@ -50,9 +52,9 @@
     contextId="scrollable-messages-div">
     {#snippet children(intersecting)}
         <LinkPreviews
-            text={text ?? ""}
             {me}
             {ogPreviews}
+            {messagePreviews}
             {intersecting}
             onRemove={onRemovePreview} />
     {/snippet}

--- a/frontend/openchat-agent/src/services/common/chatMappersV2.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappersV2.ts
@@ -557,6 +557,7 @@ export function message(value: TMessage): Message {
         blockLevelMarkdown: value.block_level_markdown ?? false,
         senderContext: mapOptional(value.sender_context, senderContext),
         ogPreviews: (value.og_previews ?? []).map(ogPreview),
+        messagePreviews: [], // this will be rehydrated later
     };
 }
 

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1099,8 +1099,9 @@ export class OpenChatAgent extends EventTarget {
         if (contextMap.length === 0) return Promise.resolve(new AsyncMessageContextMap());
 
         const mapped = await contextMap.asyncMap((ctx, idxs) => {
+            const uniqueIdxs = [...new Set(idxs)];
             return this._chatEventsReader
-                .messagesByMessageIndex(ctx.chatId, ctx.threadRootMessageIndex, idxs, undefined)
+                .messagesByMessageIndex(ctx.chatId, ctx.threadRootMessageIndex, uniqueIdxs, undefined)
                 .aggregate(mergeEventStreamResponses, emptyEventsResponse())
                 .toPromise()
                 .then((resp) => this.messagesFromEventsResponse(ctx, resp));

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -128,6 +128,7 @@ import type {
     PublicGroupSummaryResponse,
     PublicProfile,
     Referral,
+    RehydratedMessagePreview,
     RegisterPollVoteResponse,
     RegisterProposalVoteResponse,
     RegisterUserResponse,
@@ -241,6 +242,7 @@ import { createHttpAgentSync } from "../utils/httpAgent";
 import { chunk, distinctBy, toRecord, toRecord2 } from "../utils/list";
 import { bytesToHexString, mapOptional } from "../utils/mapping";
 import { mean } from "../utils/maths";
+import { extractMessagePreviews } from "../utils/linkPreviews";
 import { AsyncMessageContextMap } from "../utils/messageContext";
 // import { isMainnet } from "../utils/network";
 import {
@@ -876,6 +878,7 @@ export class OpenChatAgent extends EventTarget {
                 threadRootMessageIndex,
                 latestKnownUpdate,
             )
+            .aggregate(mergeEventStreamResponses, emptyEventsResponse())
             .mapAsync((resp) =>
                 this.rehydrateEventResponse(
                     chatId,
@@ -903,6 +906,7 @@ export class OpenChatAgent extends EventTarget {
                 threadRootMessageIndex,
                 latestKnownUpdate,
             )
+            .aggregate(mergeEventStreamResponses, emptyEventsResponse())
             .mapAsync((resp) =>
                 this.rehydrateEventResponse(
                     chatId,
@@ -921,6 +925,7 @@ export class OpenChatAgent extends EventTarget {
     ): Stream<EventsResponse<ChatEvent>> {
         return this._chatEventsReader
             .chatEventsByIndex(chatId, eventIndexes, threadRootMessageIndex, latestKnownUpdate)
+            .aggregate(mergeEventStreamResponses, emptyEventsResponse())
             .mapAsync((resp) =>
                 this.rehydrateEventResponse(
                     chatId,
@@ -1000,11 +1005,6 @@ export class OpenChatAgent extends EventTarget {
         threadRootMessageIndex: number | undefined,
     ): AsyncMessageContextMap<number> {
         return events.reduce<AsyncMessageContextMap<number>>((result, ev) => {
-            // todo - can we also find message previews here by extracting urls from the message content
-            // well - yes we can and that would get the content loaded.
-            // But the issue is that the data ends up being keyed by event index and we would need it to be
-            // keyed on message index.
-            // Can't really think of a way round this at the moment.
             if (
                 ev.event.kind === "message" &&
                 ev.event.repliesTo &&
@@ -1075,14 +1075,49 @@ export class OpenChatAgent extends EventTarget {
         return mapped;
     }
 
+    private findMissingMessagePreviewsByChat<T extends ChatEvent>(
+        events: EventWrapper<T>[],
+    ): AsyncMessageContextMap<number> {
+        return events.reduce<AsyncMessageContextMap<number>>((result, ev) => {
+            if (ev.event.kind === "message" && ev.event.content.kind === "text_content") {
+                for (const preview of extractMessagePreviews(ev.event.content.text)) {
+                    result.insert(
+                        { chatId: preview.chatId, threadRootMessageIndex: preview.threadRootMessageIndex },
+                        preview.messageIndex,
+                    );
+                }
+            }
+            return result;
+        }, new AsyncMessageContextMap());
+    }
+
+    private async resolveMissingMessagePreviews<T extends ChatEvent>(
+        events: EventWrapper<T>[],
+    ): Promise<AsyncMessageContextMap<EventWrapper<Message>>> {
+        const contextMap = this.findMissingMessagePreviewsByChat(events);
+
+        if (contextMap.length === 0) return Promise.resolve(new AsyncMessageContextMap());
+
+        const mapped = await contextMap.asyncMap((ctx, idxs) => {
+            return this._chatEventsReader
+                .messagesByMessageIndex(ctx.chatId, ctx.threadRootMessageIndex, idxs, undefined)
+                .aggregate(mergeEventStreamResponses, emptyEventsResponse())
+                .toPromise()
+                .then((resp) => this.messagesFromEventsResponse(ctx, resp));
+        });
+
+        return mapped;
+    }
+
     private rehydrateEvent<T extends ChatEvent>(
         ev: EventWrapper<T>,
         defaultChatId: ChatIdentifier,
         missingReplies: AsyncMessageContextMap<EventWrapper<Message>>,
+        missingMessagePreviews: AsyncMessageContextMap<EventWrapper<Message>>,
         threadRootMessageIndex: number | undefined,
     ): EventWrapper<T> {
         if (ev.event.kind === "message") {
-            const messagePreviews: Message[] = [];
+            const messagePreviews: RehydratedMessagePreview[] = [];
             const originalContent = ev.event.content;
             const rehydratedContent = this.rehydrateMessageContent(originalContent);
 
@@ -1121,6 +1156,27 @@ export class OpenChatAgent extends EventTarget {
                 }
             }
 
+            if (ev.event.content.kind === "text_content") {
+                for (const preview of extractMessagePreviews(ev.event.content.text)) {
+                    const context = {
+                        chatId: preview.chatId,
+                        threadRootMessageIndex: preview.threadRootMessageIndex,
+                    };
+                    const messages = missingMessagePreviews.lookup(context);
+                    const msg = messages.find(
+                        (me) => me.event.messageIndex === preview.messageIndex,
+                    )?.event;
+                    if (msg) {
+                        messagePreviews.push({
+                            url: preview.url,
+                            chatId: preview.chatId,
+                            threadRootMessageIndex: preview.threadRootMessageIndex,
+                            message: msg,
+                        });
+                    }
+                }
+            }
+
             if (
                 originalContent !== rehydratedContent ||
                 rehydratedReplyContext !== undefined ||
@@ -1150,15 +1206,18 @@ export class OpenChatAgent extends EventTarget {
             return resp;
         }
 
-        const missing = await this.resolveMissingIndexes(
-            currentChatId,
-            resp.events,
-            threadRootMessageIndex,
-            latestKnownUpdate,
-        );
+        const [missing, missingPreviews] = await Promise.all([
+            this.resolveMissingIndexes(
+                currentChatId,
+                resp.events,
+                threadRootMessageIndex,
+                latestKnownUpdate,
+            ),
+            this.resolveMissingMessagePreviews(resp.events),
+        ]);
 
         resp.events = resp.events.map((e) =>
-            this.rehydrateEvent(e, currentChatId, missing, threadRootMessageIndex),
+            this.rehydrateEvent(e, currentChatId, missing, missingPreviews, threadRootMessageIndex),
         );
         return resp;
     }
@@ -1234,13 +1293,16 @@ export class OpenChatAgent extends EventTarget {
         threadRootMessageIndex: number | undefined,
         latestKnownUpdate: bigint | undefined,
     ): Promise<EventWrapper<Message>> {
-        const missing = await this.resolveMissingIndexes(
-            chatId,
-            [message],
-            threadRootMessageIndex,
-            latestKnownUpdate,
-        );
-        return this.rehydrateEvent(message, chatId, missing, threadRootMessageIndex);
+        const [missing, missingPreviews] = await Promise.all([
+            this.resolveMissingIndexes(
+                chatId,
+                [message],
+                threadRootMessageIndex,
+                latestKnownUpdate,
+            ),
+            this.resolveMissingMessagePreviews([message]),
+        ]);
+        return this.rehydrateEvent(message, chatId, missing, missingPreviews, threadRootMessageIndex);
     }
 
     searchUsers(searchTerm: string, maxResults = 20): Promise<UserSummary[]> {
@@ -3003,6 +3065,7 @@ export class OpenChatAgent extends EventTarget {
                 r,
                 thread.chatId,
                 threadMissing,
+                new AsyncMessageContextMap(),
                 thread.rootMessage.event.messageIndex,
             ),
         );
@@ -3010,6 +3073,7 @@ export class OpenChatAgent extends EventTarget {
             thread.rootMessage,
             thread.chatId,
             rootMissing,
+            new AsyncMessageContextMap(),
             undefined,
         );
 

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1166,12 +1166,14 @@ export class OpenChatAgent extends EventTarget {
                     const msg = messages.find(
                         (me) => me.event.messageIndex === preview.messageIndex,
                     )?.event;
-                    if (msg) {
                         messagePreviews.push({
                             url: preview.url,
                             chatId: preview.chatId,
                             threadRootMessageIndex: preview.threadRootMessageIndex,
-                            message: msg,
+                            message: {
+                                ...msg,
+                                content: structuredClone(this.rehydrateMessageContent(msg.content)),
+                            },
                         });
                     }
                 }

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1188,10 +1188,11 @@ export class OpenChatAgent extends EventTarget {
                 return {
                     ...ev,
                     event: {
+                    event: {
                         ...ev.event,
                         content: rehydratedContent,
                         repliesTo: rehydratedReplyContext ?? originalReplyContext,
-                        messagePreviews,
+                        messagePreviews: messagePreviews.length > 0 ? messagePreviews : ev.event.messagePreviews,
                     },
                 };
             }

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1167,6 +1167,7 @@ export class OpenChatAgent extends EventTarget {
                     const msg = messages.find(
                         (me) => me.event.messageIndex === preview.messageIndex,
                     )?.event;
+                    if(msg) {
                         messagePreviews.push({
                             url: preview.url,
                             chatId: preview.chatId,
@@ -1188,11 +1189,10 @@ export class OpenChatAgent extends EventTarget {
                 return {
                     ...ev,
                     event: {
-                    event: {
                         ...ev.event,
                         content: rehydratedContent,
                         repliesTo: rehydratedReplyContext ?? originalReplyContext,
-                        messagePreviews: messagePreviews.length > 0 ? messagePreviews : ev.event.messagePreviews,
+                        messagePreviews,
                     },
                 };
             }

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -215,15 +215,14 @@ import {
     isError,
     isSuccessfulEventsResponse,
     mergeEventStreamResponses,
-    messageContextsEqual,
     messageContextToString,
+    messageContextsEqual,
     offline,
     textToCode,
     waitAll,
 } from "openchat-shared";
 import type { AgentConfig } from "../config";
 import { CachePrimer } from "../utils/cachePrimer";
-import { ChatsDb } from "../utils/chatsDb";
 import {
     buildBlobUrl,
     buildUserAvatarUrl,
@@ -232,6 +231,7 @@ import {
     mergeGroupChatUpdates,
     mergeGroupChats,
 } from "../utils/chat";
+import { ChatsDb } from "../utils/chatsDb";
 import {
     isSuccessfulCommunitySummaryResponse,
     mergeCommunities,
@@ -265,6 +265,7 @@ import { GroupIndexClient } from "./groupIndex/groupIndex.client";
 import { IcpLedgerIndexClient } from "./icpLedgerIndex/icpLedgerIndex.client";
 import { IcpSwapClient } from "./icpSwap/icpSwapClient";
 import { IcpCoinsClient } from "./icpcoins/icpCoinsClient";
+import { IdentityClient } from "./identity/identity.client";
 import { LedgerClient } from "./ledger/ledger.client";
 import { LedgerIndexClient } from "./ledgerIndex/ledgerIndex.client";
 import { LocalUserIndexClient } from "./localUserIndex/localUserIndex.client";
@@ -276,7 +277,6 @@ import { OneSecMinterClient } from "./oneSecMinter/oneSecMinter.client";
 import { OnlineClient } from "./online/online.client";
 import { ProposalsBotClient } from "./proposalsBot/proposalsBot.client";
 import { RegistryClient } from "./registry/registry.client";
-import { IdentityClient } from "./identity/identity.client";
 import { SignInWithEmailClient } from "./signInWithEmail/signInWithEmail.client";
 import { SignInWithEthereumClient } from "./signInWithEthereum/signInWithEthereum.client";
 import { SignInWithSolanaClient } from "./signInWithSolana/signInWithSolana.client";
@@ -1000,6 +1000,11 @@ export class OpenChatAgent extends EventTarget {
         threadRootMessageIndex: number | undefined,
     ): AsyncMessageContextMap<number> {
         return events.reduce<AsyncMessageContextMap<number>>((result, ev) => {
+            // todo - can we also find message previews here by extracting urls from the message content
+            // well - yes we can and that would get the content loaded.
+            // But the issue is that the data ends up being keyed by event index and we would need it to be
+            // keyed on message index.
+            // Can't really think of a way round this at the moment.
             if (
                 ev.event.kind === "message" &&
                 ev.event.repliesTo &&
@@ -1077,6 +1082,7 @@ export class OpenChatAgent extends EventTarget {
         threadRootMessageIndex: number | undefined,
     ): EventWrapper<T> {
         if (ev.event.kind === "message") {
+            const messagePreviews: Message[] = [];
             const originalContent = ev.event.content;
             const rehydratedContent = this.rehydrateMessageContent(originalContent);
 
@@ -1115,13 +1121,18 @@ export class OpenChatAgent extends EventTarget {
                 }
             }
 
-            if (originalContent !== rehydratedContent || rehydratedReplyContext !== undefined) {
+            if (
+                originalContent !== rehydratedContent ||
+                rehydratedReplyContext !== undefined ||
+                messagePreviews.length > 0
+            ) {
                 return {
                     ...ev,
                     event: {
                         ...ev.event,
                         content: rehydratedContent,
                         repliesTo: rehydratedReplyContext ?? originalReplyContext,
+                        messagePreviews,
                     },
                 };
             }
@@ -2202,7 +2213,13 @@ export class OpenChatAgent extends EventTarget {
                 const localUserIndex = await this._groupClient.localUserIndex(chatId.groupId);
                 const groupInviteCode = this._groupClient.inviteCode(chatId.groupId);
                 return this._localUserIndexClient
-                    .joinGroup(localUserIndex, chatId.groupId, groupInviteCode, credentialArgs, compositeGateIndex)
+                    .joinGroup(
+                        localUserIndex,
+                        chatId.groupId,
+                        groupInviteCode,
+                        credentialArgs,
+                        compositeGateIndex,
+                    )
                     .then((resp) => {
                         if (resp.kind === "success") {
                             return {
@@ -2262,7 +2279,14 @@ export class OpenChatAgent extends EventTarget {
         const localUserIndex = await this._communityClient.localUserIndex(id.communityId);
         const referredBy = await this.getCommunityReferral(id.communityId);
         return this._localUserIndexClient
-            .joinCommunity(localUserIndex, id.communityId, inviteCode, credentialArgs, referredBy, compositeGateIndex)
+            .joinCommunity(
+                localUserIndex,
+                id.communityId,
+                inviteCode,
+                credentialArgs,
+                referredBy,
+                compositeGateIndex,
+            )
             .then((resp) => {
                 if (resp.kind === "success") {
                     deleteCommunityReferral(id.communityId);

--- a/frontend/openchat-agent/src/utils/linkPreviews.ts
+++ b/frontend/openchat-agent/src/utils/linkPreviews.ts
@@ -11,7 +11,8 @@ const groupMessageRegex = /\/group\/([a-z0-9_-]+)\/(\d+)(?:\/(\d+))?/i;
 
 function extractUrls(text: string): string[] {
     const withoutMarkdownDisplayText = text.replace(/\[[^\]]*\]\((https?:\/\/[^)]*)\)/g, "$1");
-    return [...new Set(withoutMarkdownDisplayText.match(URL_REGEX) ?? [])];
+    const urls = withoutMarkdownDisplayText.match(URL_REGEX) ?? [];
+    return [...new Set(urls.filter((u) => !u.endsWith("#LINK_REMOVED")))];
 }
 
 function parseOCMessageUrl(urlText: string): MessagePreview | undefined {

--- a/frontend/openchat-agent/src/utils/linkPreviews.ts
+++ b/frontend/openchat-agent/src/utils/linkPreviews.ts
@@ -1,0 +1,68 @@
+import type { MessagePreview } from "openchat-shared";
+
+// Originally taken from here - https://stackoverflow.com/a/6041965
+const URL_REGEX = new RegExp(
+    `(https?):\\/\\/(localhost|[\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:\\/~+#-]*[\\w@?^=%&\\/~+#-])`,
+    "g",
+);
+
+const communityMessageRegex = /\/community\/([a-z0-9_-]+)\/channel\/(\d+)\/(\d+)(?:\/(\d+))?/i;
+const groupMessageRegex = /\/group\/([a-z0-9_-]+)\/(\d+)(?:\/(\d+))?/i;
+
+function extractUrls(text: string): string[] {
+    const withoutMarkdownDisplayText = text.replace(/\[[^\]]*\]\((https?:\/\/[^)]*)\)/g, "$1");
+    return [...new Set(withoutMarkdownDisplayText.match(URL_REGEX) ?? [])];
+}
+
+function parseOCMessageUrl(urlText: string): MessagePreview | undefined {
+    let url: URL;
+    try {
+        url = new URL(urlText);
+    } catch {
+        return;
+    }
+    if (
+        url.hostname !== "oc.app" &&
+        !url.hostname.endsWith(".oc.app") &&
+        url.hostname !== "localhost"
+    ) {
+        return;
+    }
+
+    let m = url.pathname.match(communityMessageRegex);
+    if (m) {
+        return {
+            kind: "message",
+            url: urlText,
+            chatId: {
+                kind: "channel",
+                communityId: m[1],
+                channelId: Number(m[2]),
+            },
+            threadRootMessageIndex: m[4] ? Number(m[3]) : undefined,
+            messageIndex: m[4] ? Number(m[4]) : Number(m[3]),
+        };
+    }
+
+    m = url.pathname.match(groupMessageRegex);
+    if (m) {
+        return {
+            kind: "message",
+            url: urlText,
+            chatId: {
+                kind: "group_chat",
+                groupId: m[1],
+            },
+            threadRootMessageIndex: m[3] ? Number(m[2]) : undefined,
+            messageIndex: m[3] ? Number(m[3]) : Number(m[2]),
+        };
+    }
+}
+
+export function extractMessagePreviews(text: string): MessagePreview[] {
+    return extractUrls(text).reduce<MessagePreview[]>((previews, url) => {
+        const preview = parseOCMessageUrl(url);
+        if (preview) previews.push(preview);
+        return previews;
+    }, []);
+}

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -749,6 +749,7 @@ function chatMessage(): EventWrapper<Message> {
             blockLevelMarkdown: false,
             tips: {},
             ogPreviews: [],
+            messagePreviews: [],
         },
     };
 }

--- a/frontend/openchat-client/src/state/unread/markRead.spec.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.spec.ts
@@ -27,6 +27,7 @@ describe("mark messages read", () => {
                 deleted: false,
                 blockLevelMarkdown: false,
                 ogPreviews: [],
+                messagePreviews: [],
             },
             index: 0,
             timestamp: BigInt(0),

--- a/frontend/openchat-client/src/utils/chat.spec.ts
+++ b/frontend/openchat-client/src/utils/chat.spec.ts
@@ -129,6 +129,7 @@ describe("thread utils", () => {
                     deleted: false,
                     blockLevelMarkdown: false,
                     ogPreviews: [],
+                    messagePreviews: [],
                 },
             },
         );

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -297,6 +297,7 @@ export function createMessage(
             blockLevelMarkdown: message.blockLevelMarkdown,
             senderContext: message.senderContext,
             ogPreviews: message.ogPreviews,
+            messagePreviews: [],
         },
         timestamp: message.timestamp,
         index: eventIndex,

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -800,6 +800,7 @@ export type Message<T extends MessageContent = MessageContent> = {
     blockLevelMarkdown: boolean;
     senderContext?: SenderContext;
     ogPreviews: OgPreview[];
+    messagePreviews: Message[];
 };
 
 export type BotContextCommand = {

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -800,7 +800,7 @@ export type Message<T extends MessageContent = MessageContent> = {
     blockLevelMarkdown: boolean;
     senderContext?: SenderContext;
     ogPreviews: OgPreview[];
-    messagePreviews: Message[];
+    messagePreviews: RehydratedMessagePreview[];
 };
 
 export type BotContextCommand = {
@@ -2553,6 +2553,13 @@ export type MessagePreview = LinkPreviewBase & {
     chatId: MultiUserChatIdentifier;
     threadRootMessageIndex: number | undefined;
     messageIndex: number;
+};
+
+export type RehydratedMessagePreview = {
+    url: string;
+    chatId: MultiUserChatIdentifier;
+    threadRootMessageIndex: number | undefined;
+    message: Message;
 };
 
 export type GenericPreview = LinkPreviewBase & {

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -2559,7 +2559,7 @@ export type RehydratedMessagePreview = {
     url: string;
     chatId: MultiUserChatIdentifier;
     threadRootMessageIndex: number | undefined;
-    message: Message;
+    message: Omit<Message, "messagePreviews">;
 };
 
 export type GenericPreview = LinkPreviewBase & {


### PR DESCRIPTION
This further simplifies the UI side of previews and _should_ further reduce timeline jiggle. 

This should remove the final barrier to virtualising the timeline message list. 