### PR TITLE
feat: use OpenChat app as a share target when sharing from other apps

### DIFF
--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -13,6 +13,7 @@
     import { incomingVideoCall } from "@stores/video";
     import { broadcastLoggedInUser } from "@stores/xframe";
     import "@utils/markdown";
+    import { getProxyAdjustedBlobUrl } from "@utils/media";
     import {
         expectNewFcmToken,
         expectNotificationTap,
@@ -25,7 +26,14 @@
     import "@utils/scream";
     import { portalState } from "component-lib";
     import {
+        allChatsStore,
+        allUsersStore,
         type ChatIdentifier,
+        type ChatSummary,
+        communitiesStore,
+        compareChats,
+        LazyFile,
+        localUpdates,
         OpenChat,
         type VideoCallType,
         botState,
@@ -38,11 +46,13 @@
         routeForScope,
         subscribe,
     } from "openchat-client";
+    import { convertFileSrc } from "@tauri-apps/api/core";
+    import { derived } from "svelte/store";
     import page from "page";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
-    import { getFcmToken, svelteReady } from "tauri-plugin-oc-api";
+    import { getFcmToken, svelteReady, updateChatShortcuts } from "tauri-plugin-oc-api";
     import Head from "./Head.svelte";
     import NotificationsBar from "./home/NotificationsBar.svelte";
     import ActiveCall from "./home/video/ActiveCall.svelte";
@@ -181,21 +191,112 @@
         setStatusAndNavBarSizesForNativeApp();
     }
 
-    function handleShareTarget(shareTarget: ShareTarget) {
-        // Reuse the existing in-app "share message" flow: SlidingModals already
-        // subscribes to "shareMessage" and renders ShareMessageModal, which
-        // wraps SelectChatModal and pre-fills the chosen chat's draft via
-        // localUpdates.draftMessages.setTextContent.
-        // TODO shortcutId fast-path (Direct Share) — skip the picker and page
-        //      straight to the chat the shortcut maps to.
-        // TODO file payloads — read shareTarget.files[].path into File objects
-        //      via the Tauri fs plugin before attaching to share.files.
+    // Shortcut ids round-trip through the Android shortcut system as opaque
+    // strings, so we need a kind-prefixed encoding to reverse them back into
+    // a ChatIdentifier when the share arrives. chatIdentifierToString in
+    // openchat-shared drops the kind, which makes direct vs group ids
+    // indistinguishable on the way back.
+    function chatIdToShortcutId(id: ChatIdentifier): string {
+        switch (id.kind) {
+            case "direct_chat":
+                return `d:${id.userId}`;
+            case "group_chat":
+                return `g:${id.groupId}`;
+            case "channel":
+                return `c:${id.communityId}:${id.channelId}`;
+        }
+    }
+
+    function shortcutIdToChatId(s: string): ChatIdentifier | undefined {
+        const colon = s.indexOf(":");
+        if (colon < 0) return undefined;
+        const kind = s.slice(0, colon);
+        const rest = s.slice(colon + 1);
+        switch (kind) {
+            case "d":
+                return { kind: "direct_chat", userId: rest };
+            case "g":
+                return { kind: "group_chat", groupId: rest };
+            case "c": {
+                const sep = rest.lastIndexOf(":");
+                if (sep < 0) return undefined;
+                const channelId = Number(rest.slice(sep + 1));
+                if (!Number.isFinite(channelId)) return undefined;
+                return {
+                    kind: "channel",
+                    communityId: rest.slice(0, sep),
+                    channelId,
+                };
+            }
+            default:
+                return undefined;
+        }
+    }
+
+    function shareToChat(chatId: ChatIdentifier, shareTarget: ShareTarget) {
+        // Set the draft synchronously — the chat doesn't have to exist in
+        // chatSummariesStore yet; the draft is keyed by id and the composer
+        // picks it up reactively once the chat is selected.
         const text = shareTarget.text ?? "";
+        if (text.length > 0) {
+            localUpdates.draftMessages.setTextContent({ chatId }, text);
+        }
+        const firstFile = shareTarget.files[0];
+        if (firstFile) {
+            const lazy = LazyFile.fromUrl(
+                convertFileSrc(firstFile.path),
+                firstFile.name,
+                firstFile.mimeType ?? "application/octet-stream",
+                firstFile.size,
+            );
+            client
+                .messageContentFromFile(lazy as unknown as File)
+                .then((content) =>
+                    localUpdates.draftMessages.setAttachment({ chatId }, content),
+                )
+                .catch((err) => console.error("Failed to attach shared file", err));
+        }
+        // Defer the navigation: on cold start, the share-target event can
+        // arrive while Home.svelte is still doing its initial route resolution
+        // (which pageReplaces the home_route to the default scope). Pushing
+        // through a macrotask lets that settle first, so our chat route wins.
+        setTimeout(() => page(routeForChatIdentifier($chatListScopeStore.kind, chatId)));
+    }
+
+    function handleShareTarget(shareTarget: ShareTarget) {
+        // Direct Share fast-path: the share came from a chat shortcut we
+        // pushed via updateChatShortcuts, so we know the destination and
+        // can skip the picker entirely.
+        if (shareTarget.shortcutId) {
+            const chatId = shortcutIdToChatId(shareTarget.shortcutId);
+            if (chatId !== undefined) {
+                shareToChat(chatId, shareTarget);
+                return;
+            }
+            // Unrecognised shortcut id — fall through to the picker.
+        }
+
+        // Generic share-sheet path: reuse the existing in-app "share message"
+        // flow. SlidingModals subscribes to "shareMessage" and renders
+        // ShareMessageModal, which wraps SelectChatModal and pre-fills the
+        // chosen chat's draft via localUpdates.draftMessages.
+        const text = shareTarget.text ?? "";
+        // Wrap each shared file path in a LazyFile so the existing
+        // messageContentFromFile path can stream bytes through Tauri's asset
+        // protocol instead of buffering them across the IPC boundary.
+        const files = shareTarget.files.map((f) =>
+            LazyFile.fromUrl(
+                convertFileSrc(f.path),
+                f.name,
+                f.mimeType ?? "application/octet-stream",
+                f.size,
+            ),
+        );
         const share: Share = {
             title: undefined,
             text: text.length > 0 ? text : undefined,
             url: undefined,
-            files: [],
+            files: files as unknown as File[],
         };
         publish("shareMessage", share);
     }
@@ -241,6 +342,85 @@
                         console.log("FCM token already registered");
                     }
                 });
+            });
+
+            // Push the top recent chats to the Android Sharing Shortcuts API
+            // so they appear directly in the system share sheet (like
+            // WhatsApp's per-chat tiles). chatSummariesListStore re-fires on
+            // every message in any chat, but the top-N identity changes far
+            // less often — we dedupe by a stringified key to avoid hammering
+            // the native side (each push downloads avatars via Coil).
+            //
+            // Cap matches the typical Android Direct Share row (4 tiles).
+            const SHORTCUT_COUNT = 4;
+            const topShortcutsStore = derived(
+                [allChatsStore, allUsersStore, communitiesStore],
+                ([chats, users, communities]) => {
+                    // allChatsStore is a ChatMap across every scope (direct
+                    // chats, groups, channels in any community) so users see
+                    // the right tiles regardless of which scope the app is
+                    // currently in. compareChats matches the comparator the
+                    // in-app chat list uses internally.
+                    //
+                    // Filter out chats we can't actually send a message to
+                    // (OpenChatBot, proposal bot, read-only groups, etc.)
+                    // BEFORE slicing — otherwise a non-sendable chat near the
+                    // top would waste a tile slot.
+                    const sorted: ChatSummary[] = [...chats.values()].sort(compareChats);
+                    return sorted
+                        .filter((chat) => client.canSendMessage(chat.id, "message"))
+                        .slice(0, SHORTCUT_COUNT)
+                        .map((chat) => {
+                            if (chat.kind === "direct_chat") {
+                                const them = users.get(chat.them.userId);
+                                return {
+                                    id: chatIdToShortcutId(chat.id),
+                                    name: client.displayName(them),
+                                    // Adjust dev-mode localhost canister URLs so the
+                                    // native side can fetch the avatar bytes via Coil.
+                                    avatarUrl: getProxyAdjustedBlobUrl(client.userAvatarUrl(them)),
+                                };
+                            }
+                            if (chat.kind === "channel") {
+                                // Prefix channel tiles with the community name
+                                // so the user can tell which community the
+                                // channel belongs to (the channel name alone
+                                // is often ambiguous across communities).
+                                const community = communities.get({
+                                    kind: "community",
+                                    communityId: chat.id.communityId,
+                                });
+                                const name = community
+                                    ? `${community.name}#${chat.name}`
+                                    : chat.name;
+                                return {
+                                    id: chatIdToShortcutId(chat.id),
+                                    name,
+                                    avatarUrl: getProxyAdjustedBlobUrl(
+                                        client.groupAvatarUrl(chat),
+                                    ),
+                                };
+                            }
+                            return {
+                                id: chatIdToShortcutId(chat.id),
+                                name: chat.name,
+                                avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
+                            };
+                        });
+                },
+            );
+            let lastPushedShortcutsKey = "";
+            topShortcutsStore.subscribe((chats) => {
+                // Skip the transient empty emit during chat-list hydration —
+                // pushing an empty list would prune any existing shortcuts,
+                // leaving a window where the system share sheet has none.
+                if (chats.length === 0) return;
+                const key = JSON.stringify(chats);
+                if (key === lastPushedShortcutsKey) return;
+                lastPushedShortcutsKey = key;
+                updateChatShortcuts({ chats }).catch((err) =>
+                    console.error("Failed to update chat shortcuts", err),
+                );
             });
 
             // Inform the native android app that svelte code is ready! SetTimeout

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -17,8 +17,11 @@
         expectNewFcmToken,
         expectNotificationTap,
         expectPushNotifications,
+        expectShareTarget,
         expectWindowInsetChange,
+        type ShareTarget,
     } from "@utils/native/notification_channels";
+    import type { Share } from "@utils/share";
     import "@utils/scream";
     import { portalState } from "component-lib";
     import {
@@ -30,6 +33,7 @@
         fontSize,
         identityStateStore,
         inititaliseLogger,
+        publish,
         routeForChatIdentifier,
         routeForScope,
         subscribe,
@@ -177,6 +181,25 @@
         setStatusAndNavBarSizesForNativeApp();
     }
 
+    function handleShareTarget(shareTarget: ShareTarget) {
+        // Reuse the existing in-app "share message" flow: SlidingModals already
+        // subscribes to "shareMessage" and renders ShareMessageModal, which
+        // wraps SelectChatModal and pre-fills the chosen chat's draft via
+        // localUpdates.draftMessages.setTextContent.
+        // TODO shortcutId fast-path (Direct Share) — skip the picker and page
+        //      straight to the chat the shortcut maps to.
+        // TODO file payloads — read shareTarget.files[].path into File objects
+        //      via the Tauri fs plugin before attaching to share.files.
+        const text = shareTarget.text ?? "";
+        const share: Share = {
+            title: undefined,
+            text: text.length > 0 ? text : undefined,
+            url: undefined,
+            files: [],
+        };
+        publish("shareMessage", share);
+    }
+
     // Sets up push notifications and FCM token management for native apps
     function setupNativeApp() {
         const addFcmToken = (token: string) => {
@@ -193,6 +216,11 @@
 
             // Listen for notifications user has tapped on
             expectNotificationTap().catch(console.error);
+
+            // Listen for content shared into OpenChat from the system share sheet
+            // (or via a Direct Share chat shortcut). Cold-start shares are queued
+            // by the native side and delivered once svelteReady fires below.
+            expectShareTarget(handleShareTarget).catch(console.error);
 
             // Expect FCM token refreshes
             expectNewFcmToken(addFcmToken);

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -40,7 +40,7 @@
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
     import { getFcmToken, svelteReady } from "tauri-plugin-oc-api";
-    import { startChatShortcutPusher } from "@stores/chatShortcuts";
+    import { clearChatShortcuts, startChatShortcutPusher } from "@stores/chatShortcuts";
     import Head from "./Head.svelte";
     import NotificationsBar from "./home/NotificationsBar.svelte";
     import ActiveCall from "./home/video/ActiveCall.svelte";
@@ -273,6 +273,7 @@
             (ev.reason?.name === "SessionExpiryError" ||
                 ev.reason?.name === "InvalidDelegationError")
         ) {
+            if (client.isNativeApp()) clearChatShortcuts();
             client.logout();
             ev.preventDefault();
         }

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -13,27 +13,17 @@
     import { incomingVideoCall } from "@stores/video";
     import { broadcastLoggedInUser } from "@stores/xframe";
     import "@utils/markdown";
-    import { getProxyAdjustedBlobUrl } from "@utils/media";
     import {
         expectNewFcmToken,
         expectNotificationTap,
         expectPushNotifications,
-        expectShareTarget,
         expectWindowInsetChange,
-        type ShareTarget,
     } from "@utils/native/notification_channels";
-    import type { Share } from "@utils/share";
+    import { expectShareTarget, handleShareTarget } from "@utils/native/share_target";
     import "@utils/scream";
     import { portalState } from "component-lib";
     import {
-        allChatsStore,
-        allUsersStore,
         type ChatIdentifier,
-        type ChatSummary,
-        communitiesStore,
-        compareChats,
-        LazyFile,
-        localUpdates,
         OpenChat,
         type VideoCallType,
         botState,
@@ -41,18 +31,16 @@
         fontSize,
         identityStateStore,
         inititaliseLogger,
-        publish,
         routeForChatIdentifier,
         routeForScope,
         subscribe,
     } from "openchat-client";
-    import { convertFileSrc } from "@tauri-apps/api/core";
-    import { derived } from "svelte/store";
     import page from "page";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
-    import { getFcmToken, svelteReady, updateChatShortcuts } from "tauri-plugin-oc-api";
+    import { getFcmToken, svelteReady } from "tauri-plugin-oc-api";
+    import { startChatShortcutPusher } from "@stores/chatShortcuts";
     import Head from "./Head.svelte";
     import NotificationsBar from "./home/NotificationsBar.svelte";
     import ActiveCall from "./home/video/ActiveCall.svelte";
@@ -191,116 +179,6 @@
         setStatusAndNavBarSizesForNativeApp();
     }
 
-    // Shortcut ids round-trip through the Android shortcut system as opaque
-    // strings, so we need a kind-prefixed encoding to reverse them back into
-    // a ChatIdentifier when the share arrives. chatIdentifierToString in
-    // openchat-shared drops the kind, which makes direct vs group ids
-    // indistinguishable on the way back.
-    function chatIdToShortcutId(id: ChatIdentifier): string {
-        switch (id.kind) {
-            case "direct_chat":
-                return `d:${id.userId}`;
-            case "group_chat":
-                return `g:${id.groupId}`;
-            case "channel":
-                return `c:${id.communityId}:${id.channelId}`;
-        }
-    }
-
-    function shortcutIdToChatId(s: string): ChatIdentifier | undefined {
-        const colon = s.indexOf(":");
-        if (colon < 0) return undefined;
-        const kind = s.slice(0, colon);
-        const rest = s.slice(colon + 1);
-        switch (kind) {
-            case "d":
-                return { kind: "direct_chat", userId: rest };
-            case "g":
-                return { kind: "group_chat", groupId: rest };
-            case "c": {
-                const sep = rest.lastIndexOf(":");
-                if (sep < 0) return undefined;
-                const channelId = Number(rest.slice(sep + 1));
-                if (!Number.isFinite(channelId)) return undefined;
-                return {
-                    kind: "channel",
-                    communityId: rest.slice(0, sep),
-                    channelId,
-                };
-            }
-            default:
-                return undefined;
-        }
-    }
-
-    function shareToChat(chatId: ChatIdentifier, shareTarget: ShareTarget) {
-        // Set the draft synchronously — the chat doesn't have to exist in
-        // chatSummariesStore yet; the draft is keyed by id and the composer
-        // picks it up reactively once the chat is selected.
-        const text = shareTarget.text ?? "";
-        if (text.length > 0) {
-            localUpdates.draftMessages.setTextContent({ chatId }, text);
-        }
-        const firstFile = shareTarget.files[0];
-        if (firstFile) {
-            const lazy = LazyFile.fromUrl(
-                convertFileSrc(firstFile.path),
-                firstFile.name,
-                firstFile.mimeType ?? "application/octet-stream",
-                firstFile.size,
-            );
-            client
-                .messageContentFromFile(lazy as unknown as File)
-                .then((content) =>
-                    localUpdates.draftMessages.setAttachment({ chatId }, content),
-                )
-                .catch((err) => console.error("Failed to attach shared file", err));
-        }
-        // Defer the navigation: on cold start, the share-target event can
-        // arrive while Home.svelte is still doing its initial route resolution
-        // (which pageReplaces the home_route to the default scope). Pushing
-        // through a macrotask lets that settle first, so our chat route wins.
-        setTimeout(() => page(routeForChatIdentifier($chatListScopeStore.kind, chatId)));
-    }
-
-    function handleShareTarget(shareTarget: ShareTarget) {
-        // Direct Share fast-path: the share came from a chat shortcut we
-        // pushed via updateChatShortcuts, so we know the destination and
-        // can skip the picker entirely.
-        if (shareTarget.shortcutId) {
-            const chatId = shortcutIdToChatId(shareTarget.shortcutId);
-            if (chatId !== undefined) {
-                shareToChat(chatId, shareTarget);
-                return;
-            }
-            // Unrecognised shortcut id — fall through to the picker.
-        }
-
-        // Generic share-sheet path: reuse the existing in-app "share message"
-        // flow. SlidingModals subscribes to "shareMessage" and renders
-        // ShareMessageModal, which wraps SelectChatModal and pre-fills the
-        // chosen chat's draft via localUpdates.draftMessages.
-        const text = shareTarget.text ?? "";
-        // Wrap each shared file path in a LazyFile so the existing
-        // messageContentFromFile path can stream bytes through Tauri's asset
-        // protocol instead of buffering them across the IPC boundary.
-        const files = shareTarget.files.map((f) =>
-            LazyFile.fromUrl(
-                convertFileSrc(f.path),
-                f.name,
-                f.mimeType ?? "application/octet-stream",
-                f.size,
-            ),
-        );
-        const share: Share = {
-            title: undefined,
-            text: text.length > 0 ? text : undefined,
-            url: undefined,
-            files: files as unknown as File[],
-        };
-        publish("shareMessage", share);
-    }
-
     // Sets up push notifications and FCM token management for native apps
     function setupNativeApp() {
         const addFcmToken = (token: string) => {
@@ -321,7 +199,7 @@
             // Listen for content shared into OpenChat from the system share sheet
             // (or via a Direct Share chat shortcut). Cold-start shares are queued
             // by the native side and delivered once svelteReady fires below.
-            expectShareTarget(handleShareTarget).catch(console.error);
+            expectShareTarget((share) => handleShareTarget(client, share)).catch(console.error);
 
             // Expect FCM token refreshes
             expectNewFcmToken(addFcmToken);
@@ -346,82 +224,8 @@
 
             // Push the top recent chats to the Android Sharing Shortcuts API
             // so they appear directly in the system share sheet (like
-            // WhatsApp's per-chat tiles). chatSummariesListStore re-fires on
-            // every message in any chat, but the top-N identity changes far
-            // less often — we dedupe by a stringified key to avoid hammering
-            // the native side (each push downloads avatars via Coil).
-            //
-            // Cap matches the typical Android Direct Share row (4 tiles).
-            const SHORTCUT_COUNT = 4;
-            const topShortcutsStore = derived(
-                [allChatsStore, allUsersStore, communitiesStore],
-                ([chats, users, communities]) => {
-                    // allChatsStore is a ChatMap across every scope (direct
-                    // chats, groups, channels in any community) so users see
-                    // the right tiles regardless of which scope the app is
-                    // currently in. compareChats matches the comparator the
-                    // in-app chat list uses internally.
-                    //
-                    // Filter out chats we can't actually send a message to
-                    // (OpenChatBot, proposal bot, read-only groups, etc.)
-                    // BEFORE slicing — otherwise a non-sendable chat near the
-                    // top would waste a tile slot.
-                    const sorted: ChatSummary[] = [...chats.values()].sort(compareChats);
-                    return sorted
-                        .filter((chat) => client.canSendMessage(chat.id, "message"))
-                        .slice(0, SHORTCUT_COUNT)
-                        .map((chat) => {
-                            if (chat.kind === "direct_chat") {
-                                const them = users.get(chat.them.userId);
-                                return {
-                                    id: chatIdToShortcutId(chat.id),
-                                    name: client.displayName(them),
-                                    // Adjust dev-mode localhost canister URLs so the
-                                    // native side can fetch the avatar bytes via Coil.
-                                    avatarUrl: getProxyAdjustedBlobUrl(client.userAvatarUrl(them)),
-                                };
-                            }
-                            if (chat.kind === "channel") {
-                                // Prefix channel tiles with the community name
-                                // so the user can tell which community the
-                                // channel belongs to (the channel name alone
-                                // is often ambiguous across communities).
-                                const community = communities.get({
-                                    kind: "community",
-                                    communityId: chat.id.communityId,
-                                });
-                                const name = community
-                                    ? `${community.name}#${chat.name}`
-                                    : chat.name;
-                                return {
-                                    id: chatIdToShortcutId(chat.id),
-                                    name,
-                                    avatarUrl: getProxyAdjustedBlobUrl(
-                                        client.groupAvatarUrl(chat),
-                                    ),
-                                };
-                            }
-                            return {
-                                id: chatIdToShortcutId(chat.id),
-                                name: chat.name,
-                                avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
-                            };
-                        });
-                },
-            );
-            let lastPushedShortcutsKey = "";
-            topShortcutsStore.subscribe((chats) => {
-                // Skip the transient empty emit during chat-list hydration —
-                // pushing an empty list would prune any existing shortcuts,
-                // leaving a window where the system share sheet has none.
-                if (chats.length === 0) return;
-                const key = JSON.stringify(chats);
-                if (key === lastPushedShortcutsKey) return;
-                lastPushedShortcutsKey = key;
-                updateChatShortcuts({ chats }).catch((err) =>
-                    console.error("Failed to update chat shortcuts", err),
-                );
-            });
+            // WhatsApp's per-chat tiles).
+            startChatShortcutPusher(client);
 
             // Inform the native android app that svelte code is ready! SetTimeout
             // delays the fn execution until the call stack is empty, just to

--- a/frontend/app/src/components_mobile/ShareMessageModal.svelte
+++ b/frontend/app/src/components_mobile/ShareMessageModal.svelte
@@ -12,8 +12,10 @@
 
     let { onClose, share }: Props = $props();
 
+    $inspect("SHARE", share);
+
     function shareMessage(chatId: ChatIdentifier) {
-        page(routeForChatIdentifier($chatListScopeStore.kind, chatId));
+        console.log("ROUTE TO CHAT", chatId);
 
         const shareText = share.text ?? "";
         const shareTitle = share.title ?? "";
@@ -29,7 +31,13 @@
         }
 
         localUpdates.draftMessages.setTextContent({ chatId }, text);
+
+        // onClose() calls history.back() to consume the dummy history entry
+        // the sliding modal pushed when it opened. Navigating before that
+        // back() settles makes the back() rewind past our new route, so we
+        // defer the page() until after popstate has fired.
         onClose();
+        setTimeout(() => page(routeForChatIdentifier($chatListScopeStore.kind, chatId)));
     }
 </script>
 

--- a/frontend/app/src/components_mobile/ShareMessageModal.svelte
+++ b/frontend/app/src/components_mobile/ShareMessageModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { ChatIdentifier, OpenChat } from "openchat-client";
-    import { chatListScopeStore, localUpdates, routeForChatIdentifier } from "openchat-client";
-    import page from "page";
+    import { localUpdates } from "openchat-client";
     import { getContext } from "svelte";
     import { i18nKey } from "../i18n/i18n";
     import type { Share } from "../utils/share";
@@ -10,10 +9,19 @@
 
     interface Props {
         share: Share;
+        /** Called when the user backs out of the picker without choosing a chat. */
         onClose: () => void;
+        /**
+         * Called when the user has picked a chat. The caller is responsible
+         * for both closing the modal *and* navigating to the chat — keeping
+         * those atomic from the caller's side avoids the popstate race that
+         * arises if the modal calls onClose (history.back) and then tries
+         * to navigate independently.
+         */
+        onShare: (chatId: ChatIdentifier) => void;
     }
 
-    let { onClose, share }: Props = $props();
+    let { onClose, onShare, share }: Props = $props();
 
     const client = getContext<OpenChat>("client");
 
@@ -46,12 +54,7 @@
                 .catch((err) => toastStore.showFailureToast(i18nKey(String(err))));
         }
 
-        // onClose() calls history.back() to consume the dummy history entry
-        // the sliding modal pushed when it opened. Navigating before that
-        // back() settles makes the back() rewind past our new route, so we
-        // defer the page() until after popstate has fired.
-        onClose();
-        setTimeout(() => page(routeForChatIdentifier($chatListScopeStore.kind, chatId)));
+        onShare(chatId);
     }
 </script>
 

--- a/frontend/app/src/components_mobile/ShareMessageModal.svelte
+++ b/frontend/app/src/components_mobile/ShareMessageModal.svelte
@@ -51,7 +51,7 @@
             client
                 .messageContentFromFile(firstFile)
                 .then((content) => localUpdates.draftMessages.setAttachment({ chatId }, content))
-                .catch((err) => toastStore.showFailureToast(i18nKey(String(err))));
+                .catch((err) => toastStore.showFailureToast(i18nKey(err)));
         }
 
         onShare(chatId);

--- a/frontend/app/src/components_mobile/ShareMessageModal.svelte
+++ b/frontend/app/src/components_mobile/ShareMessageModal.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-    import type { ChatIdentifier } from "openchat-client";
+    import type { ChatIdentifier, OpenChat } from "openchat-client";
     import { chatListScopeStore, localUpdates, routeForChatIdentifier } from "openchat-client";
     import page from "page";
+    import { getContext } from "svelte";
+    import { i18nKey } from "../i18n/i18n";
     import type { Share } from "../utils/share";
+    import { toastStore } from "../stores/toast";
     import SelectChatModal from "./SelectChatModal.svelte";
 
     interface Props {
@@ -12,11 +15,9 @@
 
     let { onClose, share }: Props = $props();
 
-    $inspect("SHARE", share);
+    const client = getContext<OpenChat>("client");
 
     function shareMessage(chatId: ChatIdentifier) {
-        console.log("ROUTE TO CHAT", chatId);
-
         const shareText = share.text ?? "";
         const shareTitle = share.title ?? "";
         const shareUrl = share.url ?? "";
@@ -31,6 +32,19 @@
         }
 
         localUpdates.draftMessages.setTextContent({ chatId }, text);
+
+        // The composer holds a single attachment per draft, so when the share
+        // delivers multiple files we attach the first and drop the rest. Fire
+        // the conversion off rather than awaiting it — the draft store is
+        // reactive, so the composer picks up the attachment as soon as it
+        // resolves, which keeps the modal-close path snappy for large files.
+        const firstFile = share.files[0];
+        if (firstFile) {
+            client
+                .messageContentFromFile(firstFile)
+                .then((content) => localUpdates.draftMessages.setAttachment({ chatId }, content))
+                .catch((err) => toastStore.showFailureToast(i18nKey(String(err))));
+        }
 
         // onClose() calls history.back() to consume the dummy history entry
         // the sliding modal pushed when it opened. Navigating before that

--- a/frontend/app/src/components_mobile/home/ChatEventList.svelte
+++ b/frontend/app/src/components_mobile/home/ChatEventList.svelte
@@ -463,11 +463,13 @@
     }
 
     function shouldLoadPreviousMessages() {
+        if (!chat) return false;
         morePrevAvailable = client.morePreviousMessagesAvailable(chat.id, threadRootEvent);
         return visible && insideTopThreshold() && morePrevAvailable;
     }
 
     function shouldLoadNewMessages() {
+        if (!chat) return false;
         moreNewAvailable = client.moreNewMessagesAvailable(chat.id, threadRootEvent);
         return visible && insideBottomThreshold() && moreNewAvailable;
     }

--- a/frontend/app/src/components_mobile/home/SlidingModals.svelte
+++ b/frontend/app/src/components_mobile/home/SlidingModals.svelte
@@ -5,8 +5,11 @@
     import { removeQueryStringParam, stripThreadFromUrl } from "@src/utils/urls";
     import { portalState } from "component-lib";
     import {
+        chatListScopeStore,
+        type ChatIdentifier,
         OpenChat,
         pageReplace,
+        routeForChatIdentifier,
         selectedChatMembersStore,
         selectedChatSummaryStore,
         selectedCommunitySummaryStore,
@@ -38,6 +41,7 @@
     import { getContext, onMount } from "svelte";
     import { minimizeApp } from "tauri-plugin-oc-api";
     import { expectBackPress } from "../../utils/native/notification_channels";
+    import { pendingShareStore } from "@stores/pendingShare";
     import type { Share as ShareType } from "../../utils/share";
     import BotBuilderModal from "../bots/BotBuilderModal.svelte";
     import BotDetailsPage from "../bots/BotDetailsPage.svelte";
@@ -264,6 +268,18 @@
         history.back();
     }
 
+    // Specialised close-and-navigate path used by the share picker.
+    // Going via pop() (history.back) races page.js's popstate handler, which
+    // re-dispatches the previous URL's route — that fights our subsequent
+    // navigation on some WebViews (Samsung release builds especially). Doing
+    // the modalStack pop directly + a pageReplace gives us a single
+    // history.replaceState write with no popstate event in the middle.
+    function shareToChosenChat(chatId: ChatIdentifier) {
+        modalStack.pop();
+        historyDepth = historyDepth - 1;
+        pageReplace(routeForChatIdentifier($chatListScopeStore.kind, chatId));
+    }
+
     function popStack() {
         if (!recursivePop && modalStack.length > 0) {
             recursivePop = true;
@@ -308,6 +324,15 @@
             subscribe("shareMessage", (share) =>
                 push({ kind: "share_message", share: share as unknown as ShareType }),
             ),
+            // Android share-target events use a store (rather than pubsub) so
+            // cold-start shares that arrive before this onMount runs aren't
+            // dropped. We consume on subscribe and clear so opening the modal
+            // a second time requires a fresh share.
+            pendingShareStore.subscribe((share) => {
+                if (share === undefined) return;
+                push({ kind: "share_message", share });
+                pendingShareStore.set(undefined);
+            }),
             subscribe("viewBotCommand", (command) => push({ kind: "view_bot_command", command })),
             subscribe("registerBot", () => push({ kind: "register_bot" })),
             subscribe("updateBot", () => push({ kind: "update_bot" })),
@@ -539,7 +564,10 @@
         {:else if page.kind === "forward_message"}
             <ForwardMessageModal onClose={pop} msg={page.msg} />
         {:else if page.kind === "share_message"}
-            <ShareMessageModal onClose={pop} share={page.share} />
+            <ShareMessageModal
+                onClose={pop}
+                onShare={shareToChosenChat}
+                share={page.share} />
         {:else if page.kind === "register_bot"}
             <BotBuilderModal onClose={pop} mode={"register"} />
         {:else if page.kind === "update_bot"}

--- a/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import MulticolourText from "@src/components_mobile/MulticolourText.svelte";
     import { i18nKey } from "@src/i18n/i18n";
+    import { clearChatShortcuts } from "@stores/chatShortcuts";
     import { Body, Container, IconButton, MenuItem, MenuTrigger } from "component-lib";
     import {
         allUsersStore,
@@ -80,7 +81,12 @@
                             <MenuItem onclick={appSettings}>
                                 <Translatable resourceKey={i18nKey("App settings")} />
                             </MenuItem>
-                            <MenuItem danger onclick={() => client.logout()}>
+                            <MenuItem
+                                danger
+                                onclick={() => {
+                                    if (client.isNativeApp()) clearChatShortcuts();
+                                    client.logout();
+                                }}>
                                 <Translatable resourceKey={i18nKey("Logout")} />
                             </MenuItem>
                         {/snippet}

--- a/frontend/app/src/stores/chatShortcuts.ts
+++ b/frontend/app/src/stores/chatShortcuts.ts
@@ -113,10 +113,13 @@ export function startChatShortcutPusher(client: OpenChat): () => void {
 
     let lastPushedKey = "";
     return topShortcutsStore.subscribe((chats) => {
-        // Skip the transient empty emit during chat-list hydration — pushing
-        // an empty list prunes existing shortcuts, leaving a window where the
-        // system share sheet has none.
-        if (chats.length === 0) return;
+        // Skip *only* the transient empty emit that fires during initial
+        // chat-list hydration (before we've pushed anything). A genuine
+        // transition to zero sendable chats — e.g. the user just left every
+        // group / deleted every DM — needs to propagate so the native side
+        // can prune the stale share-target tiles. We detect "haven't pushed
+        // yet" by the sentinel empty-string initial value of lastPushedKey.
+        if (chats.length === 0 && lastPushedKey === "") return;
         const key = JSON.stringify(chats);
         if (key === lastPushedKey) return;
         lastPushedKey = key;

--- a/frontend/app/src/stores/chatShortcuts.ts
+++ b/frontend/app/src/stores/chatShortcuts.ts
@@ -91,3 +91,16 @@ export function startChatShortcutPusher(client: OpenChat): () => void {
         );
     });
 }
+
+/**
+ * Clear all Direct Share chat shortcuts. Used on logout so the previous
+ * user's chats don't sit on the system share sheet until the next user's
+ * chat list hydrates. Fire-and-forget: the JS context typically dies right
+ * after this (logout reloads the page), but the native Kotlin side keeps
+ * running and will process the IPC regardless.
+ */
+export function clearChatShortcuts(): void {
+    updateChatShortcuts({ chats: [] }).catch((err) =>
+        console.error("Failed to clear chat shortcuts", err),
+    );
+}

--- a/frontend/app/src/stores/chatShortcuts.ts
+++ b/frontend/app/src/stores/chatShortcuts.ts
@@ -16,6 +16,43 @@ import { updateChatShortcuts, type ChatShortcut } from "tauri-plugin-oc-api";
 // shortcuts to roughly this number anyway.
 const SHORTCUT_COUNT = 4;
 
+// Minimum tiles to allocate to each category before filling remaining slots
+// by recency. Without these floors, a user who's recently active in just one
+// community can end up with all 4 tiles pointing at the same set of channels,
+// which makes the share sheet much less useful.
+const MIN_DIRECT_CHATS = 2;
+const MIN_GROUPS_AND_CHANNELS = 1;
+
+// Pick the chats that should become Direct Share tiles. Reserves the
+// category minimums first, then fills the remaining slots by overall recency
+// across both pools. Falls back gracefully when one category is empty or
+// short (e.g. a user with no DMs yet gets 4 group/channel tiles instead).
+function selectShortcutChats(sortedSendable: ChatSummary[]): ChatSummary[] {
+    const directs: ChatSummary[] = [];
+    const groupsAndChannels: ChatSummary[] = [];
+    for (const chat of sortedSendable) {
+        if (chat.kind === "direct_chat") {
+            directs.push(chat);
+        } else {
+            groupsAndChannels.push(chat);
+        }
+    }
+
+    const reserved: ChatSummary[] = [
+        ...directs.slice(0, Math.min(MIN_DIRECT_CHATS, directs.length)),
+        ...groupsAndChannels.slice(0, Math.min(MIN_GROUPS_AND_CHANNELS, groupsAndChannels.length)),
+    ];
+    const reservedIds = new Set(reserved.map((c) => chatIdToShortcutId(c.id)));
+    const remaining = sortedSendable.filter(
+        (c) => !reservedIds.has(chatIdToShortcutId(c.id)),
+    );
+    const filled = reserved.concat(remaining.slice(0, SHORTCUT_COUNT - reserved.length));
+
+    // Re-sort by recency so the most active chat lands first in the tile
+    // row — the category-floor logic above scrambles that order.
+    return filled.sort(compareChats);
+}
+
 /**
  * Subscribe to the chats / users / communities stores and push the top-N
  * sendable chats to the Android Sharing Shortcuts API. Re-fires on any chat
@@ -36,44 +73,41 @@ export function startChatShortcutPusher(client: OpenChat): () => void {
             // the in-app chat list uses internally.
             //
             // Filter out non-sendable chats (OpenChatBot, proposal bot,
-            // read-only groups) BEFORE slicing — otherwise one would consume
-            // a tile slot.
-            const sorted: ChatSummary[] = [...chats.values()].sort(compareChats);
-            return sorted
-                .filter((chat) => client.canSendMessage(chat.id, "message"))
-                .slice(0, SHORTCUT_COUNT)
-                .map<ChatShortcut>((chat) => {
-                    if (chat.kind === "direct_chat") {
-                        const them = users.get(chat.them.userId);
-                        return {
-                            id: chatIdToShortcutId(chat.id),
-                            name: client.displayName(them),
-                            // Adjust dev-mode localhost canister URLs so the
-                            // native side can fetch the avatar bytes via Coil.
-                            avatarUrl: getProxyAdjustedBlobUrl(client.userAvatarUrl(them)),
-                        };
-                    }
-                    if (chat.kind === "channel") {
-                        // Lead with the channel name so it's visible even when
-                        // the community name is long enough to truncate.
-                        const community = communities.get({
-                            kind: "community",
-                            communityId: chat.id.communityId,
-                        });
-                        return {
-                            id: chatIdToShortcutId(chat.id),
-                            name: community
-                                ? `${chat.name} (${community.name})`
-                                : chat.name,
-                            avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
-                        };
-                    }
+            // read-only groups) BEFORE handing to the selector — otherwise
+            // they'd consume tile slots that the floors are trying to reserve.
+            const sortedSendable: ChatSummary[] = [...chats.values()]
+                .sort(compareChats)
+                .filter((chat) => client.canSendMessage(chat.id, "message"));
+            return selectShortcutChats(sortedSendable).map<ChatShortcut>((chat) => {
+                if (chat.kind === "direct_chat") {
+                    const them = users.get(chat.them.userId);
                     return {
                         id: chatIdToShortcutId(chat.id),
-                        name: chat.name,
+                        name: client.displayName(them),
+                        // Adjust dev-mode localhost canister URLs so the
+                        // native side can fetch the avatar bytes via Coil.
+                        avatarUrl: getProxyAdjustedBlobUrl(client.userAvatarUrl(them)),
+                    };
+                }
+                if (chat.kind === "channel") {
+                    // Lead with the channel name so it's visible even when
+                    // the community name is long enough to truncate.
+                    const community = communities.get({
+                        kind: "community",
+                        communityId: chat.id.communityId,
+                    });
+                    return {
+                        id: chatIdToShortcutId(chat.id),
+                        name: community ? `${chat.name} (${community.name})` : chat.name,
                         avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
                     };
-                });
+                }
+                return {
+                    id: chatIdToShortcutId(chat.id),
+                    name: chat.name,
+                    avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
+                };
+            });
         },
     );
 

--- a/frontend/app/src/stores/chatShortcuts.ts
+++ b/frontend/app/src/stores/chatShortcuts.ts
@@ -1,0 +1,93 @@
+import { getProxyAdjustedBlobUrl } from "@utils/media";
+import { chatIdToShortcutId } from "@utils/native/share_target";
+import {
+    allChatsStore,
+    allUsersStore,
+    type ChatSummary,
+    communitiesStore,
+    compareChats,
+    OpenChat,
+} from "openchat-client";
+import { derived } from "svelte/store";
+import { updateChatShortcuts, type ChatShortcut } from "tauri-plugin-oc-api";
+
+// Cap matches the typical Android Direct Share row (4 tiles). Pushing more
+// doesn't necessarily display more — Android caps per-activity dynamic
+// shortcuts to roughly this number anyway.
+const SHORTCUT_COUNT = 4;
+
+/**
+ * Subscribe to the chats / users / communities stores and push the top-N
+ * sendable chats to the Android Sharing Shortcuts API. Re-fires on any chat
+ * activity but dedupes by stringified payload, so the native side (which
+ * downloads avatars via Coil on each push) only churns when something
+ * meaningfully changes.
+ *
+ * Returns an unsubscribe function. Currently never called — App.svelte fires
+ * this once for the app's lifetime — but exposing it costs nothing and keeps
+ * the contract symmetric with the other listener helpers.
+ */
+export function startChatShortcutPusher(client: OpenChat): () => void {
+    const topShortcutsStore = derived(
+        [allChatsStore, allUsersStore, communitiesStore],
+        ([chats, users, communities]) => {
+            // allChatsStore is global across scopes (direct chats, groups,
+            // channels in any community). compareChats matches the comparator
+            // the in-app chat list uses internally.
+            //
+            // Filter out non-sendable chats (OpenChatBot, proposal bot,
+            // read-only groups) BEFORE slicing — otherwise one would consume
+            // a tile slot.
+            const sorted: ChatSummary[] = [...chats.values()].sort(compareChats);
+            return sorted
+                .filter((chat) => client.canSendMessage(chat.id, "message"))
+                .slice(0, SHORTCUT_COUNT)
+                .map<ChatShortcut>((chat) => {
+                    if (chat.kind === "direct_chat") {
+                        const them = users.get(chat.them.userId);
+                        return {
+                            id: chatIdToShortcutId(chat.id),
+                            name: client.displayName(them),
+                            // Adjust dev-mode localhost canister URLs so the
+                            // native side can fetch the avatar bytes via Coil.
+                            avatarUrl: getProxyAdjustedBlobUrl(client.userAvatarUrl(them)),
+                        };
+                    }
+                    if (chat.kind === "channel") {
+                        // Lead with the channel name so it's visible even when
+                        // the community name is long enough to truncate.
+                        const community = communities.get({
+                            kind: "community",
+                            communityId: chat.id.communityId,
+                        });
+                        return {
+                            id: chatIdToShortcutId(chat.id),
+                            name: community
+                                ? `${chat.name} (${community.name})`
+                                : chat.name,
+                            avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
+                        };
+                    }
+                    return {
+                        id: chatIdToShortcutId(chat.id),
+                        name: chat.name,
+                        avatarUrl: getProxyAdjustedBlobUrl(client.groupAvatarUrl(chat)),
+                    };
+                });
+        },
+    );
+
+    let lastPushedKey = "";
+    return topShortcutsStore.subscribe((chats) => {
+        // Skip the transient empty emit during chat-list hydration — pushing
+        // an empty list prunes existing shortcuts, leaving a window where the
+        // system share sheet has none.
+        if (chats.length === 0) return;
+        const key = JSON.stringify(chats);
+        if (key === lastPushedKey) return;
+        lastPushedKey = key;
+        updateChatShortcuts({ chats }).catch((err) =>
+            console.error("Failed to update chat shortcuts", err),
+        );
+    });
+}

--- a/frontend/app/src/stores/pendingShare.ts
+++ b/frontend/app/src/stores/pendingShare.ts
@@ -1,0 +1,15 @@
+import type { Share } from "@utils/share";
+import { writable } from "svelte/store";
+
+/**
+ * Holds a Share that's waiting for the share-message modal to pick it up.
+ *
+ * The publish/subscribe layer in openchat-shared/utils/pubsub is a plain
+ * synchronous emitter — events are dropped if no subscriber is registered
+ * at publish time. On Android cold-start, the share-target event arrives
+ * (and handleShareTarget runs) before SlidingModals has mounted and called
+ * subscribe("shareMessage", ...), so the modal never opens.
+ *
+ * This store buffers the value until SlidingModals mounts and consumes it.
+ */
+export const pendingShareStore = writable<Share | undefined>(undefined);

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -9,7 +9,6 @@ const NEW_FCM_TOKEN_EVENT = "fcm-token";
 const NOTIFICATION_TAP_EVENT = "notification-tap";
 const BACK_PRESS_EVENT = "back-pressed";
 const WINDOW_INSET_CHANGE_EVENT = "window-inset-change";
-const SHARE_TARGET_EVENT = "share-target";
 
 type PushNotification = {
     id: number;
@@ -221,41 +220,4 @@ export async function expectWindowInsetChange(
     handler: (data: WindowInsetChange) => void,
 ): Promise<PluginListener> {
     return addPluginListener(TAURI_PLUGIN_NAME, WINDOW_INSET_CHANGE_EVENT, handler);
-}
-
-/**
- * Payload delivered when the user selects OpenChat from the system share sheet,
- * or taps one of our Direct Share chat shortcuts.
- */
-export interface SharedFile {
-    /** Absolute path of the file on app cache storage. The native side copies
-     *  incoming content URIs into the cache so the temporary read grant from
-     *  the source app cannot expire while the user composes. */
-    path: string;
-    name: string;
-    mimeType: string | null;
-    size: number;
-}
-
-export interface ShareTarget {
-    /** Original mime type from the source share intent. */
-    mimeType: string;
-    /** Plain text payload (EXTRA_TEXT). Present for text/URL shares. */
-    text: string | null;
-    /** Chat id this share was directed at, when launched from a Direct Share
-     *  shortcut. Null when launched via "OpenChat" in the generic share sheet. */
-    shortcutId: string | null;
-    /** Files copied into app cache, ready to feed into the upload path. */
-    files: SharedFile[];
-}
-
-/**
- * Subscribe to share intents delivered from the Android system share sheet.
- * Fires on cold-start shares too (the native side queues the event until
- * Svelte signals svelteReady).
- */
-export async function expectShareTarget(
-    handler: (share: ShareTarget) => void,
-): Promise<PluginListener> {
-    return addPluginListener(TAURI_PLUGIN_NAME, SHARE_TARGET_EVENT, handler);
 }

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -9,6 +9,7 @@ const NEW_FCM_TOKEN_EVENT = "fcm-token";
 const NOTIFICATION_TAP_EVENT = "notification-tap";
 const BACK_PRESS_EVENT = "back-pressed";
 const WINDOW_INSET_CHANGE_EVENT = "window-inset-change";
+const SHARE_TARGET_EVENT = "share-target";
 
 type PushNotification = {
     id: number;
@@ -220,4 +221,41 @@ export async function expectWindowInsetChange(
     handler: (data: WindowInsetChange) => void,
 ): Promise<PluginListener> {
     return addPluginListener(TAURI_PLUGIN_NAME, WINDOW_INSET_CHANGE_EVENT, handler);
+}
+
+/**
+ * Payload delivered when the user selects OpenChat from the system share sheet,
+ * or taps one of our Direct Share chat shortcuts.
+ */
+export interface SharedFile {
+    /** Absolute path of the file on app cache storage. The native side copies
+     *  incoming content URIs into the cache so the temporary read grant from
+     *  the source app cannot expire while the user composes. */
+    path: string;
+    name: string;
+    mimeType: string | null;
+    size: number;
+}
+
+export interface ShareTarget {
+    /** Original mime type from the source share intent. */
+    mimeType: string;
+    /** Plain text payload (EXTRA_TEXT). Present for text/URL shares. */
+    text: string | null;
+    /** Chat id this share was directed at, when launched from a Direct Share
+     *  shortcut. Null when launched via "OpenChat" in the generic share sheet. */
+    shortcutId: string | null;
+    /** Files copied into app cache, ready to feed into the upload path. */
+    files: SharedFile[];
+}
+
+/**
+ * Subscribe to share intents delivered from the Android system share sheet.
+ * Fires on cold-start shares too (the native side queues the event until
+ * Svelte signals svelteReady).
+ */
+export async function expectShareTarget(
+    handler: (share: ShareTarget) => void,
+): Promise<PluginListener> {
+    return addPluginListener(TAURI_PLUGIN_NAME, SHARE_TARGET_EVENT, handler);
 }

--- a/frontend/app/src/utils/native/share_target.ts
+++ b/frontend/app/src/utils/native/share_target.ts
@@ -159,6 +159,14 @@ export function handleShareTarget(client: OpenChat, shareTarget: ShareTarget): v
             f.size,
         ),
     );
+    // Share.files is typed File[] because its other consumer is the Web
+    // Share API (navigator.share), which genuinely requires DOM File.
+    // Here we hand it LazyFile instead — strictly an unsound cast, but
+    // safe in practice: the only downstream consumer of Share.files via
+    // this code path is messageContentFromFile, which accepts File | LazyFile.
+    // If a future caller of Share.files starts calling File-specific methods
+    // (slice, stream, text, etc.) on items from a share-target payload, this
+    // cast will need revisiting — probably by splitting the type.
     const share: Share = {
         title: undefined,
         text: text.length > 0 ? text : undefined,

--- a/frontend/app/src/utils/native/share_target.ts
+++ b/frontend/app/src/utils/native/share_target.ts
@@ -120,7 +120,7 @@ export function shareToChat(
             firstFile.size,
         );
         client
-            .messageContentFromFile(lazy as unknown as File)
+            .messageContentFromFile(lazy)
             .then((content) => localUpdates.draftMessages.setAttachment({ chatId }, content))
             .catch((err) => console.error("Failed to attach shared file", err));
     }

--- a/frontend/app/src/utils/native/share_target.ts
+++ b/frontend/app/src/utils/native/share_target.ts
@@ -1,4 +1,5 @@
 import { addPluginListener, convertFileSrc, type PluginListener } from "@tauri-apps/api/core";
+import { pendingShareStore } from "@stores/pendingShare";
 import {
     type ChatIdentifier,
     LazyFile,
@@ -6,7 +7,6 @@ import {
     localUpdates,
     OpenChat,
     pageNavigate,
-    publish,
     routeForChatIdentifier,
 } from "openchat-client";
 import { get } from "svelte/store";
@@ -165,5 +165,8 @@ export function handleShareTarget(client: OpenChat, shareTarget: ShareTarget): v
         url: undefined,
         files: files as unknown as File[],
     };
-    publish("shareMessage", share);
+    // Use a writable store rather than publish() so cold-start shares that
+    // arrive before SlidingModals has subscribed don't get dropped. The
+    // store retains the value; SlidingModals reads it on mount.
+    pendingShareStore.set(share);
 }

--- a/frontend/app/src/utils/native/share_target.ts
+++ b/frontend/app/src/utils/native/share_target.ts
@@ -1,0 +1,169 @@
+import { addPluginListener, convertFileSrc, type PluginListener } from "@tauri-apps/api/core";
+import {
+    type ChatIdentifier,
+    LazyFile,
+    chatListScopeStore,
+    localUpdates,
+    OpenChat,
+    pageNavigate,
+    publish,
+    routeForChatIdentifier,
+} from "openchat-client";
+import { get } from "svelte/store";
+import type { Share } from "../share";
+
+const TAURI_PLUGIN_NAME = "oc";
+const SHARE_TARGET_EVENT = "share-target";
+
+/**
+ * One shared file. The native side copies content URIs into app cache before
+ * raising the event, so {@link path} can be read for as long as the app lives
+ * (the source app's temporary read grant would otherwise expire).
+ */
+export interface SharedFile {
+    path: string;
+    name: string;
+    mimeType: string | null;
+    size: number;
+}
+
+/**
+ * Payload delivered when the user selects OpenChat from the system share sheet
+ * or taps one of our Direct Share chat shortcuts.
+ */
+export interface ShareTarget {
+    /** Original mime type from the source share intent. */
+    mimeType: string;
+    /** Plain text payload (EXTRA_TEXT). Present for text/URL shares. */
+    text: string | null;
+    /** Chat id this share was directed at, when launched from a Direct Share
+     *  shortcut. Null when launched via "OpenChat" in the generic share sheet. */
+    shortcutId: string | null;
+    /** Files copied into app cache, ready to feed into the upload path. */
+    files: SharedFile[];
+}
+
+/**
+ * Subscribe to share intents delivered from the Android system share sheet.
+ * Cold-start shares are queued by the native side and delivered once Svelte
+ * signals svelteReady.
+ */
+export async function expectShareTarget(
+    handler: (share: ShareTarget) => void,
+): Promise<PluginListener> {
+    return addPluginListener(TAURI_PLUGIN_NAME, SHARE_TARGET_EVENT, handler);
+}
+
+/**
+ * Encode a {@link ChatIdentifier} as an opaque string suitable for Android
+ * shortcut ids. The kind prefix lets us reverse the mapping unambiguously —
+ * the existing chatIdentifierToString drops the kind, which makes direct vs
+ * group ids indistinguishable when the shortcut launches our activity.
+ */
+export function chatIdToShortcutId(id: ChatIdentifier): string {
+    switch (id.kind) {
+        case "direct_chat":
+            return `d:${id.userId}`;
+        case "group_chat":
+            return `g:${id.groupId}`;
+        case "channel":
+            return `c:${id.communityId}:${id.channelId}`;
+    }
+}
+
+export function shortcutIdToChatId(s: string): ChatIdentifier | undefined {
+    const colon = s.indexOf(":");
+    if (colon < 0) return undefined;
+    const kind = s.slice(0, colon);
+    const rest = s.slice(colon + 1);
+    switch (kind) {
+        case "d":
+            return { kind: "direct_chat", userId: rest };
+        case "g":
+            return { kind: "group_chat", groupId: rest };
+        case "c": {
+            const sep = rest.lastIndexOf(":");
+            if (sep < 0) return undefined;
+            const channelId = Number(rest.slice(sep + 1));
+            if (!Number.isFinite(channelId)) return undefined;
+            return {
+                kind: "channel",
+                communityId: rest.slice(0, sep),
+                channelId,
+            };
+        }
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Drop the share content into the chat's draft and navigate to it. Used by
+ * the Direct Share fast-path; the modal-picker path goes through the existing
+ * "shareMessage" event in {@link handleShareTarget} instead.
+ */
+export function shareToChat(
+    client: OpenChat,
+    chatId: ChatIdentifier,
+    shareTarget: ShareTarget,
+): void {
+    const text = shareTarget.text ?? "";
+    if (text.length > 0) {
+        localUpdates.draftMessages.setTextContent({ chatId }, text);
+    }
+    const firstFile = shareTarget.files[0];
+    if (firstFile) {
+        const lazy = LazyFile.fromUrl(
+            convertFileSrc(firstFile.path),
+            firstFile.name,
+            firstFile.mimeType ?? "application/octet-stream",
+            firstFile.size,
+        );
+        client
+            .messageContentFromFile(lazy as unknown as File)
+            .then((content) => localUpdates.draftMessages.setAttachment({ chatId }, content))
+            .catch((err) => console.error("Failed to attach shared file", err));
+    }
+    // pageNavigate (rather than raw page()) polls routerReadyStore until the
+    // router has finished its initial setup. Cold-start shares arrive while
+    // Home.svelte is still pageReplacing the home_route to the default scope,
+    // so we'd otherwise lose the race; this gates us until the route resolver
+    // is settled.
+    pageNavigate(routeForChatIdentifier(get(chatListScopeStore).kind, chatId));
+}
+
+/**
+ * Entry point for incoming share-target events. Routes to either the Direct
+ * Share fast-path (when the share carries a known shortcut id) or the generic
+ * "shareMessage" picker flow (reuses the in-app share infrastructure).
+ */
+export function handleShareTarget(client: OpenChat, shareTarget: ShareTarget): void {
+    if (shareTarget.shortcutId) {
+        const chatId = shortcutIdToChatId(shareTarget.shortcutId);
+        if (chatId !== undefined) {
+            shareToChat(client, chatId, shareTarget);
+            return;
+        }
+        // Unrecognised shortcut id — fall through to the picker.
+    }
+
+    const text = shareTarget.text ?? "";
+    // Wrap each shared file path in a LazyFile so messageContentFromFile can
+    // stream bytes through Tauri's asset protocol instead of buffering them
+    // across the IPC boundary.
+    const files = shareTarget.files.map((f) =>
+        LazyFile.fromUrl(
+            convertFileSrc(f.path),
+            f.name,
+            f.mimeType ?? "application/octet-stream",
+            f.size,
+        ),
+    );
+    const share: Share = {
+        title: undefined,
+        text: text.length > 0 ? text : undefined,
+        url: undefined,
+        files: files as unknown as File[],
+    };
+    publish("shareMessage", share);
+}

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         tools:ignore="MissingTvBanner">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:label="@string/main_activity_title"
             android:name=".MainActivity"
             android:windowSoftInputMode="adjustNothing"
@@ -58,12 +58,35 @@
                 <data android:scheme="https" />
                 <data android:scheme="http" />
                 <data android:host="oc.app" />
-                
-                
-                
-                
+
+
+
+
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
+
+            <!-- Share target: text/URL -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <!-- Share target: any single file (images, video, audio, pdf, etc.) -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <!-- Share target: multiple files -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <provider

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
@@ -20,6 +20,7 @@ import app.tauri.plugin.JSObject
 import com.ocplugin.app.LOG_TAG
 import com.ocplugin.app.NotificationsManager
 import com.ocplugin.app.OCPluginCompanion
+import com.ocplugin.app.ShareIntentManager
 import kotlinx.coroutines.launch
 
 class MainActivity : TauriActivity() {
@@ -33,6 +34,7 @@ class MainActivity : TauriActivity() {
         try {
             handleWindowInsets()
             handleNotificationIntent(intent)
+            ShareIntentManager.handle(this, intent)
         } catch (e: Exception) {
             Log.e(LOG_TAG, "Error occurred $e")
         }
@@ -51,6 +53,7 @@ class MainActivity : TauriActivity() {
         super.onNewIntent(intent)
         try {
             handleNotificationIntent(intent)
+            ShareIntentManager.handle(this, intent)
         } catch (e: Exception) {
             Log.e(LOG_TAG, "Error occurred $e")
         }

--- a/frontend/src-tauri/gen/android/app/src/main/res/xml/shortcuts.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        Declares MainActivity as a share target so dynamic ShortcutInfoCompat
+        instances tagged with the SHARE_TARGET category will surface in the
+        Direct Share row of the system share sheet.
+    -->
+    <share-target android:targetClass="com.oc.app.MainActivity">
+        <data android:mimeType="*/*" />
+        <category android:name="com.oc.app.category.SHARE_TARGET" />
+    </share-target>
+</shortcuts>

--- a/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
@@ -15,3 +15,9 @@ const val SHARE_TARGET_CATEGORY = "com.oc.app.category.SHARE_TARGET"
 // distinguish them from other dynamic shortcuts (e.g. notification
 // conversation shortcuts) when refreshing the set.
 const val SHARE_SHORTCUT_ID_PREFIX = "share_"
+
+// Intent extra that carries the OpenChat chat id when a share is delivered
+// via a Direct Share shortcut. We use a custom key (rather than
+// Intent.EXTRA_SHORTCUT_ID) because Android sets that to the shortcut's
+// own id (e.g. "share_<chatId>"), and we want the bare chat id.
+const val EXTRA_CHAT_ID = "com.oc.app.extra.CHAT_ID"

--- a/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
@@ -5,3 +5,13 @@ const val LOG_TAG = "TEST_OC"
 
 // Log tag for notification!
 const val OC_TAG_NOT = "OC_TAG_NOT"
+
+// Category that links dynamic ShortcutInfoCompat instances to the
+// <share-target> declared in res/xml/shortcuts.xml. Shortcuts tagged
+// with this category appear in the Direct Share row of the share sheet.
+const val SHARE_TARGET_CATEGORY = "com.oc.app.category.SHARE_TARGET"
+
+// All share-target shortcuts use this prefix on their ID, so we can
+// distinguish them from other dynamic shortcuts (e.g. notification
+// conversation shortcuts) when refreshing the set.
+const val SHARE_SHORTCUT_ID_PREFIX = "share_"

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
@@ -34,6 +34,10 @@ class OpenChatPlugin(private val activity: Activity) : Plugin(activity) {
 
         // Init FCM token cache, have it populated with a token!
         OCPluginCompanion.initFcmTokenCache()
+
+        // Sweep shared files older than 24h out of the app cache. Runs on a
+        // background thread, so this doesn't block the activity launch.
+        ShareIntentManager.cleanupStaleShares(activity)
     }
 
     @Command

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
@@ -105,6 +105,11 @@ class OpenChatPlugin(private val activity: Activity) : Plugin(activity) {
     fun disableViewportResize(invoke: Invoke) {
         ViewportResize(activity).disable(invoke)
     }
+
+    @Command
+    fun updateChatShortcuts(invoke: Invoke) {
+        UpdateChatShortcuts(activity).handler(invoke)
+    }
 }
 
 object OCPluginCompanion {

--- a/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
@@ -1,0 +1,175 @@
+package com.ocplugin.app
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Parcelable
+import android.provider.OpenableColumns
+import android.util.Log
+import app.tauri.plugin.JSArray
+import app.tauri.plugin.JSObject
+import java.io.File
+
+object ShareIntentManager {
+
+    private const val SHARE_EVENT = "share-target"
+    private const val CACHE_SUBDIR = "shares"
+
+    // Returns true if the intent was a share intent (handled), false otherwise.
+    fun handle(context: Context, intent: Intent): Boolean {
+        val action = intent.action ?: return false
+        if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) {
+            return false
+        }
+
+        val mimeType = intent.type ?: "*/*"
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+        val shortcutId = intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID)
+
+        val uris: List<Uri> = when (action) {
+            Intent.ACTION_SEND -> {
+                val uri = getParcelableExtraCompat(intent, Intent.EXTRA_STREAM, Uri::class.java)
+                if (uri != null) listOf(uri) else emptyList()
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                getParcelableArrayListExtraCompat(intent, Intent.EXTRA_STREAM, Uri::class.java)
+                    ?: emptyList()
+            }
+            else -> emptyList()
+        }
+
+        // Copy each URI to app cache so the temporary read grant (tied to the
+        // source activity) can't expire while the user is composing.
+        val files = uris.mapNotNull { copyToCache(context, it) }
+
+        val payload = JSObject()
+            .put("mimeType", mimeType)
+            .put("text", text)
+            .put("shortcutId", shortcutId)
+            .put("files", JSArray().apply { files.forEach { put(it.toJSObject()) } })
+
+        Log.d(LOG_TAG, "Share intent received: $payload")
+        OCPluginCompanion.triggerRef(SHARE_EVENT, payload)
+        return true
+    }
+
+    private data class CachedFile(
+        val path: String,
+        val name: String,
+        val mimeType: String?,
+        val size: Long,
+    ) {
+        fun toJSObject(): JSObject = JSObject()
+            .put("path", path)
+            .put("name", name)
+            .put("mimeType", mimeType)
+            .put("size", size)
+    }
+
+    private fun copyToCache(context: Context, uri: Uri): CachedFile? {
+        return try {
+            val resolver = context.contentResolver
+            val mimeType = resolver.getType(uri)
+
+            val (displayName, sizeFromQuery) = queryDisplayNameAndSize(context, uri)
+            val safeName = sanitiseName(displayName ?: defaultNameForMime(mimeType))
+
+            val cacheRoot = File(context.cacheDir, CACHE_SUBDIR).apply { mkdirs() }
+            val target = uniqueChildFile(cacheRoot, safeName)
+
+            val bytesCopied = resolver.openInputStream(uri)?.use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            } ?: 0L
+
+            CachedFile(
+                path = target.absolutePath,
+                name = safeName,
+                mimeType = mimeType,
+                size = if (sizeFromQuery > 0L) sizeFromQuery else bytesCopied,
+            )
+        } catch (e: Exception) {
+            Log.e(LOG_TAG, "Failed to copy shared URI to cache: $uri", e)
+            null
+        }
+    }
+
+    private fun queryDisplayNameAndSize(context: Context, uri: Uri): Pair<String?, Long> {
+        var name: String? = null
+        var size: Long = 0
+        try {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val nameIdx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIdx >= 0 && !cursor.isNull(nameIdx)) {
+                        name = cursor.getString(nameIdx)
+                    }
+                    val sizeIdx = cursor.getColumnIndex(OpenableColumns.SIZE)
+                    if (sizeIdx >= 0 && !cursor.isNull(sizeIdx)) {
+                        size = cursor.getLong(sizeIdx)
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Some providers don't support OpenableColumns; that's fine.
+        }
+        return name to size
+    }
+
+    private fun sanitiseName(name: String): String {
+        val cleaned = name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim()
+        return cleaned.ifEmpty { "shared" }
+    }
+
+    private fun defaultNameForMime(mimeType: String?): String {
+        val ext = when {
+            mimeType == null -> "bin"
+            mimeType.startsWith("image/") -> mimeType.substringAfter("/")
+            mimeType.startsWith("video/") -> mimeType.substringAfter("/")
+            mimeType.startsWith("audio/") -> mimeType.substringAfter("/")
+            mimeType == "application/pdf" -> "pdf"
+            else -> "bin"
+        }
+        return "shared_${System.currentTimeMillis()}.$ext"
+    }
+
+    private fun uniqueChildFile(dir: File, name: String): File {
+        val base = File(dir, name)
+        if (!base.exists()) return base
+        val dot = name.lastIndexOf('.')
+        val stem = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        var i = 1
+        while (true) {
+            val candidate = File(dir, "${stem}_$i$ext")
+            if (!candidate.exists()) return candidate
+            i++
+        }
+    }
+
+    private fun <T : Parcelable> getParcelableExtraCompat(
+        intent: Intent,
+        key: String,
+        clazz: Class<T>,
+    ): T? {
+        @Suppress("DEPRECATION")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(key, clazz)
+        } else {
+            intent.getParcelableExtra(key)
+        }
+    }
+
+    private fun <T : Parcelable> getParcelableArrayListExtraCompat(
+        intent: Intent,
+        key: String,
+        clazz: Class<T>,
+    ): ArrayList<T>? {
+        @Suppress("DEPRECATION")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableArrayListExtra(key, clazz)
+        } else {
+            intent.getParcelableArrayListExtra(key)
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
@@ -25,7 +25,16 @@ object ShareIntentManager {
 
         val mimeType = intent.type ?: "*/*"
         val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-        val shortcutId = intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID)
+        // Prefer our custom extra (set explicitly on the shortcut's intent
+        // template). Fall back to Android's auto-populated EXTRA_SHORTCUT_ID,
+        // which arrives as the shortcut's full id ("share_<chatId>"), so we
+        // strip our known prefix to recover the bare chat id.
+        val shortcutId = intent.getStringExtra(EXTRA_CHAT_ID)
+            ?: intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID)?.let { sid ->
+                if (sid.startsWith(SHARE_SHORTCUT_ID_PREFIX))
+                    sid.removePrefix(SHARE_SHORTCUT_ID_PREFIX)
+                else null
+            }
 
         val uris: List<Uri> = when (action) {
             Intent.ACTION_SEND -> {

--- a/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
@@ -15,6 +15,11 @@ object ShareIntentManager {
 
     private const val SHARE_EVENT = "share-target"
     private const val CACHE_SUBDIR = "shares"
+    // Cached shared files live until either (a) they are consumed by the
+    // composer and uploaded, or (b) the user abandons the share. We keep
+    // them around for a day so users who get distracted mid-share can come
+    // back, but no longer — otherwise the directory grows unboundedly.
+    private const val MAX_CACHED_SHARE_AGE_MS = 24L * 60 * 60 * 1000
 
     // Returns true if the intent was a share intent (handled), false otherwise.
     fun handle(context: Context, intent: Intent): Boolean {
@@ -61,6 +66,28 @@ object ShareIntentManager {
         Log.d(LOG_TAG, "Share intent received: $payload")
         OCPluginCompanion.triggerRef(SHARE_EVENT, payload)
         return true
+    }
+
+    // Sweep stale files out of the shares cache directory. Safe to call on
+    // any thread; runs the actual I/O in a background thread so the caller
+    // (typically the plugin's load() callback) doesn't block.
+    fun cleanupStaleShares(context: Context) {
+        Thread {
+            try {
+                val cacheRoot = File(context.cacheDir, CACHE_SUBDIR)
+                if (!cacheRoot.isDirectory) return@Thread
+                val threshold = System.currentTimeMillis() - MAX_CACHED_SHARE_AGE_MS
+                cacheRoot.listFiles()?.forEach { file ->
+                    if (file.isFile && file.lastModified() < threshold) {
+                        if (!file.delete()) {
+                            Log.w(LOG_TAG, "Could not delete stale shared file: ${file.name}")
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(LOG_TAG, "Failed to clean stale shared files", e)
+            }
+        }.start()
     }
 
     private data class CachedFile(

--- a/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.Parcelable
 import android.provider.OpenableColumns
 import android.util.Log
@@ -22,12 +24,20 @@ object ShareIntentManager {
     private const val MAX_CACHED_SHARE_AGE_MS = 24L * 60 * 60 * 1000
 
     // Returns true if the intent was a share intent (handled), false otherwise.
+    // Caller is typically MainActivity.onCreate / onNewIntent (UI thread); the
+    // intent-shape inspection happens synchronously so the bool is accurate,
+    // but the file copy and event dispatch are moved to a background thread —
+    // a multi-MB shared video would otherwise jank the activity launch and
+    // risk an ANR on slower devices.
     fun handle(context: Context, intent: Intent): Boolean {
         val action = intent.action ?: return false
         if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) {
             return false
         }
 
+        // Snapshot everything we need off the intent on the calling thread.
+        // Intents shouldn't be mutated after delivery in practice, but reading
+        // extras off-thread risks tripping over Bundle's internal lazy unparcel.
         val mimeType = intent.type ?: "*/*"
         val text = intent.getStringExtra(Intent.EXTRA_TEXT)
         // Prefer our custom extra (set explicitly on the shortcut's intent
@@ -40,7 +50,6 @@ object ShareIntentManager {
                     sid.removePrefix(SHARE_SHORTCUT_ID_PREFIX)
                 else null
             }
-
         val uris: List<Uri> = when (action) {
             Intent.ACTION_SEND -> {
                 val uri = getParcelableExtraCompat(intent, Intent.EXTRA_STREAM, Uri::class.java)
@@ -52,19 +61,38 @@ object ShareIntentManager {
             }
             else -> emptyList()
         }
+        val appContext = context.applicationContext
 
-        // Copy each URI to app cache so the temporary read grant (tied to the
-        // source activity) can't expire while the user is composing.
-        val files = uris.mapNotNull { copyToCache(context, it) }
+        Thread {
+            // Copy each URI to app cache so the source app's temporary read
+            // grant can't expire while the user is composing.
+            val files = uris.mapNotNull { copyToCache(appContext, it) }
 
-        val payload = JSObject()
-            .put("mimeType", mimeType)
-            .put("text", text)
-            .put("shortcutId", shortcutId)
-            .put("files", JSArray().apply { files.forEach { put(it.toJSObject()) } })
+            val payload = JSObject()
+                .put("mimeType", mimeType)
+                .put("text", text)
+                .put("shortcutId", shortcutId)
+                .put("files", JSArray().apply { files.forEach { put(it.toJSObject()) } })
 
-        Log.d(LOG_TAG, "Share intent received: $payload")
-        OCPluginCompanion.triggerRef(SHARE_EVENT, payload)
+            // Stats-only log, debug builds only — the raw payload contains
+            // arbitrary user-shared text and file paths we shouldn't ship
+            // into logcat on release devices.
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    LOG_TAG,
+                    "Share intent received: mime=$mimeType, files=${files.size}, hasText=${text != null}, hasShortcutId=${shortcutId != null}",
+                )
+            }
+
+            // triggerRef either dispatches via Tauri's plugin.trigger (which
+            // expects the main thread for the JS side) or appends to
+            // eventQueue (a plain MutableList that flushQueuedEvents iterates
+            // on the main thread). Either path wants the main thread.
+            Handler(Looper.getMainLooper()).post {
+                OCPluginCompanion.triggerRef(SHARE_EVENT, payload)
+            }
+        }.start()
+
         return true
     }
 

--- a/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/ShareIntentManager.kt
@@ -142,9 +142,17 @@ object ShareIntentManager {
             val cacheRoot = File(context.cacheDir, CACHE_SUBDIR).apply { mkdirs() }
             val target = uniqueChildFile(cacheRoot, safeName)
 
-            val bytesCopied = resolver.openInputStream(uri)?.use { input ->
-                target.outputStream().use { output -> input.copyTo(output) }
-            } ?: 0L
+            // openInputStream can return null if the provider doesn't recognise
+            // the URI or refuses to open it. Bail out rather than handing back
+            // a CachedFile pointing at a path we never actually wrote.
+            val input = resolver.openInputStream(uri)
+            if (input == null) {
+                Log.w(LOG_TAG, "openInputStream returned null for shared URI; dropping entry")
+                return null
+            }
+            val bytesCopied = input.use { src ->
+                target.outputStream().use { output -> src.copyTo(output) }
+            }
 
             CachedFile(
                 path = target.absolutePath,

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
@@ -10,6 +10,7 @@ import app.tauri.annotation.InvokeArg
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 import com.ocplugin.app.AvatarHelper
+import com.ocplugin.app.EXTRA_CHAT_ID
 import com.ocplugin.app.LOG_TAG
 import com.ocplugin.app.SHARE_SHORTCUT_ID_PREFIX
 import com.ocplugin.app.SHARE_TARGET_CATEGORY
@@ -77,16 +78,15 @@ class UpdateChatShortcuts(private val activity: Activity) {
     }
 
     // Builds the Intent that fires when the user taps a chat shortcut from the
-    // share sheet. EXTRA_SHORTCUT_ID is supplied by Android automatically when
-    // launched via a shortcut, but we also set it explicitly so direct launches
-    // from the launcher (long-press app icon) carry it too.
+    // share sheet. We put the chat id under our own extra (not EXTRA_SHORTCUT_ID,
+    // which Android overwrites with the shortcut's full id "share_<chatId>").
     private fun buildShareIntent(chatId: String): Intent {
         val packageName = activity.packageName
         val mainActivityClass = Class.forName("$packageName.MainActivity")
         return Intent(activity, mainActivityClass).apply {
             action = Intent.ACTION_SEND
             type = "*/*"
-            putExtra(Intent.EXTRA_SHORTCUT_ID, chatId)
+            putExtra(EXTRA_CHAT_ID, chatId)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
     }

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
@@ -81,9 +81,7 @@ class UpdateChatShortcuts(private val activity: Activity) {
     // share sheet. We put the chat id under our own extra (not EXTRA_SHORTCUT_ID,
     // which Android overwrites with the shortcut's full id "share_<chatId>").
     private fun buildShareIntent(chatId: String): Intent {
-        val packageName = activity.packageName
-        val mainActivityClass = Class.forName("$packageName.MainActivity")
-        return Intent(activity, mainActivityClass).apply {
+        return Intent(activity, activity::class.java).apply {
             action = Intent.ACTION_SEND
             type = "*/*"
             putExtra(EXTRA_CHAT_ID, chatId)

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/UpdateChatShortcuts.kt
@@ -1,0 +1,103 @@
+package com.ocplugin.app.commands
+
+import android.app.Activity
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import app.tauri.annotation.InvokeArg
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import com.ocplugin.app.AvatarHelper
+import com.ocplugin.app.LOG_TAG
+import com.ocplugin.app.SHARE_SHORTCUT_ID_PREFIX
+import com.ocplugin.app.SHARE_TARGET_CATEGORY
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+
+@InvokeArg
+class ChatShortcutArg {
+    var id: String? = null
+    var name: String? = null
+    var avatarUrl: String? = null
+}
+
+@InvokeArg
+class UpdateChatShortcutsArgs {
+    var chats: List<ChatShortcutArg> = emptyList()
+}
+
+@Suppress("UNUSED")
+class UpdateChatShortcuts(private val activity: Activity) {
+
+    fun handler(invoke: Invoke) {
+        val args = invoke.parseArgs(UpdateChatShortcutsArgs::class.java)
+        val chats = args.chats.mapNotNull { c ->
+            val id = c.id?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val name = c.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            Triple(id, name, c.avatarUrl)
+        }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                // Load avatars in parallel.
+                val withIcons = chats.map { (id, name, avatarUrl) ->
+                    async {
+                        val icon = avatarUrl?.let { AvatarHelper.loadBitmap(activity, it) }
+                            ?.let { IconCompat.createWithBitmap(it) }
+                        ShortcutInfoCompat.Builder(activity, "$SHARE_SHORTCUT_ID_PREFIX$id")
+                            .setShortLabel(name)
+                            .setLongLabel(name)
+                            .setLongLived(true)
+                            .setCategories(setOf(SHARE_TARGET_CATEGORY))
+                            .setIntent(buildShareIntent(id))
+                            .apply { if (icon != null) setIcon(icon) }
+                            .build()
+                    }
+                }.awaitAll()
+
+                // Remove any stale share-target shortcuts that aren't in the
+                // new top-N before pushing the new ones, so the share sheet
+                // doesn't keep showing chats that have aged out.
+                pruneStaleShareShortcuts(withIcons.map { it.id })
+
+                withIcons.forEach { ShortcutManagerCompat.pushDynamicShortcut(activity, it) }
+
+                Log.d(LOG_TAG, "Updated ${withIcons.size} share-target shortcuts")
+                invoke.resolve(JSObject().put("count", withIcons.size))
+            } catch (e: Exception) {
+                Log.e(LOG_TAG, "Failed to update chat shortcuts", e)
+                invoke.reject(e.message ?: "UPDATE_CHAT_SHORTCUTS_FAILED")
+            }
+        }
+    }
+
+    // Builds the Intent that fires when the user taps a chat shortcut from the
+    // share sheet. EXTRA_SHORTCUT_ID is supplied by Android automatically when
+    // launched via a shortcut, but we also set it explicitly so direct launches
+    // from the launcher (long-press app icon) carry it too.
+    private fun buildShareIntent(chatId: String): Intent {
+        val packageName = activity.packageName
+        val mainActivityClass = Class.forName("$packageName.MainActivity")
+        return Intent(activity, mainActivityClass).apply {
+            action = Intent.ACTION_SEND
+            type = "*/*"
+            putExtra(Intent.EXTRA_SHORTCUT_ID, chatId)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+    }
+
+    private fun pruneStaleShareShortcuts(keepIds: List<String>) {
+        val keep = keepIds.toSet()
+        val stale = ShortcutManagerCompat.getDynamicShortcuts(activity)
+            .filter { it.id.startsWith(SHARE_SHORTCUT_ID_PREFIX) && it.id !in keep }
+            .map { it.id }
+        if (stale.isNotEmpty()) {
+            ShortcutManagerCompat.removeDynamicShortcuts(activity, stale)
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/build.rs
+++ b/frontend/tauri-plugin-oc/build.rs
@@ -16,6 +16,7 @@ const COMMANDS: &[&str] = &[
     "enable_viewport_resize",
     "disable_viewport_resize",
     "save_media",
+    "update_chat_shortcuts",
 ];
 
 fn main() {

--- a/frontend/tauri-plugin-oc/guest-js/commands/updateChatShortcuts.ts
+++ b/frontend/tauri-plugin-oc/guest-js/commands/updateChatShortcuts.ts
@@ -1,0 +1,23 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ChatShortcut = {
+    id: string;
+    name: string;
+    avatarUrl?: string;
+};
+
+export type UpdateChatShortcutsRequest = {
+    chats: ChatShortcut[];
+};
+
+export type UpdateChatShortcutsResponse = {
+    count: number;
+};
+
+export async function updateChatShortcuts(
+    payload: UpdateChatShortcutsRequest,
+): Promise<UpdateChatShortcutsResponse> {
+    return await invoke<UpdateChatShortcutsResponse>("plugin:oc|update_chat_shortcuts", {
+        payload,
+    });
+}

--- a/frontend/tauri-plugin-oc/guest-js/index.ts
+++ b/frontend/tauri-plugin-oc/guest-js/index.ts
@@ -15,5 +15,11 @@ export {
 export { saveMediaToDevice, type SaveMediaRequest } from "./commands/saveMedia";
 export { enableViewportResize } from "./commands/enableViewportResize";
 export { disableViewportResize } from "./commands/disableViewportResize";
+export {
+    updateChatShortcuts,
+    type ChatShortcut,
+    type UpdateChatShortcutsRequest,
+    type UpdateChatShortcutsResponse,
+} from "./commands/updateChatShortcuts";
 export * from "./models/credentials";
 export * from "./models/error";

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/update_chat_shortcuts.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/update_chat_shortcuts.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-update-chat-shortcuts"
+description = "Enables the update_chat_shortcuts command without any pre-configured scope."
+commands.allow = ["update_chat_shortcuts"]
+
+[[permission]]
+identifier = "deny-update-chat-shortcuts"
+description = "Denies the update_chat_shortcuts command without any pre-configured scope."
+commands.deny = ["update_chat_shortcuts"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
@@ -21,6 +21,7 @@ Default permissions for the plugin
 - `allow-enable-viewport-resize`
 - `allow-disable-viewport-resize`
 - `allow-save-media`
+- `allow-update-chat-shortcuts`
 
 ## Permission Table
 
@@ -469,6 +470,32 @@ Enables the svelte_ready command without any pre-configured scope.
 <td>
 
 Denies the svelte_ready command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:allow-update-chat-shortcuts`
+
+</td>
+<td>
+
+Enables the update_chat_shortcuts command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-update-chat-shortcuts`
+
+</td>
+<td>
+
+Denies the update_chat_shortcuts command without any pre-configured scope.
 
 </td>
 </tr>

--- a/frontend/tauri-plugin-oc/permissions/default.toml
+++ b/frontend/tauri-plugin-oc/permissions/default.toml
@@ -18,4 +18,5 @@ permissions = [
     "allow-enable-viewport-resize",
     "allow-disable-viewport-resize",
     "allow-save-media",
+    "allow-update-chat-shortcuts",
 ]

--- a/frontend/tauri-plugin-oc/permissions/schemas/schema.json
+++ b/frontend/tauri-plugin-oc/permissions/schemas/schema.json
@@ -499,10 +499,22 @@
           "markdownDescription": "Denies the svelte_ready command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`",
+          "description": "Enables the update_chat_shortcuts command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-update-chat-shortcuts",
+          "markdownDescription": "Enables the update_chat_shortcuts command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the update_chat_shortcuts command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-update-chat-shortcuts",
+          "markdownDescription": "Denies the update_chat_shortcuts command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`"
         }
       ]
     }

--- a/frontend/tauri-plugin-oc/src/commands.rs
+++ b/frontend/tauri-plugin-oc/src/commands.rs
@@ -107,6 +107,14 @@ pub(crate) async fn disable_viewport_resize<R: Runtime>(app: AppHandle<R>) -> Re
     app.oc().toggle_viewport_resize(false)
 }
 
+#[command]
+pub(crate) async fn update_chat_shortcuts<R: Runtime>(
+    app: AppHandle<R>,
+    payload: UpdateChatShortcutsRequest,
+) -> Result<UpdateChatShortcutsResponse> {
+    app.oc().update_chat_shortcuts(payload)
+}
+
 // This command is only used to save files to local public storage.
 //
 // Note: this command is not handled by kotlin code.

--- a/frontend/tauri-plugin-oc/src/desktop.rs
+++ b/frontend/tauri-plugin-oc/src/desktop.rs
@@ -52,4 +52,11 @@ impl<R: Runtime> Oc<R> {
     pub fn toggle_viewport_resize(&self, _toggle: bool) -> crate::Result<()> {
         unimplemented!("not implemented for desktop environment")
     }
+
+    pub fn update_chat_shortcuts(
+        &self,
+        _payload: UpdateChatShortcutsRequest,
+    ) -> crate::Result<UpdateChatShortcutsResponse> {
+        unimplemented!("not implemented for desktop environment")
+    }
 }

--- a/frontend/tauri-plugin-oc/src/lib.rs
+++ b/frontend/tauri-plugin-oc/src/lib.rs
@@ -55,6 +55,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         commands::enable_viewport_resize,
         commands::disable_viewport_resize,
         commands::save_media,
+        commands::update_chat_shortcuts,
     ]);
 
     // Only register the custom protocol handler when not in debug mode

--- a/frontend/tauri-plugin-oc/src/mobile.rs
+++ b/frontend/tauri-plugin-oc/src/mobile.rs
@@ -91,4 +91,13 @@ impl<R: Runtime> Oc<R> {
 
         res.map_err(Into::into)
     }
+
+    pub fn update_chat_shortcuts(
+        &self,
+        payload: UpdateChatShortcutsRequest,
+    ) -> crate::Result<UpdateChatShortcutsResponse> {
+        self.0
+            .run_mobile_plugin("updateChatShortcuts", payload)
+            .map_err(Into::into)
+    }
 }

--- a/frontend/tauri-plugin-oc/src/models.rs
+++ b/frontend/tauri-plugin-oc/src/models.rs
@@ -95,3 +95,23 @@ pub struct SaveMediaRequest {
     pub data: Vec<u8>,
     pub mime_type: String,
 }
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatShortcut {
+    pub id: String,
+    pub name: String,
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateChatShortcutsRequest {
+    pub chats: Vec<ChatShortcut>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateChatShortcutsResponse {
+    pub count: usize,
+}


### PR DESCRIPTION
Native (Android)
- Manifest: SEND/SEND_MULTIPLE intent-filters, shortcuts.xml share-target, launchMode="singleTask".
- ShareIntentManager.kt: extracts text/files/EXTRA_CHAT_ID, copies content URIs into cacheDir/shares/, fires a share-target event. Background sweep deletes cache files older than 24h.
- UpdateChatShortcuts.kt: pushes ShortcutInfoCompat tiles tagged with the share-target category, prunes stale ones, loads avatars via Coil.
- New update_chat_shortcuts Tauri command wired through Rust + guest-js.

Frontend
- handleShareTarget fast-paths a shortcutId straight to the chat via pageNavigate; otherwise stashes a Share in pendingShareStore for the picker.
- ShareMessageModal reuses SelectChatModal, sets the draft text/attachment, then delegates to a caller-provided onShare(chatId).
- SlidingModals.shareToChosenChat does modalStack.pop() + pageReplace(chatRoute) — no history.back, no popstate race (was the cause of "chat opens then closes" on Samsung release).
- Files: SharedFile.path → LazyFile.fromUrl(convertFileSrc(path), …) → client.messageContentFromFile → setAttachment.
- startChatShortcutPusher: top-N tiles derived across all scopes, sendable-only, deduped before pushing native-side.
- selectShortcutChats: minimum 2 directs + 1 group/channel, rest by recency, graceful fallback.
- Channel tiles labelled channel (community); clearChatShortcuts() on logout.
- pendingShareStore buffers cold-start shares — the pubsub layer silently drops events fired before mount.

Pre-existing bug fixed
- ChatEventList.svelte null-guards chat in shouldLoad{Previous,New}Messages — async callbacks were dereferencing it after a chat-switch.

New files
- utils/native/share_target.ts — types, codecs, handleShareTarget, shareToChat.
- stores/chatShortcuts.ts — pusher + clear + selection logic.
- stores/pendingShare.ts — cold-start buffer.