### PR TITLE
fix(notifications): remove FCM tokens that Firebase reports as UNREGISTERED

### DIFF
--- a/backend/canisters/notifications_index/CHANGELOG.md
+++ b/backend/canisters/notifications_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Add `remove_fcm_tokens` endpoint so the notification pusher can drop FCM tokens that Firebase reports as `UNREGISTERED`
+
 ## [[2.0.1954](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1954-notifications_index)] - 2026-01-14
 
 ### Changed

--- a/backend/canisters/notifications_index/api/src/updates/mod.rs
+++ b/backend/canisters/notifications_index/api/src/updates/mod.rs
@@ -4,6 +4,7 @@ pub mod c2c_user_index;
 pub mod mark_subscription_active;
 pub mod notify_local_index_added;
 pub mod push_subscription;
+pub mod remove_fcm_tokens;
 pub mod remove_subscription;
 pub mod remove_subscriptions;
 pub mod remove_subscriptions_for_user;

--- a/backend/canisters/notifications_index/api/src/updates/remove_fcm_tokens.rs
+++ b/backend/canisters/notifications_index/api/src/updates/remove_fcm_tokens.rs
@@ -1,0 +1,16 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+use types::{FcmToken, SuccessOnly, UserId};
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct Args {
+    pub tokens_by_user: Vec<UserFcmTokens>,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct UserFcmTokens {
+    pub user_id: UserId,
+    pub tokens: Vec<FcmToken>,
+}
+
+pub type Response = SuccessOnly;

--- a/backend/canisters/notifications_index/client/src/lib.rs
+++ b/backend/canisters/notifications_index/client/src/lib.rs
@@ -5,4 +5,5 @@ use notifications_index_canister::*;
 generate_query_call!(notification_canisters);
 
 // Updates
+generate_update_call!(remove_fcm_tokens);
 generate_update_call!(remove_subscriptions);

--- a/backend/canisters/notifications_index/impl/src/lib.rs
+++ b/backend/canisters/notifications_index/impl/src/lib.rs
@@ -97,8 +97,8 @@ impl RuntimeState {
         })
     }
 
-    // TODO remove tokens when push to firebase fails
-    #[allow(dead_code)]
+    // Called when a push to Firebase fails because the token is no longer valid
+    // (FCM `UNREGISTERED`), so we stop pushing to dead tokens.
     pub fn remove_fcm_token(&mut self, user_id: UserId, fcm_token: FcmToken) -> Result<(), String> {
         self.data.fcm_token_store.remove(&user_id, &fcm_token).map(|_| {
             self.push_event_to_local_indexes(NotificationsIndexEvent::FcmTokenRemoved(user_id, fcm_token), self.env.now());

--- a/backend/canisters/notifications_index/impl/src/updates/mod.rs
+++ b/backend/canisters/notifications_index/impl/src/updates/mod.rs
@@ -2,6 +2,7 @@ mod add_fcm_token;
 mod mark_subscription_active;
 mod notify_local_index_added;
 mod push_subscription;
+mod remove_fcm_tokens;
 mod remove_subscription;
 mod remove_subscriptions;
 mod remove_subscriptions_for_user;

--- a/backend/canisters/notifications_index/impl/src/updates/remove_fcm_tokens.rs
+++ b/backend/canisters/notifications_index/impl/src/updates/remove_fcm_tokens.rs
@@ -1,0 +1,22 @@
+use crate::guards::caller_is_push_service;
+use crate::{RuntimeState, mutate_state};
+use canister_api_macros::update;
+use canister_tracing_macros::trace;
+use notifications_index_canister::remove_fcm_tokens::*;
+
+#[update(guard = "caller_is_push_service", msgpack = true)]
+#[trace]
+fn remove_fcm_tokens(args: Args) -> Response {
+    mutate_state(|state| remove_fcm_tokens_impl(args, state))
+}
+
+fn remove_fcm_tokens_impl(args: Args, state: &mut RuntimeState) -> Response {
+    for user in args.tokens_by_user {
+        for token in user.tokens {
+            // Best-effort: a token may already be gone (e.g. re-registered), in
+            // which case remove returns an error we can safely ignore.
+            let _ = state.remove_fcm_token(user.user_id, token);
+        }
+    }
+    Response::Success
+}

--- a/backend/notification_pusher/core/src/ic_agent.rs
+++ b/backend/notification_pusher/core/src/ic_agent.rs
@@ -1,10 +1,10 @@
 use ic_agent::identity::{BasicIdentity, Secp256k1Identity};
 use ic_agent::{Agent, Identity};
 use local_user_index_canister::{latest_notification_index, notifications, remove_notifications};
-use notifications_index_canister::remove_subscriptions;
+use notifications_index_canister::{remove_fcm_tokens, remove_subscriptions};
 use std::collections::HashMap;
 use tracing::trace;
-use types::{CanisterId, Empty, Error, UserId};
+use types::{CanisterId, Empty, Error, FcmToken, UserId};
 
 #[derive(Clone)]
 pub struct IcAgent {
@@ -95,6 +95,29 @@ impl IcAgent {
         trace!(?args, "remove_subscriptions::args");
 
         notifications_index_canister_client::remove_subscriptions(&self.agent, index_canister_id, &args).await?;
+
+        Ok(())
+    }
+
+    pub async fn remove_fcm_tokens(
+        &self,
+        index_canister_id: &CanisterId,
+        tokens_by_user: HashMap<UserId, Vec<FcmToken>>,
+    ) -> Result<(), Error> {
+        if tokens_by_user.is_empty() {
+            return Ok(());
+        }
+
+        let tokens_by_user = tokens_by_user
+            .into_iter()
+            .map(|(user_id, tokens)| remove_fcm_tokens::UserFcmTokens { user_id, tokens })
+            .collect();
+
+        let args = remove_fcm_tokens::Args { tokens_by_user };
+
+        trace!(?args, "remove_fcm_tokens::args");
+
+        notifications_index_canister_client::remove_fcm_tokens(&self.agent, index_canister_id, &args).await?;
 
         Ok(())
     }

--- a/backend/notification_pusher/core/src/user_notifications.rs
+++ b/backend/notification_pusher/core/src/user_notifications.rs
@@ -1,5 +1,6 @@
 use crate::ic_agent::IcAgent;
 use crate::metrics::register_metric;
+use crate::user_notifications::fcm_token_remover::FcmTokenRemover;
 use crate::user_notifications::processor::Processor;
 use crate::user_notifications::pusher::Pusher;
 use crate::user_notifications::subscription_remover::SubscriptionRemover;
@@ -8,8 +9,9 @@ use async_channel::Sender;
 use fcm_service::FcmService;
 use prometheus::PullingGauge;
 use std::sync::{Arc, RwLock};
-use types::{CanisterId, UserId};
+use types::{CanisterId, FcmToken, UserId};
 
+mod fcm_token_remover;
 mod processor;
 mod pusher;
 mod subscription_remover;
@@ -24,6 +26,7 @@ pub fn start_user_notifications_processor(
     let (to_process_sender, to_process_receiver) = async_channel::bounded::<PushNotification>(200_000);
     let (to_push_sender, to_push_receiver) = async_channel::bounded::<NotificationToPush>(200_000);
     let (subscriptions_to_remove_sender, subscriptions_to_remove_receiver) = async_channel::bounded(20_000);
+    let (fcm_tokens_to_remove_sender, fcm_tokens_to_remove_receiver) = async_channel::bounded(20_000);
 
     let invalid_subscriptions = Arc::new(RwLock::default());
     let throttled_subscriptions = Arc::new(RwLock::default());
@@ -41,6 +44,7 @@ pub fn start_user_notifications_processor(
         let pusher = Pusher::new(
             to_push_receiver.clone(),
             subscriptions_to_remove_sender.clone(),
+            fcm_tokens_to_remove_sender.clone(),
             invalid_subscriptions.clone(),
             throttled_subscriptions.clone(),
             fcm_service.clone(),
@@ -48,11 +52,21 @@ pub fn start_user_notifications_processor(
         tokio::spawn(pusher.run());
     }
 
-    let subscription_remover = SubscriptionRemover::new(ic_agent, index_canister_id, subscriptions_to_remove_receiver);
+    let subscription_remover =
+        SubscriptionRemover::new(ic_agent.clone(), index_canister_id, subscriptions_to_remove_receiver);
 
     tokio::spawn(subscription_remover.run());
 
-    register_metrics(to_process_sender.clone(), to_push_sender, subscriptions_to_remove_sender);
+    let fcm_token_remover = FcmTokenRemover::new(ic_agent, index_canister_id, fcm_tokens_to_remove_receiver);
+
+    tokio::spawn(fcm_token_remover.run());
+
+    register_metrics(
+        to_process_sender.clone(),
+        to_push_sender,
+        subscriptions_to_remove_sender,
+        fcm_tokens_to_remove_sender,
+    );
 
     to_process_sender
 }
@@ -61,6 +75,7 @@ fn register_metrics(
     to_process_sender: Sender<PushNotification>,
     to_push_sender: Sender<NotificationToPush>,
     subscriptions_to_remove_sender: Sender<(UserId, String)>,
+    fcm_tokens_to_remove_sender: Sender<(UserId, FcmToken)>,
 ) {
     let notifications_to_process_queue = PullingGauge::new(
         "notifications_to_process_queue",
@@ -83,7 +98,15 @@ fn register_metrics(
     )
     .unwrap();
 
+    let fcm_tokens_to_remove_queue = PullingGauge::new(
+        "fcm_tokens_to_remove_queue",
+        "Number of FCM tokens queued to be removed",
+        Box::new(move || fcm_tokens_to_remove_sender.len() as f64),
+    )
+    .unwrap();
+
     register_metric(notifications_to_process_queue);
     register_metric(notifications_to_push_queue);
     register_metric(subscriptions_to_remove_queue);
+    register_metric(fcm_tokens_to_remove_queue);
 }

--- a/backend/notification_pusher/core/src/user_notifications.rs
+++ b/backend/notification_pusher/core/src/user_notifications.rs
@@ -52,8 +52,7 @@ pub fn start_user_notifications_processor(
         tokio::spawn(pusher.run());
     }
 
-    let subscription_remover =
-        SubscriptionRemover::new(ic_agent.clone(), index_canister_id, subscriptions_to_remove_receiver);
+    let subscription_remover = SubscriptionRemover::new(ic_agent.clone(), index_canister_id, subscriptions_to_remove_receiver);
 
     tokio::spawn(subscription_remover.run());
 

--- a/backend/notification_pusher/core/src/user_notifications/fcm_token_remover.rs
+++ b/backend/notification_pusher/core/src/user_notifications/fcm_token_remover.rs
@@ -1,0 +1,54 @@
+use crate::ic_agent::IcAgent;
+use async_channel::Receiver;
+use std::collections::HashMap;
+use tokio::time;
+use tracing::{error, info};
+use types::{CanisterId, FcmToken, PushIfNotContains, UserId};
+
+// Mirrors SubscriptionRemover: batches FCM tokens that FCM rejected as no longer valid
+// and removes them from the notifications index, so we stop pushing to dead tokens.
+pub struct FcmTokenRemover {
+    ic_agent: IcAgent,
+    index_canister_id: CanisterId,
+    fcm_tokens_to_remove_receiver: Receiver<(UserId, FcmToken)>,
+}
+
+impl FcmTokenRemover {
+    pub fn new(
+        ic_agent: IcAgent,
+        index_canister_id: CanisterId,
+        fcm_tokens_to_remove_receiver: Receiver<(UserId, FcmToken)>,
+    ) -> Self {
+        Self {
+            ic_agent,
+            index_canister_id,
+            fcm_tokens_to_remove_receiver,
+        }
+    }
+
+    pub async fn run(self) {
+        let mut interval = time::interval(time::Duration::from_secs(60));
+        loop {
+            let mut tokens_to_remove: HashMap<UserId, Vec<FcmToken>> = HashMap::new();
+            while let Ok((user_id, token)) = self.fcm_tokens_to_remove_receiver.try_recv() {
+                tokens_to_remove.entry(user_id).or_default().push_if_not_contains(token);
+            }
+
+            if !tokens_to_remove.is_empty() {
+                let count = tokens_to_remove.len();
+                let user_ids: Vec<_> = tokens_to_remove.keys().map(|u| u.to_string()).collect();
+                if let Err(error) = self
+                    .ic_agent
+                    .remove_fcm_tokens(&self.index_canister_id, tokens_to_remove)
+                    .await
+                {
+                    error!(?error, "Failed to remove FCM tokens");
+                } else {
+                    info!(?user_ids, "Removed FCM tokens for {count} users");
+                }
+            }
+
+            interval.tick().await;
+        }
+    }
+}

--- a/backend/notification_pusher/core/src/user_notifications/pusher.rs
+++ b/backend/notification_pusher/core/src/user_notifications/pusher.rs
@@ -6,7 +6,7 @@ use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use tracing::{error, info};
-use types::{Milliseconds, TimestampMillis, UserId};
+use types::{FcmToken, Milliseconds, TimestampMillis, UserId};
 use web_push::{HyperWebPushClient, WebPushClient, WebPushError};
 
 const ONE_MINUTE: Milliseconds = 60 * 1000;
@@ -15,6 +15,7 @@ pub struct Pusher {
     receiver: Receiver<NotificationToPush>,
     web_push_client: HyperWebPushClient,
     subscriptions_to_remove_sender: Sender<(UserId, String)>,
+    fcm_tokens_to_remove_sender: Sender<(UserId, FcmToken)>,
     invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
     throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
     fcm_service: Arc<FcmService>,
@@ -24,6 +25,7 @@ impl Pusher {
     pub fn new(
         receiver: Receiver<NotificationToPush>,
         subscriptions_to_remove_sender: Sender<(UserId, String)>,
+        fcm_tokens_to_remove_sender: Sender<(UserId, FcmToken)>,
         invalid_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
         throttled_subscriptions: Arc<RwLock<HashMap<String, TimestampMillis>>>,
         fcm_service: Arc<FcmService>,
@@ -32,6 +34,7 @@ impl Pusher {
             receiver,
             web_push_client: HyperWebPushClient::new(),
             subscriptions_to_remove_sender,
+            fcm_tokens_to_remove_sender,
             invalid_subscriptions,
             throttled_subscriptions,
             fcm_service,
@@ -59,9 +62,6 @@ impl Pusher {
                 NotificationToPush::FcmNotificationToPush(fcm_notification_to_push) => {
                     let metadata = fcm_notification_to_push.metadata.clone();
                     let success = self.process_fcm_notification_to_push(fcm_notification_to_push).await;
-
-                    // TODO check result here, and raise event to remove token
-                    // if send notification failed!
 
                     (metadata, None, success)
                 }
@@ -129,7 +129,12 @@ impl Pusher {
     }
 
     async fn process_fcm_notification_to_push(&self, fcm_notification_to_push: Box<FcmNotification>) -> bool {
-        let fcm_data = fcm_notification_to_push.fcm_data;
+        let FcmNotification {
+            fcm_data,
+            fcm_token,
+            metadata,
+        } = *fcm_notification_to_push;
+
         let mut message = FcmMessage::new();
 
         // Should affect only android devices...
@@ -137,16 +142,33 @@ impl Pusher {
         android_config.set_priority(Some(fcm_service::Priority::High));
 
         message.set_data(fcm_data.map(|d| d.as_data()));
-        message.set_target(Target::Token(fcm_notification_to_push.fcm_token.0));
+        message.set_target(Target::Token(fcm_token.0.clone()));
         message.set_android(Some(android_config));
 
         let res = self.fcm_service.send_notification(message).await;
-        if res.is_err() {
+        if let Err(error) = &res {
             error!("Failed to push FCM notification: {:#?}", res);
+
+            // FCM returns `UNREGISTERED` (HTTP 404) when the token no longer maps to an
+            // app instance - the app was uninstalled, its data cleared, or the token was
+            // rotated. Such tokens never become valid again, so queue them for removal to
+            // stop wasting pushes on them (and to keep the store from filling with junk).
+            if is_unregistered_token_error(&error.to_string())
+                && let Err(send_error) = self.fcm_tokens_to_remove_sender.try_send((metadata.recipient, fcm_token))
+            {
+                error!(?send_error, "Failed to queue FCM token for removal");
+            }
         }
 
         res.is_ok()
     }
+}
+
+// FCM surfaces a stale-token failure with the stable error code `UNREGISTERED`. The
+// fcm-service crate currently returns errors as a stringified JSON body, so we match on
+// that code. If that crate ever exposes a typed error, switch to matching the variant.
+fn is_unregistered_token_error(error_message: &str) -> bool {
+    error_message.contains("UNREGISTERED")
 }
 
 // Prunes the oldest 1000 subscriptions


### PR DESCRIPTION
The pusher logged failed FCM pushes but never acted on them, so tokens that Firebase rejected as UNREGISTERED (app uninstalled, data cleared, token rotated) lingered in the store and kept failing on every notification.

- Add `remove_fcm_tokens` endpoint to notifications_index, guarded by `caller_is_push_service` and batched per user (mirrors `remove_subscriptions`)
- Detect the `UNREGISTERED` error in the pusher and queue the offending (user, token) pair for removal instead of just logging it
- Add `FcmTokenRemover` task that batches queued tokens every 60s and calls the new endpoint, plus an `ic_agent.remove_fcm_tokens` client method and a `fcm_tokens_to_remove_queue` metric
- Wire up removal end to end: the endpoint drops the token and emits `FcmTokenRemoved`, which propagates to local_user_index so the reader stops pushing to it
- Drop the now-obsolete TODOs and `#[allow(dead_code)]` on `remove_fcm_token`