### PR TITLE
feat: handle remaining notification types (image/video/gif/audio/file)

### DIFF
--- a/backend/canisters/community/impl/src/updates/send_message.rs
+++ b/backend/canisters/community/impl/src/updates/send_message.rs
@@ -264,6 +264,7 @@ fn process_send_message_result(
             message_type: content.content_type().to_string(),
             message_text,
             image_url: content.notification_image_url(),
+            file_name: content.notification_file_name(),
             community_avatar_id: state.data.avatar.as_ref().map(|d| d.id),
             channel_avatar_id,
             crypto_transfer: content.notification_crypto_transfer_details(&users_mentioned.mentioned_directly),

--- a/backend/canisters/community/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/community/impl/src/updates/start_video_call.rs
@@ -94,6 +94,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         message_type: result.message_event.event.content.content_type().to_string(),
         message_text: None,
         image_url: None,
+        file_name: None,
         crypto_transfer: None,
         community_name: state.data.name.value.clone(),
         channel_name: channel.chat.name.value.clone(),

--- a/backend/canisters/group/impl/src/updates/send_message.rs
+++ b/backend/canisters/group/impl/src/updates/send_message.rs
@@ -204,6 +204,7 @@ fn process_send_message_result(
             message_type: content.content_type().to_string(),
             message_text: content.notification_text(&mentioned, &[]),
             image_url: content.notification_image_url(),
+            file_name: content.notification_file_name(),
             group_avatar_id: state.data.chat.avatar.as_ref().map(|d| d.id),
             crypto_transfer: content.notification_crypto_transfer_details(&mentioned),
         });

--- a/backend/canisters/group/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/group/impl/src/updates/start_video_call.rs
@@ -87,6 +87,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         message_type: result.message_event.event.content.content_type().to_string(),
         message_text: None,
         image_url: None,
+        file_name: None,
         group_avatar_id: state.data.chat.avatar.as_ref().map(|d| d.id),
         crypto_transfer: None,
     });

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -214,6 +214,7 @@ pub(crate) fn handle_message_impl(
             message_type,
             message_text,
             image_url,
+            file_name: content.notification_file_name(),
             sender_avatar_id: args.sender_avatar_id,
             crypto_transfer: content.notification_crypto_transfer_details(&[]),
         });

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -252,6 +252,7 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
                     message_type,
                     message_text,
                     image_url,
+                    file_name: message_content.notification_file_name(),
                     sender_avatar_id: None,
                     crypto_transfer: message_content.notification_crypto_transfer_details(&[]),
                 });

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -50,6 +50,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
             message_type: message_event.event.content.content_type().to_string(),
             message_text: None,
             image_url: None,
+            file_name: None,
             sender_avatar_id: args.initiator_avatar_id,
             crypto_transfer: None,
         });

--- a/backend/libraries/types/src/fcm_data.rs
+++ b/backend/libraries/types/src/fcm_data.rs
@@ -35,6 +35,14 @@ pub struct FcmData {
     pub body: Option<String>,
     #[serde(rename = "mt", default)]
     pub body_type: BodyType,
+    // The message content type (e.g. "Image", "Video", "Giphy", "File", "Audio"). Lets
+    // the client decide how to present the attachment (render an image inline vs. show a
+    // typed "shared a …" label). None for notifications without message content.
+    #[serde(rename = "ct", default)]
+    pub message_type: Option<String>,
+    // The attached file's name, for File messages. Shown by the client in the notification.
+    #[serde(rename = "fn", default)]
+    pub file_name: Option<String>,
     #[serde(rename = "i")]
     pub image: Option<String>,
     #[serde(rename = "s")]
@@ -58,6 +66,8 @@ impl FcmData {
             thread_root_message_index: None,
             body: None,
             body_type: BodyType::Message,
+            message_type: None,
+            file_name: None,
             image: None,
             sender_id: None,
             sender_name: None,
@@ -157,6 +167,17 @@ impl FcmData {
         Self { image, ..self }
     }
 
+    pub fn set_message_type(self, message_type: String) -> Self {
+        Self {
+            message_type: Some(message_type),
+            ..self
+        }
+    }
+
+    pub fn set_file_name(self, file_name: Option<String>) -> Self {
+        Self { file_name, ..self }
+    }
+
     pub fn set_sender_id(self, sender_id: UserId) -> Self {
         Self {
             sender_id: Some(sender_id),
@@ -216,6 +237,8 @@ impl FcmData {
 
         add_to_map("threadIndex", self.thread_root_message_index.map(|t| t.to_string()));
         add_to_map("image", self.image);
+        add_to_map("messageType", self.message_type);
+        add_to_map("fileName", self.file_name);
         add_to_map("body", self.body);
         add_to_map(
             "bodyType",
@@ -243,6 +266,8 @@ impl From<UserNotificationPayload> for FcmData {
                 .set_sender_avatar_id(n.sender_avatar_id)
                 .set_thread(n.thread_root_message_index)
                 .set_message(n.message_text)
+                .set_message_type(n.message_type)
+                .set_file_name(n.file_name)
                 .set_image(n.image_url),
             UserNotificationPayload::DirectReactionAdded(n) => FcmData::for_direct_chat(n.them)
                 .set_sender_name(n.display_name, n.username)
@@ -264,6 +289,8 @@ impl From<UserNotificationPayload> for FcmData {
                 .set_sender_avatar_id(n.group_avatar_id)
                 .set_thread(n.thread_root_message_index)
                 .set_message(n.message_text)
+                .set_message_type(n.message_type)
+                .set_file_name(n.file_name)
                 .set_image(n.image_url),
             UserNotificationPayload::GroupReactionAdded(n) => FcmData::for_group(n.chat_id)
                 .set_group_name(n.group_name)
@@ -290,6 +317,8 @@ impl From<UserNotificationPayload> for FcmData {
                 .set_sender_name(n.sender_display_name, n.sender_name)
                 .set_thread(n.thread_root_message_index)
                 .set_message(n.message_text)
+                .set_message_type(n.message_type)
+                .set_file_name(n.file_name)
                 .set_image(n.image_url),
             UserNotificationPayload::AddedToChannel(n) => FcmData::for_channel(n.community_id, n.channel_id)
                 .set_community_name(n.community_name)

--- a/backend/libraries/types/src/message_content.rs
+++ b/backend/libraries/types/src/message_content.rs
@@ -243,6 +243,30 @@ impl MessageContent {
         }
     }
 
+    pub fn notification_file_name(&self) -> Option<String> {
+        match self {
+            MessageContent::File(f) => Some(f.name.clone()),
+            MessageContent::Image(_)
+            | MessageContent::Video(_)
+            | MessageContent::Text(_)
+            | MessageContent::Audio(_)
+            | MessageContent::Poll(_)
+            | MessageContent::Crypto(_)
+            | MessageContent::Deleted(_)
+            | MessageContent::Giphy(_)
+            | MessageContent::GovernanceProposal(_)
+            | MessageContent::Prize(_)
+            | MessageContent::PrizeWinner(_)
+            | MessageContent::MessageReminderCreated(_)
+            | MessageContent::MessageReminder(_)
+            | MessageContent::ReportedMessage(_)
+            | MessageContent::P2PSwap(_)
+            | MessageContent::VideoCall(_)
+            | MessageContent::Encrypted(_)
+            | MessageContent::Custom(_) => None,
+        }
+    }
+
     pub fn content_type(&self) -> MessageContentType {
         self.into()
     }

--- a/backend/libraries/types/src/notifications.rs
+++ b/backend/libraries/types/src/notifications.rs
@@ -289,6 +289,8 @@ pub struct DirectMessageNotification {
     pub message_text: Option<String>,
     #[serde(rename = "i")]
     pub image_url: Option<String>,
+    #[serde(rename = "fn", default)]
+    pub file_name: Option<String>,
     #[serde(rename = "a")]
     pub sender_avatar_id: Option<u128>,
     #[serde(rename = "ct")]
@@ -320,6 +322,8 @@ pub struct GroupMessageNotification {
     pub message_text: Option<String>,
     #[serde(rename = "i")]
     pub image_url: Option<String>,
+    #[serde(rename = "fn", default)]
+    pub file_name: Option<String>,
     #[serde(rename = "a")]
     pub group_avatar_id: Option<u128>,
     #[serde(rename = "ct")]
@@ -355,6 +359,8 @@ pub struct ChannelMessageNotification {
     pub message_text: Option<String>,
     #[serde(rename = "i")]
     pub image_url: Option<String>,
+    #[serde(rename = "fn", default)]
+    pub file_name: Option<String>,
     #[serde(rename = "ca")]
     pub community_avatar_id: Option<u128>,
     #[serde(rename = "cha")]

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -5188,6 +5188,7 @@ export const DirectMessageNotification = Type.Object({
     ty: Type.String(),
     tx: Type.Optional(Type.String()),
     i: Type.Optional(Type.String()),
+    fn: Type.Optional(Type.String()),
     a: Type.Optional(Type.BigInt()),
     ct: Type.Optional(CryptoTransferDetails),
 });
@@ -5698,6 +5699,7 @@ export const ChannelMessageNotification = Type.Object({
     ty: Type.String(),
     tx: Type.Optional(Type.String()),
     i: Type.Optional(Type.String()),
+    fn: Type.Optional(Type.String()),
     ca: Type.Optional(Type.BigInt()),
     cha: Type.Optional(Type.BigInt()),
     ct: Type.Optional(CryptoTransferDetails),
@@ -5841,6 +5843,7 @@ export const GroupMessageNotification = Type.Object({
     ty: Type.String(),
     tx: Type.Optional(Type.String()),
     i: Type.Optional(Type.String()),
+    fn: Type.Optional(Type.String()),
     a: Type.Optional(Type.BigInt()),
     ct: Type.Optional(CryptoTransferDetails),
 });

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationImageHelper.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationImageHelper.kt
@@ -1,0 +1,102 @@
+package com.ocplugin.app
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.FileProvider
+import coil3.BitmapImage
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.bitmapConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+// Loads remote message attachments (e.g. shared photos / video thumbnails) for
+// rendering inline in a MessagingStyle notification.
+//
+// MessagingStyle.Message.setData() needs a Uri the system NotificationManager can
+// read; a remote https URL won't do. So we download the bitmap, cache it as a JPEG,
+// and hand back a content:// Uri via the app's FileProvider. The system grants
+// itself temporary read access to URIs placed in a posted notification, so no extra
+// permission grants are required.
+//
+// Everything is best-effort: any failure returns null so callers fall back to a
+// plain text-only message.
+@Suppress("UNUSED")
+object NotificationImageHelper {
+    // Subdir under cacheDir for downloaded attachment previews. Covered by the
+    // FileProvider <cache-path> root, so getUriForFile resolves files written here.
+    private const val CACHE_SUBDIR = "notification_images"
+
+    // Cap the longest edge. Notification bitmaps are shipped to the system over a
+    // Binder transaction (~1MB limit), so keep them small.
+    private const val MAX_DIM = 1024
+
+    private const val JPEG_QUALITY = 80
+
+    // Delete cached previews older than this on each render. Files referenced by a
+    // freshly-posted notification are well under this age, so they're never pruned
+    // out from under the system before it reads them.
+    private const val MAX_AGE_MS = 12 * 60 * 60 * 1000L
+
+    // Download + cache a single attachment, returning a content:// Uri or null.
+    suspend fun loadAttachmentUri(context: Context, url: String): Uri? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val bitmap = loadScaledBitmap(context, url) ?: return@withContext null
+                cacheAsContentUri(context, bitmap)
+            } catch (e: Exception) {
+                Log.e(OC_TAG_NOT, "Failed to load notification image: $url", e)
+                null
+            }
+        }
+    }
+
+    private suspend fun loadScaledBitmap(context: Context, url: String): Bitmap? {
+        // TODO reuse a shared ImageLoader (see AvatarHelper TODO).
+        val loader = ImageLoader(context)
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .bitmapConfig(Bitmap.Config.ARGB_8888)
+            .size(MAX_DIM)
+            .build()
+
+        val result = loader.execute(request)
+        if (result !is SuccessResult) {
+            Log.e(OC_TAG_NOT, "Notification image load failed: $result")
+            return null
+        }
+
+        val image = result.image
+        return if (image is BitmapImage) image.bitmap else null
+    }
+
+    private fun cacheAsContentUri(context: Context, bitmap: Bitmap): Uri {
+        val dir = File(context.cacheDir, CACHE_SUBDIR).apply { mkdirs() }
+        val file = File(dir, "notif_${System.currentTimeMillis()}_${bitmap.hashCode()}.jpg")
+        file.outputStream().use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out)
+        }
+
+        val authority = "${context.packageName}.fileprovider"
+        return FileProvider.getUriForFile(context, authority, file)
+    }
+
+    // Best-effort cleanup of stale cached previews. Safe to call on every render.
+    fun pruneOldImages(context: Context) {
+        try {
+            val dir = File(context.cacheDir, CACHE_SUBDIR)
+            if (!dir.isDirectory) return
+
+            val cutoff = System.currentTimeMillis() - MAX_AGE_MS
+            dir.listFiles()?.forEach { file ->
+                if (file.lastModified() < cutoff) file.delete()
+            }
+        } catch (e: Exception) {
+            Log.e(OC_TAG_NOT, "Failed to prune notification images", e)
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
@@ -104,13 +104,16 @@ object NotificationsManager {
         // Resolve attachment images up front, in parallel, so the per-message loop
         // below stays synchronous. Each message can carry at most one inline image
         // (MessagingStyle limitation); messages without one render as plain text.
-        // Any failed/absent download maps to null and falls back to text.
+        // Only still images are rendered inline — videos send a thumbnail URL too, but
+        // we present those (and gifs/files/etc.) as a typed text label instead, so we
+        // skip the download for them. Any failed/absent download maps to null and falls
+        // back to text.
         val imageUris = coroutineScope {
             notifications.map { n ->
                 async {
-                    n.image?.takeIf { it.isNotBlank() }?.let {
-                        NotificationImageHelper.loadAttachmentUri(context, it)
-                    }
+                    n.image
+                        ?.takeIf { it.isNotBlank() && NotificationCompanion.isRenderableImage(n) }
+                        ?.let { NotificationImageHelper.loadAttachmentUri(context, it) }
                 }
             }.awaitAll()
         }

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
@@ -11,6 +11,9 @@ import app.tauri.plugin.JSObject
 import com.ocplugin.app.data.*
 import com.ocplugin.app.decoders.NotificationDecoder
 import com.ocplugin.app.models.Conversation
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 
 // TODO Fix video call notification
 // TODO Notification management improvements
@@ -98,9 +101,23 @@ object NotificationsManager {
         val you = Person.Builder().setName("You").build()
         val messagingStyle = NotificationCompat.MessagingStyle(you)
 
+        // Resolve attachment images up front, in parallel, so the per-message loop
+        // below stays synchronous. Each message can carry at most one inline image
+        // (MessagingStyle limitation); messages without one render as plain text.
+        // Any failed/absent download maps to null and falls back to text.
+        val imageUris = coroutineScope {
+            notifications.map { n ->
+                async {
+                    n.image?.takeIf { it.isNotBlank() }?.let {
+                        NotificationImageHelper.loadAttachmentUri(context, it)
+                    }
+                }
+            }.awaitAll()
+        }
+
         // Build personas list
         val persons = mutableListOf<Person>()
-        notifications.forEach { n ->
+        notifications.forEachIndexed { index, n ->
             val personBuilder = Person.Builder()
                 .setName(n.senderName)
                 .setImportant(true)
@@ -110,12 +127,19 @@ object NotificationsManager {
             }
 
             persons.add(personBuilder.build())
-            messagingStyle.addMessage(
+
+            val message = NotificationCompat.MessagingStyle.Message(
                 NotificationCompanion.toMessage(n),
                 n.receivedAt,
                 persons.last()
             )
+            imageUris[index]?.let { uri ->
+                message.setData("image/jpeg", uri)
+            }
+            messagingStyle.addMessage(message)
         }
+
+        NotificationImageHelper.pruneOldImages(context)
 
         // Get the conversation context type for the new notification
         val title = NotificationCompanion.toTitle(notification)

--- a/frontend/tauri-plugin-oc/android/src/main/java/data/AppDb.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/data/AppDb.kt
@@ -27,6 +27,8 @@ abstract class AppDb: RoomDatabase() {
             override fun migrate(connection: SQLiteConnection) {
                 connection.execSQL("ALTER TABLE notifications ADD COLUMN messageType TEXT")
                 connection.execSQL("ALTER TABLE notifications ADD COLUMN fileName TEXT")
+                // Backfill messageType for pre-v2 rows to preserve thumbnail rendering.
+                connection.execSQL("UPDATE notifications SET messageType = 'Image' WHERE image IS NOT NULL AND TRIM(image) <> ''")
             }
         }
 

--- a/frontend/tauri-plugin-oc/android/src/main/java/data/AppDb.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/data/AppDb.kt
@@ -5,10 +5,13 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
 
 @Database(
     entities = [Notification::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -18,6 +21,15 @@ abstract class AppDb: RoomDatabase() {
     companion object {
         @Volatile private var INSTANCE: AppDb? = null
 
+        // v2: add the nullable `messageType` and `fileName` columns to `notifications`,
+        // backing inline image vs. typed "shared a …" notification rendering.
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE notifications ADD COLUMN messageType TEXT")
+                connection.execSQL("ALTER TABLE notifications ADD COLUMN fileName TEXT")
+            }
+        }
+
         fun init(context: Context) {
             if (INSTANCE == null) {
                 synchronized(this) {
@@ -26,7 +38,9 @@ abstract class AppDb: RoomDatabase() {
                             context.applicationContext,
                             AppDb::class.java,
                             "app.db"
-                        ).build()
+                        )
+                            .addMigrations(MIGRATION_1_2)
+                            .build()
                     }
                 }
             }

--- a/frontend/tauri-plugin-oc/android/src/main/java/data/Notification.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/data/Notification.kt
@@ -90,7 +90,12 @@ object NotificationCompanion {
     // True when the attachment is a still image we render inline in the notification.
     // Videos, gifs, files, etc. are presented as a typed text label instead (see
     // attachmentLabel), so they should not be downloaded/rendered as a thumbnail.
-    fun isRenderableImage(notification: Notification): Boolean = notification.messageType == TYPE_IMAGE
+    //
+    // Pre-v2 rows predate messageType, so a null messageType with a populated image URL
+    // is treated as a renderable image to preserve the original behavior.
+    fun isRenderableImage(notification: Notification): Boolean =
+        notification.messageType == TYPE_IMAGE ||
+            (notification.messageType == null && !notification.image.isNullOrBlank())
 
     // TODO i18n
     // TODO would be cool if we could have a part of the parent message when dealing with threads
@@ -132,7 +137,9 @@ object NotificationCompanion {
             TYPE_GIPHY -> "🎞️ " + (caption ?: "Shared a GIF")
             TYPE_AUDIO -> "🎙️ " + (caption ?: "Shared audio")
             TYPE_FILE -> "📎 " + (notification.fileName?.takeIf { it.isNotBlank() } ?: caption ?: "Shared a file")
-            else -> notification.body
+            // Pre-v2 rows have no messageType; an image-only row would otherwise render as
+            // empty text, so fall back to the image placeholder when an image URL is present.
+            else -> caption ?: if (!notification.image.isNullOrBlank()) "📷 Photo" else notification.body
         }
     }
 

--- a/frontend/tauri-plugin-oc/android/src/main/java/data/Notification.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/data/Notification.kt
@@ -68,6 +68,11 @@ data class Notification(
     val body: String,
     val bodyType: BodyType,
     val image: String? = null,
+    // Message content type as sent by the backend ("Image", "Video", "Giphy", "File",
+    // "Audio", "Text", ...). Drives how an attachment is presented in the notification.
+    val messageType: String? = null,
+    // Attached file's name, for "File" messages.
+    val fileName: String? = null,
 
     // Metadata for the notification.
     val isReleased: Boolean = false,
@@ -75,6 +80,18 @@ data class Notification(
 )
 
 object NotificationCompanion {
+    // Message content types, matching the backend's MessageContentType Display strings.
+    const val TYPE_IMAGE = "Image"
+    const val TYPE_VIDEO = "Video"
+    const val TYPE_GIPHY = "Giphy"
+    const val TYPE_AUDIO = "Audio"
+    const val TYPE_FILE = "File"
+
+    // True when the attachment is a still image we render inline in the notification.
+    // Videos, gifs, files, etc. are presented as a typed text label instead (see
+    // attachmentLabel), so they should not be downloaded/rendered as a thumbnail.
+    fun isRenderableImage(notification: Notification): Boolean = notification.messageType == TYPE_IMAGE
+
     // TODO i18n
     // TODO would be cool if we could have a part of the parent message when dealing with threads
     fun toTitle(notification: Notification): String {
@@ -96,6 +113,25 @@ object NotificationCompanion {
             BodyType.REACTION -> "${notification.senderName} reacted with ${notification.body}"
             BodyType.TIP -> "${notification.senderName} sent a tip of ${notification.body}"
             BodyType.INVITE -> "${notification.senderName} invited you to ${notification.body}"
+            else -> attachmentLabel(notification)
+        }
+    }
+
+    // Builds the text shown for a message, accounting for non-text attachments.
+    //
+    // Images are rendered inline (see NotificationsManager), so we show the caption if any
+    // and otherwise a "📷 Photo" placeholder. Videos, gifs, audio and files are NOT rendered,
+    // so we tag them with an emoji + a "shared a …" label (or the caption / file name when
+    // available) to make the content type obvious at a glance.
+    // TODO i18n
+    private fun attachmentLabel(notification: Notification): String {
+        val caption = notification.body.takeIf { it.isNotBlank() }
+        return when (notification.messageType) {
+            TYPE_IMAGE -> caption ?: "📷 Photo"
+            TYPE_VIDEO -> "🎥 " + (caption ?: "Shared a video")
+            TYPE_GIPHY -> "🎞️ " + (caption ?: "Shared a GIF")
+            TYPE_AUDIO -> "🎙️ " + (caption ?: "Shared audio")
+            TYPE_FILE -> "📎 " + (notification.fileName?.takeIf { it.isNotBlank() } ?: caption ?: "Shared a file")
             else -> notification.body
         }
     }
@@ -121,6 +157,8 @@ object NotificationCompanion {
             .put("body", notification.body)
             .put("bodyType", notification.bodyType.name)
             .put("image", notification.image)
+            .put("messageType", notification.messageType)
+            .put("fileName", notification.fileName)
             .put("receivedAt", notification.receivedAt)
     }
 }

--- a/frontend/tauri-plugin-oc/android/src/main/java/decoders/NotificationDecoder.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/decoders/NotificationDecoder.kt
@@ -50,6 +50,8 @@ object NotificationDecoder {
                     body = data["body"] ?: "",
                     bodyType = decodeBodyType(data),
                     image = data["image"],
+                    messageType = data["messageType"],
+                    fileName = data["fileName"],
                 )
             } else {
                 Log.e(LOG_TAG, "Unknown notification type: $data")


### PR DESCRIPTION
- Add NotificationImageHelper: downloads the attachment via Coil, downscales it
  (longest edge <= 1024px to stay under the Binder transaction limit), caches it
  as a JPEG, and returns a content:// Uri via the app's FileProvider so the
  system NotificationManager can read it
- Attach the image to each MessagingStyle.Message via setData(); messages with
  several photos coalesce into one notification, each showing its own thumbnail
- Resolve attachment URIs in parallel before building messages, so the per-message
  loop stays synchronous and download latency is bounded by the slowest image
- Best-effort throughout: a failed/absent download falls back to a text-only
  message, so notifications never break on a bad image
- Prune cached previews older than 12h on each render to bound cache growth
- Forward the message content type into the FCM payload: FcmData now carries
  `messageType` (Image/Video/Giphy/File/Audio) and `fileName`, plumbed from the
  notification payloads through FcmData::from + as_data so the device can tell
  attachment kinds apart (previously it only saw an image URL, so video thumbnails
  rendered like photos)
- Add `file_name` to the Direct/Group/Channel message notification payloads and a
  `MessageContent::notification_file_name()` helper to source it
- Android: only render an inline thumbnail for real images; present videos, gifs,
  audio and files as an emoji-tagged "shared a …" label (🎥 video, 🎞️  gif,
  📎 <filename>, 🎙️  audio), falling back to the caption when present
- Android: bump Room DB to v2 with a migration adding the nullable `messageType`
  and `fileName` columns to the notifications table
- Keep the generated typebox bindings in sync with the new `fn` field

<img width="529" height="211" alt="image" src="https://github.com/user-attachments/assets/f07aa51d-9a67-43df-bc52-5d7efce669c9" />

<img width="1079" height="563" alt="image" src="https://github.com/user-attachments/assets/c4b21d2c-d5b8-4ed3-be11-f002b975ba0b" />
