### PR TITLE
Sunset DecideAI unique-personhood verification

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Suspend "verified user" (unique person) gating - the gate now always passes ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
+- Suspend "verified user" (unique person) gating - the gate is ignored, filtered out of composite gates so an OR gate requires another branch ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
 - Allow specifying which inner composite gate to check ([#8987](https://github.com/open-chat-labs/open-chat/pull/8987))
 
 ### Fixed

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Suspend "verified user" (unique person) gating - the gate now always passes ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
 - Allow specifying which inner composite gate to check ([#8987](https://github.com/open-chat-labs/open-chat/pull/8987))
 
 ### Fixed

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Suspend "verified user" (unique person) gating - the gate now always passes ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
+- Suspend "verified user" (unique person) gating - the gate is ignored, filtered out of composite gates so an OR gate requires another branch ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
 - Allow specifying which inner composite gate to check ([#8987](https://github.com/open-chat-labs/open-chat/pull/8987))
 
 ### Fixed

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Suspend "verified user" (unique person) gating - the gate now always passes ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
 - Allow specifying which inner composite gate to check ([#8987](https://github.com/open-chat-labs/open-chat/pull/8987))
 
 ### Fixed

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Suspend "verified user" (unique person) prize gating - every user is now eligible ([#9061](https://github.com/open-chat-labs/open-chat/pull/9061))
 - Remove option to verify using delegation when updating PIN ([#8811](https://github.com/open-chat-labs/open-chat/pull/8811))
 
 ### Removed

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -1052,7 +1052,7 @@ impl ChatEvents {
         message: &mut MessageInternal,
         user_id: UserId,
         now: TimestampMillis,
-        is_unique_person: bool,
+        _is_unique_person: bool,
         diamond_status: DiamondMembershipStatus,
         total_chit_earned: u32,
         streak: u16,
@@ -1075,9 +1075,7 @@ impl ChatEvents {
             return Err(UpdateEventError::NoChange(OCErrorCode::PrizeUserNotElligible));
         }
 
-        if content.unique_person_only && !is_unique_person {
-            return Err(UpdateEventError::NoChange(OCErrorCode::PrizeUserNotElligible));
-        }
+        // Unique person verification (DecideAI) is suspended - every user is eligible.
 
         if content.min_chit_earned > total_chit_earned {
             return Err(UpdateEventError::NoChange(OCErrorCode::PrizeUserNotElligible));

--- a/backend/libraries/gated_groups/src/lib.rs
+++ b/backend/libraries/gated_groups/src/lib.rs
@@ -140,12 +140,9 @@ fn check_lifetime_diamond_member_gate(
     }
 }
 
-fn check_unique_person_gate(is_unique_person: bool) -> CheckIfPassesGateResult {
-    if is_unique_person {
-        CheckIfPassesGateResult::Success(Vec::new())
-    } else {
-        CheckIfPassesGateResult::Failed(GateCheckFailedReason::NoUniquePersonProof)
-    }
+fn check_unique_person_gate(_is_unique_person: bool) -> CheckIfPassesGateResult {
+    // Unique person verification (DecideAI) is suspended - always pass.
+    CheckIfPassesGateResult::Success(Vec::new())
 }
 
 fn check_chit_earned_gate(gate: &ChitEarnedGate, total_chit_earned: i32) -> CheckIfPassesGateResult {

--- a/backend/libraries/gated_groups/src/lib.rs
+++ b/backend/libraries/gated_groups/src/lib.rs
@@ -145,6 +145,18 @@ fn check_unique_person_gate(_is_unique_person: bool) -> CheckIfPassesGateResult 
     CheckIfPassesGateResult::Success(Vec::new())
 }
 
+// Unique person verification (DecideAI) is suspended, so a unique-person gate is treated as absent
+// within a composite gate: filtered out before the gate is evaluated. An OR gate therefore requires
+// one of its other branches (no one is a unique person), while an AND gate is unaffected (everyone
+// is a unique person). This runs after the explicit composite_gate_index path, which still indexes
+// into the original inner gates.
+fn filter_out_suspended_gates(inner: Vec<AccessGateNonComposite>) -> Vec<AccessGateNonComposite> {
+    inner
+        .into_iter()
+        .filter(|g| !matches!(g, AccessGateNonComposite::UniquePerson))
+        .collect()
+}
+
 fn check_chit_earned_gate(gate: &ChitEarnedGate, total_chit_earned: i32) -> CheckIfPassesGateResult {
     if total_chit_earned.max(0) as u32 >= gate.min_chit_earned {
         CheckIfPassesGateResult::Success(Vec::new())
@@ -222,6 +234,14 @@ async fn check_composite_gate(gate: CompositeGate, args: CheckGateArgs) -> Check
         };
     }
 
+    let gate = CompositeGate {
+        inner: filter_out_suspended_gates(gate.inner),
+        and: gate.and,
+    };
+    if gate.inner.is_empty() {
+        return CheckIfPassesGateResult::Success(Vec::new());
+    }
+
     if let Some(result) = check_composite_gate_synchronously(gate.clone(), args.clone()) {
         return result;
     }
@@ -249,6 +269,13 @@ async fn check_composite_gate(gate: CompositeGate, args: CheckGateArgs) -> Check
 }
 
 fn check_composite_gate_synchronously(gate: CompositeGate, args: CheckGateArgs) -> Option<CheckIfPassesGateResult> {
+    let gate = CompositeGate {
+        inner: filter_out_suspended_gates(gate.inner),
+        and: gate.and,
+    };
+    if gate.inner.is_empty() {
+        return Some(CheckIfPassesGateResult::Success(Vec::new()));
+    }
     let count = gate.inner.len();
     let mut any_require_async = false;
     for (index, inner) in gate.inner.into_iter().enumerate() {

--- a/backend/libraries/gated_groups/src/lib.rs
+++ b/backend/libraries/gated_groups/src/lib.rs
@@ -227,11 +227,16 @@ async fn check_composite_gate(gate: CompositeGate, args: CheckGateArgs) -> Check
     if !gate.and
         && let Some(gate_index) = args.composite_gate_index
     {
-        return if let Some(inner) = gate.inner.get(gate_index as usize) {
-            check_non_composite_gate(inner.clone(), args).await
-        } else {
-            CheckIfPassesGateResult::Error(OCErrorCode::InvalidRequest.with_message("Gate index out of range"))
-        };
+        match gate.inner.get(gate_index as usize) {
+            // A suspended (unique-person) gate is treated as absent, so a request that selects it
+            // must not short-circuit to Success - fall through to the filtered evaluation, which
+            // still requires a real branch. The backend is the trust boundary here.
+            Some(AccessGateNonComposite::UniquePerson) => {}
+            Some(inner) => return check_non_composite_gate(inner.clone(), args).await,
+            None => {
+                return CheckIfPassesGateResult::Error(OCErrorCode::InvalidRequest.with_message("Gate index out of range"));
+            }
+        }
     }
 
     let gate = CompositeGate {
@@ -242,7 +247,7 @@ async fn check_composite_gate(gate: CompositeGate, args: CheckGateArgs) -> Check
         return CheckIfPassesGateResult::Success(Vec::new());
     }
 
-    if let Some(result) = check_composite_gate_synchronously(gate.clone(), args.clone()) {
+    if let Some(result) = check_composite_gate_synchronously_inner(gate.clone(), args.clone()) {
         return result;
     }
 
@@ -276,6 +281,11 @@ fn check_composite_gate_synchronously(gate: CompositeGate, args: CheckGateArgs) 
     if gate.inner.is_empty() {
         return Some(CheckIfPassesGateResult::Success(Vec::new()));
     }
+    check_composite_gate_synchronously_inner(gate, args)
+}
+
+// Assumes suspended (unique-person) gates have already been filtered out of `gate.inner`.
+fn check_composite_gate_synchronously_inner(gate: CompositeGate, args: CheckGateArgs) -> Option<CheckIfPassesGateResult> {
     let count = gate.inner.len();
     let mut any_require_async = false;
     for (index, inner) in gate.inner.into_iter().enumerate() {

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -30,6 +30,7 @@
         selectedChatUserGroupKeysStore,
         selectedCommunitySummaryStore,
         showMiddle,
+        stripSuspendedGate,
         threadOpenStore,
         unconfirmedStore,
     } from "openchat-client";
@@ -245,7 +246,8 @@
             ($selectedCommunitySummaryStore.membership.role === ROLE_NONE ||
                 $selectedCommunitySummaryStore.membership.lapsed) &&
             (!$selectedCommunitySummaryStore.public ||
-                $selectedCommunitySummaryStore.gateConfig.gate.kind !== "no_gate"),
+                stripSuspendedGate($selectedCommunitySummaryStore.gateConfig.gate).kind !==
+                    "no_gate"),
     );
     let privatePreview = $derived(privateCommunityPreview || privateChatPreview);
     let isEmptyChat = $derived(chat.latestEventIndex <= 0 || privatePreview);

--- a/frontend/app/src/components/home/PrizeContent.svelte
+++ b/frontend/app/src/components/home/PrizeContent.svelte
@@ -5,7 +5,6 @@
         chitBands,
         chitStateStore,
         cryptoLookup,
-        currentUserStore,
         isDiamondStore,
         isLifetimeDiamondStore,
         mobileWidth,
@@ -28,7 +27,6 @@
     import ButtonGroup from "../ButtonGroup.svelte";
     import Diamond from "../icons/Diamond.svelte";
     import SpinningToken from "../icons/SpinningToken.svelte";
-    import Verified from "../icons/Verified.svelte";
     import SecureButton from "../SecureButton.svelte";
     import Translatable from "../Translatable.svelte";
     import Badges from "./profile/Badges.svelte";
@@ -77,10 +75,6 @@
         publish("upgrade");
     }
 
-    function onUniquePersonClick() {
-        publish("verifyHumanity");
-    }
-
     function onStreakClick() {
         publish("claimDailyChit");
     }
@@ -97,7 +91,7 @@
     let userEligible = $derived(
         (!content.diamondOnly || $isDiamondStore) &&
             (!content.lifetimeDiamondOnly || $isLifetimeDiamondStore) &&
-            (!content.uniquePersonOnly || $currentUserStore.isUniquePerson) &&
+            // Unique person ("verified user") gating is suspended - always eligible
             content.streakOnly <= $chitStateStore.streak &&
             content.minChitEarned <= $chitStateStore.totalChitEarned,
     );
@@ -117,7 +111,6 @@
     let restrictedPrize = $derived(
         content.diamondOnly ||
             content.lifetimeDiamondOnly ||
-            content.uniquePersonOnly ||
             content.streakOnly > 0 ||
             content.requiresCaptcha ||
             content.minChitEarned > 0,
@@ -161,7 +154,7 @@
                 <div class="badges">
                     <Badges
                         {diamondStatus}
-                        uniquePerson={content.uniquePersonOnly}
+                        uniquePerson={false}
                         chitEarned={content.minChitEarned}
                         streak={content.streakOnly} />
                 </div>
@@ -223,17 +216,7 @@
                                 )} />
                         </div>
                     {/if}
-                    {#if content.uniquePersonOnly}
-                        <div onclick={onUniquePersonClick}>
-                            <div>
-                                <Verified
-                                    size={"small"}
-                                    verified={content.uniquePersonOnly}
-                                    tooltip={i18nKey("prizes.uniquePerson")} />
-                            </div>
-                            <Translatable resourceKey={i18nKey("prizes.uniquePerson")} />
-                        </div>
-                    {/if}
+                    <!-- Unique person ("verified user") gating is suspended -->
                     {#if content.streakOnly > 0}
                         <div onclick={onStreakClick}>
                             <div><Streak days={content.streakOnly} /></div>

--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -492,10 +492,7 @@
                                             group={"diamond"} />
                                     </div>
                                 {/if}
-                                <Checkbox
-                                    id="unique_person_only"
-                                    label={i18nKey(`prizes.onlyUniquePerson`)}
-                                    bind:checked={uniquePersonOnly} />
+                                <!-- Unique person ("verified user") gating is suspended -->
                                 <Checkbox
                                     id="streak_only"
                                     label={i18nKey(`prizes.onlyStreak`)}

--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -96,7 +96,9 @@
     let selectedDuration: Duration = $state($prizeConfig.duration);
     let diamondType: "none" | "standard" | "lifetime" = $state($prizeConfig.diamond);
     let diamondOnly = $derived(diamondType !== "none");
-    let uniquePersonOnly = $state($prizeConfig.uniquePersonOnly);
+    // Unique-person ("verified user") gating is suspended - force off so a value persisted from a
+    // previous session can't be silently reapplied (the restriction control is removed).
+    const uniquePersonOnly = false;
     let minStreak = $state<number>($prizeConfig.minStreak);
     let minChitEarned = $state<number>($prizeConfig.minChitEarned);
     let streakOnly = $derived(minStreak > 0);
@@ -327,7 +329,6 @@
     function onAnyUserChecked() {
         anyUser = true;
         diamondType = "none";
-        uniquePersonOnly = false;
         streakOnly = false;
         chitOnly = false;
     }

--- a/frontend/app/src/components/home/VisibilityControl.svelte
+++ b/frontend/app/src/components/home/VisibilityControl.svelte
@@ -5,6 +5,7 @@
         isDiamondStore,
         type OpenChat,
         publish,
+        stripSuspendedGate,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
@@ -48,7 +49,7 @@
         if (
             gateDirty &&
             candidate.kind === "candidate_group_chat" &&
-            candidate.gateConfig.gate.kind !== "no_gate"
+            stripSuspendedGate(candidate.gateConfig.gate).kind !== "no_gate"
         ) {
             candidate.messagesVisibleToNonMembers = false;
         }
@@ -61,7 +62,7 @@
         }
         if (candidate.kind === "candidate_group_chat") {
             candidate.messagesVisibleToNonMembers =
-                candidate.public && candidate.gateConfig.gate.kind === "no_gate";
+                candidate.public && stripSuspendedGate(candidate.gateConfig.gate).kind === "no_gate";
         }
     }
 

--- a/frontend/app/src/components/home/access/AccessGateBuilder.svelte
+++ b/frontend/app/src/components/home/access/AccessGateBuilder.svelte
@@ -6,6 +6,7 @@
         isLeafGate,
         isUniquePersonGate,
         nervousSystemLookup,
+        stripSuspendedGate,
         type AccessGate,
         type AccessGateConfig,
         type Level,
@@ -132,7 +133,9 @@
         {/snippet}
         {#snippet body()}
             <div class="body access-gate-builder">
-                {#if isLeafGate(gateConfig.gate)}
+                <!-- A lone unique-person gate is suspended: render neither branch so it shows as no
+                     gate and can't be edited/overwritten - the gate stays dormant in gateConfig. -->
+                {#if isLeafGate(gateConfig.gate) && !isUniquePersonGate(gateConfig.gate)}
                     <LeafGateBuilder
                         {gateBindings}
                         {neuronGateBindings}
@@ -201,7 +204,7 @@
                     </div>
                 {/if}
 
-                {#if gateConfig.gate.kind !== "no_gate"}
+                {#if stripSuspendedGate(gateConfig.gate).kind !== "no_gate"}
                     {#if editable}
                         <div class="section expiry">
                             <Checkbox

--- a/frontend/app/src/components/home/access/AccessGateBuilder.svelte
+++ b/frontend/app/src/components/home/access/AccessGateBuilder.svelte
@@ -4,6 +4,7 @@
         iconSize,
         isCompositeGate,
         isLeafGate,
+        isUniquePersonGate,
         nervousSystemLookup,
         type AccessGate,
         type AccessGateConfig,
@@ -66,8 +67,13 @@
     let title = $derived(!editable ? i18nKey("access.readonlyTitle") : i18nKey("access.title"));
 
     $effect(() => {
+        // Suspended (unique person) gate rows are hidden so never report validity - treat them as
+        // valid, otherwise their unset entry would make the whole gate invalid.
+        const gates = isCompositeGate(gateConfig.gate)
+            ? gateConfig.gate.gates
+            : [gateConfig.gate];
         const isValid =
-            gateValidity.every((v) => v) &&
+            gates.every((g, i) => isUniquePersonGate(g) || gateValidity[i]) &&
             (gateConfig.expiry !== undefined ? !editable || evaluationIntervalValid : true);
 
         if (isValid !== valid) {
@@ -139,6 +145,9 @@
                         bind:valid={gateValidity[0]} />
                 {:else if isCompositeGate(gateConfig.gate)}
                     {#each gateConfig.gate.gates as subgate, i (`${subgate.kind} + ${i}`)}
+                        <!-- Unique person (DecideAI) verification is suspended - hide the row but keep
+                             it in the bound gateConfig (index i stays aligned for edit/delete). -->
+                        {#if !isUniquePersonGate(subgate)}
                         <CollapsibleCard
                             transition={false}
                             open={selectedGateIndex === i}
@@ -173,6 +182,7 @@
                                 {level}
                                 bind:valid={gateValidity[i]} />
                         </CollapsibleCard>
+                        {/if}
                     {/each}
                 {/if}
                 {#if editable}

--- a/frontend/app/src/components/home/access/AccessGateControl.svelte
+++ b/frontend/app/src/components/home/access/AccessGateControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { iconSize, type AccessGateConfig, type Level } from "openchat-client";
+    import { iconSize, stripSuspendedGate, type AccessGateConfig, type Level } from "openchat-client";
     import { _ } from "svelte-i18n";
     import LockOutline from "svelte-material-icons/LockOutline.svelte";
     import { fade } from "svelte/transition";
@@ -33,7 +33,7 @@
                 editable
                 bind:gateConfig />
         </div>
-        {#if gateConfig.gate.kind !== "no_gate"}
+        {#if stripSuspendedGate(gateConfig.gate).kind !== "no_gate"}
             <AlertBox>
                 <Translatable
                     resourceKey={i18nKey("access.bypassWarning", undefined, level, true)} />

--- a/frontend/app/src/components/home/access/AccessGateEvaluator.svelte
+++ b/frontend/app/src/components/home/access/AccessGateEvaluator.svelte
@@ -179,20 +179,24 @@
                     </p>
 
                     {#each currentGate.gates as subgate, i}
-                        <div class="optional-gate">
-                            <Radio
-                                group={"optional_gates"}
-                                checked={!optionalGatesByIndex.has(i)}
-                                onChange={() => toggleIndex(i, currentGate)}
-                                label={i18nKey(subgate.kind)}
-                                id={`subgate_${i}`}>
-                                <AccessGateSummary
-                                    editable={false}
-                                    level={currentGate.level}
-                                    showNoGate={false}
-                                    gateConfig={{ expiry: undefined, gate: subgate }} />
-                            </Radio>
-                        </div>
+                        <!-- Unique person (DecideAI) verification is suspended - hide it as an option.
+                             Keep the original index i so compositeGateIndex still maps to the real gate. -->
+                        {#if !isUniquePersonGate(subgate)}
+                            <div class="optional-gate">
+                                <Radio
+                                    group={"optional_gates"}
+                                    checked={!optionalGatesByIndex.has(i)}
+                                    onChange={() => toggleIndex(i, currentGate)}
+                                    label={i18nKey(subgate.kind)}
+                                    id={`subgate_${i}`}>
+                                    <AccessGateSummary
+                                        editable={false}
+                                        level={currentGate.level}
+                                        showNoGate={false}
+                                        gateConfig={{ expiry: undefined, gate: subgate }} />
+                                </Radio>
+                            </div>
+                        {/if}
                     {/each}
                 {:else if isCredentialGate(currentGate)}
                     <CredentialGateEvaluator

--- a/frontend/app/src/components/home/access/AccessGateIcon.svelte
+++ b/frontend/app/src/components/home/access/AccessGateIcon.svelte
@@ -10,10 +10,10 @@
         isPaymentGate,
         type Level,
         OpenChat,
+        stripSuspendedGate,
     } from "openchat-client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
-    import AccountCheck from "svelte-material-icons/AccountCheck.svelte";
     import AccountPlusOutline from "svelte-material-icons/AccountPlusOutline.svelte";
     import Alarm from "svelte-material-icons/Alarm.svelte";
     import ShieldLockOpenOutline from "svelte-material-icons/ShieldLockOpenOutline.svelte";
@@ -95,8 +95,11 @@
             ev.preventDefault();
         }
     }
-    let tokenDetails = $derived(client.getTokenDetailsForAccessGate(gateConfig.gate));
-    let params = $derived(formatParams(gateConfig.gate, tokenDetails));
+    // The unique person ("verified user") concept is suspended, so strip it for display: a
+    // standalone unique person gate renders as no gate, a composite gate drops it and collapses.
+    let gate = $derived(stripSuspendedGate(gateConfig.gate));
+    let tokenDetails = $derived(client.getTokenDetailsForAccessGate(gate));
+    let params = $derived(formatParams(gate, tokenDetails));
     let defaultColor = $derived(button ? "var(--button-txt)" : "var(--icon-txt)");
 </script>
 
@@ -112,7 +115,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div onclick={onClick} class="wrapper">
-    {#if gateConfig.gate.kind === "no_gate" && showNoGate}
+    {#if gate.kind === "no_gate" && showNoGate}
         <Tooltip {position} {align}>
             <div class="open">
                 <ShieldLockOpenOutline size={$iconSize} color={defaultColor} />
@@ -121,7 +124,7 @@
                 <Translatable resourceKey={i18nKey("access.openAccessInfo")} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "locked_gate"}
+    {:else if gate.kind === "locked_gate"}
         <Tooltip {position} {align}>
             <div class="locked"></div>
             {#snippet popupTemplate()}
@@ -129,7 +132,7 @@
                     resourceKey={i18nKey("access.lockedGateInfo", undefined, level, true)} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "chit_earned_gate"}
+    {:else if gate.kind === "chit_earned_gate"}
         <Tooltip {position} {align}>
             <div class="chit"></div>
             {#snippet popupTemplate()}
@@ -137,7 +140,7 @@
                     resourceKey={i18nKey("access.chitEarnedGateInfo", undefined, level, true)} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "composite_gate"}
+    {:else if gate.kind === "composite_gate"}
         <Tooltip {position} {align}>
             <div class="composite">
                 <VectorCombine size={$iconSize} color={defaultColor} />
@@ -146,7 +149,7 @@
                 <Translatable resourceKey={i18nKey("access.compositeGate")} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "diamond_gate"}
+    {:else if gate.kind === "diamond_gate"}
         <Tooltip {position} {align}>
             <div class="diamond">
                 <BlueDiamond />
@@ -155,7 +158,7 @@
                 <Translatable resourceKey={i18nKey("access.diamondGateInfo")} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "lifetime_diamond_gate"}
+    {:else if gate.kind === "lifetime_diamond_gate"}
         <Tooltip {position} {align}>
             <div class="diamond">
                 <GoldDiamond />
@@ -164,24 +167,14 @@
                 <Translatable resourceKey={i18nKey("access.lifetimeDiamondGateInfo")} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "unique_person_gate"}
-        <Tooltip {position} {align}>
-            <div class="unique">
-                <AccountCheck size={$iconSize} color={defaultColor} />
-            </div>
-            {#snippet popupTemplate()}
-                <Translatable resourceKey={i18nKey("access.uniquePersonInfo")} />
-            {/snippet}
-        </Tooltip>
-    {:else if gateConfig.gate.kind === "credential_gate"}
-        {@const gate = gateConfig.gate}
+    {:else if gate.kind === "credential_gate"}
         <Tooltip {position} {align}>
             <div class="credential">🔒️</div>
             {#snippet popupTemplate()}
                 <CredentialGatePopup {gate} />
             {/snippet}
         </Tooltip>
-    {:else if gateConfig.gate.kind === "referred_by_member_gate"}
+    {:else if gate.kind === "referred_by_member_gate"}
         <Tooltip {position} {align}>
             <div class="referred_by_member">
                 <AccountPlusOutline size={$iconSize} color={defaultColor} />
@@ -190,7 +183,7 @@
                 <Translatable resourceKey={i18nKey("access.referredByMemberInfo")} />
             {/snippet}
         </Tooltip>
-    {:else if isNeuronGate(gateConfig.gate)}
+    {:else if isNeuronGate(gate)}
         <Tooltip {position} {align}>
             <img class="icon" class:small src={tokenDetails?.logo} />
             {#snippet popupTemplate()}
@@ -204,7 +197,7 @@
                 <p class="params">{params}</p>
             {/snippet}
         </Tooltip>
-    {:else if isPaymentGate(gateConfig.gate)}
+    {:else if isPaymentGate(gate)}
         <Tooltip {position} {align}>
             <img class="icon" class:small src={tokenDetails?.logo} />
             {#snippet popupTemplate()}
@@ -218,8 +211,7 @@
                 <p class="params">{params}</p>
             {/snippet}
         </Tooltip>
-    {:else if isBalanceGate(gateConfig.gate)}
-        {@const gate = gateConfig.gate}
+    {:else if isBalanceGate(gate)}
         <Tooltip {position} {align}>
             <img class="icon" class:small src={tokenDetails?.logo} />
             {#snippet popupTemplate()}

--- a/frontend/app/src/components/home/access/AccessGateIcon.svelte
+++ b/frontend/app/src/components/home/access/AccessGateIcon.svelte
@@ -108,7 +108,7 @@
         valid={true}
         {level}
         onClose={() => (showDetail = false)}
-        {gateConfig}
+        gateConfig={{ ...gateConfig, gate }}
         editable={false} />
 {/if}
 

--- a/frontend/app/src/components/home/access/AccessGateIconsForChat.svelte
+++ b/frontend/app/src/components/home/access/AccessGateIconsForChat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { EnhancedAccessGate } from "openchat-client";
+    import { type EnhancedAccessGate, stripSuspendedGate } from "openchat-client";
     import AccessGateIcon from "./AccessGateIcon.svelte";
     import { mergeAccessGates } from "../../../utils/access";
 
@@ -9,10 +9,14 @@
 
     let { gates }: Props = $props();
 
-    let merged = $derived(mergeAccessGates(...gates));
+    // Drop gates that reduce to no gate once suspended (unique person) gates are stripped, so we
+    // don't render empty icons or dangling separators.
+    let merged = $derived(
+        mergeAccessGates(...gates).filter((g) => stripSuspendedGate(g).kind !== "no_gate"),
+    );
 </script>
 
-{#if gates.length > 0}
+{#if merged.length > 0}
     <div class="icons">
         {#each merged as gate, i}
             <AccessGateIcon

--- a/frontend/app/src/components/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components/home/access/AccessGateSummary.svelte
@@ -62,7 +62,11 @@
 </script>
 
 {#if showDetail}
-    <AccessGateBuilder bind:valid {level} onClose={close} bind:gateConfig {editable} />
+    {#if editable}
+        <AccessGateBuilder bind:valid {level} onClose={close} bind:gateConfig {editable} />
+    {:else}
+        <AccessGateBuilder bind:valid {level} onClose={close} gateConfig={displayGateConfig} {editable} />
+    {/if}
 {/if}
 
 {#if displayGateConfig.gate.kind !== "no_gate" || showNoGate}

--- a/frontend/app/src/components/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components/home/access/AccessGateSummary.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-    import { type AccessGate, type AccessGateConfig, type Level } from "openchat-client";
+    import {
+        type AccessGate,
+        type AccessGateConfig,
+        type Level,
+        stripSuspendedGate,
+    } from "openchat-client";
     import AccessGateIcon from "./AccessGateIcon.svelte";
     import { gateLabel } from "../../../utils/access";
     import { i18nKey } from "../../../i18n/i18n";
@@ -50,19 +55,22 @@
         showDetail = false;
         onUpdated?.();
     }
-    let gateText = $derived(getGateText(gateConfig.gate));
+    // Display the gate with any suspended (unique person) gates stripped out. The underlying
+    // gateConfig is left untouched so editing preserves the dormant gate.
+    let displayGateConfig = $derived({ ...gateConfig, gate: stripSuspendedGate(gateConfig.gate) });
+    let gateText = $derived(getGateText(displayGateConfig.gate));
 </script>
 
 {#if showDetail}
     <AccessGateBuilder bind:valid {level} onClose={close} bind:gateConfig {editable} />
 {/if}
 
-{#if gateConfig.gate.kind !== "no_gate" || showNoGate}
+{#if displayGateConfig.gate.kind !== "no_gate" || showNoGate}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class:invalid={!valid} onclick={open} class:editable class="summary">
         <div class="icon">
-            <AccessGateIcon button {level} showNoGate {gateConfig} />
+            <AccessGateIcon button {level} showNoGate gateConfig={displayGateConfig} />
         </div>
         <div class="name">
             {#if gateText !== undefined}

--- a/frontend/app/src/components/home/access/LeafGateBuilder.svelte
+++ b/frontend/app/src/components/home/access/LeafGateBuilder.svelte
@@ -360,10 +360,6 @@
         <div class="info">
             <Translatable resourceKey={i18nKey("access.lifetimeDiamondGateInfo")} />
         </div>
-    {:else if gate.kind === "unique_person_gate"}
-        <div class="info">
-            <Translatable resourceKey={i18nKey("access.uniquePersonInfo")} />
-        </div>
     {:else if isNeuronGate(gate)}
         <div class="info">
             <Translatable resourceKey={i18nKey("access.neuronHolderInfo", tokenParams(gate))} />

--- a/frontend/app/src/components/home/communities/PreviewWrapper.svelte
+++ b/frontend/app/src/components/home/communities/PreviewWrapper.svelte
@@ -5,6 +5,7 @@
         identityStateStore,
         ROLE_NONE,
         selectedCommunitySummaryStore,
+        stripSuspendedGate,
     } from "openchat-client";
     import { getContext, tick, type Snippet } from "svelte";
     import { i18nKey } from "../../../i18n/i18n";
@@ -53,7 +54,8 @@
 
             if (gateCheck === undefined) {
                 if (
-                    $selectedCommunitySummaryStore.gateConfig.gate.kind !== "no_gate" &&
+                    stripSuspendedGate($selectedCommunitySummaryStore.gateConfig.gate).kind !==
+                        "no_gate" &&
                     !$selectedCommunitySummaryStore.isInvited
                 ) {
                     const gateConfigs = [$selectedCommunitySummaryStore.gateConfig];

--- a/frontend/app/src/components/home/profile/Badges.svelte
+++ b/frontend/app/src/components/home/profile/Badges.svelte
@@ -2,7 +2,6 @@
     import { disableChit } from "@src/stores/settings";
     import type { DiamondMembershipStatus } from "openchat-client";
     import Diamond from "../../icons/Diamond.svelte";
-    import Verified from "../../icons/Verified.svelte";
     import ChitEarnedBadge from "./ChitEarnedBadge.svelte";
     import Streak from "./Streak.svelte";
 
@@ -13,16 +12,12 @@
         chitEarned?: number;
     }
 
-    let {
-        diamondStatus = undefined,
-        streak = 0,
-        uniquePerson = false,
-        chitEarned = 0,
-    }: Props = $props();
+    // uniquePerson prop retained on Props for callers, but unused - the verified badge is suspended.
+    let { diamondStatus = undefined, streak = 0, chitEarned = 0 }: Props = $props();
 </script>
 
 <Diamond status={diamondStatus} />
-<Verified size={"small"} verified={uniquePerson} />
+<!-- Verified user (DecideAI) badge is suspended - not rendered. -->
 {#if !$disableChit}
     <Streak days={streak} />
     <ChitEarnedBadge earned={chitEarned} />

--- a/frontend/app/src/components/home/profile/LearnToEarn.svelte
+++ b/frontend/app/src/components/home/profile/LearnToEarn.svelte
@@ -57,7 +57,6 @@
         "deleted_message",
         "tipped_message",
         "forwarded_message",
-        "proved_unique_personhood",
         "received_crypto",
         "received_reaction",
         "had_message_tipped",

--- a/frontend/app/src/components/icons/Verified.svelte
+++ b/frontend/app/src/components/icons/Verified.svelte
@@ -9,7 +9,10 @@
         tooltip?: ResourceKey;
     }
 
-    let { verified, size, tooltip }: Props = $props();
+    let { size, tooltip }: Props = $props();
+
+    // Verified user (DecideAI) concept is suspended - never render the badge.
+    const verified = false;
 </script>
 
 {#if verified}

--- a/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
@@ -30,6 +30,7 @@
         selectedChatUserGroupKeysStore,
         selectedCommunitySummaryStore,
         showMiddle,
+        stripSuspendedGate,
         subscribe,
         threadOpenStore,
         unconfirmedStore,
@@ -283,7 +284,8 @@
             ($selectedCommunitySummaryStore.membership.role === ROLE_NONE ||
                 $selectedCommunitySummaryStore.membership.lapsed) &&
             (!$selectedCommunitySummaryStore.public ||
-                $selectedCommunitySummaryStore.gateConfig.gate.kind !== "no_gate"),
+                stripSuspendedGate($selectedCommunitySummaryStore.gateConfig.gate).kind !==
+                    "no_gate"),
     );
     let privatePreview = $derived(privateCommunityPreview || privateChatPreview);
     let isEmptyChat = $derived(chat.latestEventIndex <= 0 || privatePreview);

--- a/frontend/app/src/components_mobile/home/PreviewFooter.svelte
+++ b/frontend/app/src/components_mobile/home/PreviewFooter.svelte
@@ -6,6 +6,7 @@
         isCompositeGate,
         isLeafGate,
         isLocked,
+        isUniquePersonGate,
         type MultiUserChat,
         type OpenChat,
     } from "openchat-client";
@@ -29,15 +30,18 @@
     let flattenedGates = $derived.by<EnhancedAccessGate[]>(() => {
         return gates.flatMap((g) => {
             if (isCompositeGate(g)) {
-                return g.gates.map((l) => ({
-                    ...l,
-                    level: g.level,
-                    expiry: g.expiry,
-                    collectionName: g.collectionName,
-                }));
+                // Unique person (DecideAI) verification is suspended - drop it from the join flow.
+                return g.gates
+                    .filter((l) => !isUniquePersonGate(l))
+                    .map((l) => ({
+                        ...l,
+                        level: g.level,
+                        expiry: g.expiry,
+                        collectionName: g.collectionName,
+                    }));
             }
             if (isLeafGate(g)) {
-                return [g];
+                return isUniquePersonGate(g) ? [] : [g];
             }
             return [];
         });

--- a/frontend/app/src/components_mobile/home/PrizeContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContent.svelte
@@ -19,7 +19,6 @@
         chitBands,
         chitStateStore,
         cryptoLookup,
-        currentUserStore,
         enhancedCryptoLookup,
         isDiamondStore,
         isLifetimeDiamondStore,
@@ -42,7 +41,6 @@
     import { toastStore } from "../../stores/toast";
     import Diamond from "../icons/Diamond.svelte";
     import SpinningToken from "../icons/SpinningToken.svelte";
-    import Verified from "../icons/Verified.svelte";
     import SecureButton from "../SecureButton.svelte";
     import Translatable from "../Translatable.svelte";
     import Badges from "./profile/Badges.svelte";
@@ -153,7 +151,7 @@
     let userEligible = $derived(
         (!content.diamondOnly || $isDiamondStore) &&
             (!content.lifetimeDiamondOnly || $isLifetimeDiamondStore) &&
-            (!content.uniquePersonOnly || $currentUserStore.isUniquePerson) &&
+            // Unique person ("verified user") gating is suspended - always eligible
             content.streakOnly <= $chitStateStore.streak &&
             content.minChitEarned <= $chitStateStore.totalChitEarned,
     );
@@ -173,7 +171,6 @@
     let restrictedPrize = $derived(
         content.diamondOnly ||
             content.lifetimeDiamondOnly ||
-            content.uniquePersonOnly ||
             content.streakOnly > 0 ||
             content.requiresCaptcha ||
             content.minChitEarned > 0,
@@ -317,7 +314,7 @@
                                 forceStreakBadge
                                 withFingerprint={content.requiresCaptcha}
                                 {diamondStatus}
-                                uniquePerson={content.uniquePersonOnly}
+                                uniquePerson={false}
                                 chitEarned={content.minChitEarned}
                                 streak={content.streakOnly}
                                 borderColor={me
@@ -471,18 +468,7 @@
                             </Body>
                         </Row>
                     {/if}
-                    {#if content.uniquePersonOnly}
-                        <Row gap="md">
-                            <Verified
-                                borderColor={ColourVars.background1}
-                                verified={content.uniquePersonOnly}
-                                tooltip={i18nKey("prizes.uniquePerson")} />
-
-                            <Body>
-                                <Translatable resourceKey={i18nKey("prizes.uniquePerson")} />
-                            </Body>
-                        </Row>
-                    {/if}
+                    <!-- Unique person ("verified user") gating is suspended -->
                     {#if content.streakOnly > 0}
                         <Row gap="md">
                             <Streak

--- a/frontend/app/src/components_mobile/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContentBuilder.svelte
@@ -90,7 +90,9 @@
     let distribution: "equal" | "random" = $state($prizeConfig.distribution);
     let selectedDuration = $state($prizeConfig.duration);
     let diamondType: "none" | "standard" | "lifetime" = $state($prizeConfig.diamond);
-    let uniquePersonOnly = $state($prizeConfig.uniquePersonOnly);
+    // Unique-person ("verified user") gating is suspended - force off so a value persisted from a
+    // previous session can't be silently reapplied (there is no UI to clear it).
+    const uniquePersonOnly = false;
     let minStreak = $state<number>($prizeConfig.minStreak);
     let minChitEarned = $state<number>($prizeConfig.minChitEarned);
     let tokenInputState: "ok" | "zero" | "too_low" | "too_high" = $state("ok");

--- a/frontend/app/src/components_mobile/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContentBuilder.svelte
@@ -43,7 +43,6 @@
         ONE_DAY,
     } from "openchat-client";
     import { onMount } from "svelte";
-    import Account from "svelte-material-icons/AccountOutline.svelte";
     import Diamond from "svelte-material-icons/DiamondOutline.svelte";
     import Lifetime from "svelte-material-icons/DiamondStone.svelte";
     import Fingerprint from "svelte-material-icons/Fingerprint.svelte";
@@ -435,15 +434,7 @@
                     {/snippet}
                     <Translatable resourceKey={i18nKey("Lifetime diamond membership")} />
                 </Chip>
-                <Chip
-                    onClick={() => (uniquePersonOnly = !uniquePersonOnly)}
-                    onRemove={uniquePersonOnly ? () => (uniquePersonOnly = false) : undefined}
-                    mode={uniquePersonOnly ? "filter" : "default"}>
-                    {#snippet icon(color)}
-                        <Account {color} />
-                    {/snippet}
-                    <Translatable resourceKey={i18nKey("Unique person")} />
-                </Chip>
+                <!-- Unique person ("verified user") gating is suspended -->
                 <Chip
                     onClick={() => (selectMinChitEarned = true)}
                     onRemove={minChitEarned > 0 ? () => (minChitEarned = 0) : undefined}

--- a/frontend/app/src/components_mobile/home/access/AccessGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateEvaluator.svelte
@@ -43,7 +43,11 @@
     import PaymentGateEvaluator from "./PaymentGateEvaluator.svelte";
     import UniqueHumanGateEvaluator from "./UniqueHumanGateEvaluator.svelte";
 
-    type SatisfiedLeafGate = EnhancedLeafGate & { satisfied: boolean; satisfiable: boolean };
+    type SatisfiedLeafGate = EnhancedLeafGate & {
+        satisfied: boolean;
+        satisfiable: boolean;
+        originalIndex: number;
+    };
 
     interface Props {
         gate: EnhancedAccessGate;
@@ -78,17 +82,30 @@
 
     function normaliseGates(gate: EnhancedAccessGate): SatisfiedLeafGate[] {
         if (isCompositeGate(gate)) {
-            return gate.gates.map((l) => ({
-                ...l,
-                level: gate.level,
-                collectionName: gate.collectionName,
-                expiry: gate.expiry,
-                satisfied: doesUserMeetLeafGate(l),
-                satisfiable: false,
-            }));
+            // Keep originalIndex before filtering so compositeGateIndex still maps to the real gate.
+            // Unique person (DecideAI) verification is suspended - hide it from the join flow.
+            return gate.gates
+                .map((l, i) => ({
+                    ...l,
+                    level: gate.level,
+                    collectionName: gate.collectionName,
+                    expiry: gate.expiry,
+                    satisfied: doesUserMeetLeafGate(l),
+                    satisfiable: false,
+                    originalIndex: i,
+                }))
+                .filter((g) => !isUniquePersonGate(g));
         }
         if (isLeafGate(gate)) {
-            return [{ ...gate, satisfied: doesUserMeetLeafGate(gate), satisfiable: false }];
+            if (isUniquePersonGate(gate)) return [];
+            return [
+                {
+                    ...gate,
+                    satisfied: doesUserMeetLeafGate(gate),
+                    satisfiable: false,
+                    originalIndex: 0,
+                },
+            ];
         }
         return [];
     }
@@ -184,10 +201,10 @@
 
     function handleComplete() {
         if (compositeOr) {
-            // Find the index of the first satisfied gate in the original (unsorted) flattenedGates
-            const satisfiedIdx = flattenedGates.findIndex((g) => g.satisfied);
-            if (satisfiedIdx !== -1) {
-                accessApprovalState.setCompositeGateIndex(satisfiedIdx);
+            // Use originalIndex so the backend still maps to the real gate after filtering.
+            const satisfied = flattenedGates.find((g) => g.satisfied);
+            if (satisfied !== undefined) {
+                accessApprovalState.setCompositeGateIndex(satisfied.originalIndex);
             }
         }
         onComplete();

--- a/frontend/app/src/components_mobile/home/access_gates/AccessGates.svelte
+++ b/frontend/app/src/components_mobile/home/access_gates/AccessGates.svelte
@@ -7,6 +7,7 @@
         isChitEarnedGate,
         isCompositeGate,
         publish,
+        stripSuspendedGate,
         type AccessGate,
     } from "openchat-client";
     import ArrowLeft from "svelte-material-icons/ArrowLeft.svelte";
@@ -29,7 +30,7 @@
     let { data }: Props = $props();
 
     let diamond = $derived($currentUserStore.diamondStatus.kind !== "inactive");
-    let hasAccessGates = $derived(data.gateConfig.gate.kind !== "no_gate");
+    let hasAccessGates = $derived(stripSuspendedGate(data.gateConfig.gate).kind !== "no_gate");
     let gateBindings: GateBinding[] = getGateBindings(data.candidate.level).filter(
         (b) => b.enabled && b.gate.kind !== "no_gate" && b.gate.kind !== "credential_gate",
     );

--- a/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
@@ -225,18 +225,18 @@
         <Container padding={"lg"} direction={"vertical"} gap={"md"}>
             {@const community = selectedCommunity}
             <CommunityCard
-                id={selectedCommunity.id.communityId}
-                name={selectedCommunity.name}
-                description={selectedCommunity.description}
-                avatar={selectedCommunity.avatar}
-                banner={selectedCommunity.banner}
-                memberCount={selectedCommunity.memberCount}
-                channelCount={selectedCommunity.channelCount}
+                id={community.id.communityId}
+                name={community.name}
+                description={community.description}
+                avatar={community.avatar}
+                banner={community.banner}
+                memberCount={community.memberCount}
+                channelCount={community.channelCount}
                 header={false}
-                gateConfig={selectedCommunity.gateConfig}
-                language={selectedCommunity.primaryLanguage}
-                flags={selectedCommunity.flags}
-                verified={selectedCommunity.verified} />
+                gateConfig={community.gateConfig}
+                language={community.primaryLanguage}
+                flags={community.flags}
+                verified={community.verified} />
             <Button onClick={() => goToCommunity(community)}>
                 {#snippet icon(color)}
                     <EyeOutline {color} />

--- a/frontend/app/src/components_mobile/home/profile/Badges.svelte
+++ b/frontend/app/src/components_mobile/home/profile/Badges.svelte
@@ -3,7 +3,6 @@
     import { ColourVars, Container } from "component-lib";
     import type { DiamondMembershipStatus } from "openchat-client";
     import Diamond from "../../icons/Diamond.svelte";
-    import Verified from "../../icons/Verified.svelte";
     import ChitEarnedBadge from "./ChitEarnedBadge.svelte";
     import Streak from "./Streak.svelte";
     import BadgeContainer, { type BadgeSize } from "./BadgeContainer.svelte";
@@ -20,10 +19,10 @@
         forceStreakBadge?: boolean;
     }
 
+    // uniquePerson prop retained on Props for callers, but unused - the verified badge is suspended.
     let {
         diamondStatus = undefined,
         streak = 0,
-        uniquePerson = false,
         chitEarned = 0,
         withFingerprint = false,
         size = "default",
@@ -48,7 +47,7 @@
         {@render fingerprint()}
     {/if}
     <Diamond {size} {borderColor} status={diamondStatus} />
-    <Verified {size} {borderColor} verified={uniquePerson} />
+    <!-- Verified user (DecideAI) badge is suspended - not rendered. -->
     {#if !$disableChit || forceStreakBadge}
         <Streak {size} {borderColor} days={streak} />
         <ChitEarnedBadge {size} {borderColor} earned={chitEarned} />

--- a/frontend/app/src/components_mobile/home/profile/LearnToEarn.svelte
+++ b/frontend/app/src/components_mobile/home/profile/LearnToEarn.svelte
@@ -67,7 +67,6 @@
         "deleted_message",
         "tipped_message",
         "forwarded_message",
-        "proved_unique_personhood",
         "received_crypto",
         "received_reaction",
         "had_message_tipped",

--- a/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import MulticolourText from "@src/components_mobile/MulticolourText.svelte";
     import { i18nKey } from "@src/i18n/i18n";
     import { clearChatShortcuts } from "@stores/chatShortcuts";
     import { Body, Container, IconButton, MenuItem, MenuTrigger } from "component-lib";
@@ -13,10 +12,8 @@
         type PublicProfile,
     } from "openchat-client";
     import { getContext, onMount } from "svelte";
-    import AccountStar from "svelte-material-icons/AccountStarOutline.svelte";
     import DotsVertical from "svelte-material-icons/DotsVertical.svelte";
     import Share from "svelte-material-icons/ShareVariantOutline.svelte";
-    import SparkleBox from "../../SparkleBox.svelte";
     import Translatable from "../../Translatable.svelte";
     import Stats from "../Stats.svelte";
     import UserProfileSummaryCard from "./UserProfileSummaryCard.svelte";
@@ -24,7 +21,6 @@
     const client = getContext<OpenChat>("client");
 
     let user = $derived($allUsersStore.get($currentUserIdStore) ?? client.nullUser("unknown"));
-    let verified = $derived(user?.isUniquePerson ?? false);
     let profile: PublicProfile | undefined = $state();
 
     onMount(() => {
@@ -95,43 +91,7 @@
             </UserProfileSummaryCard>
         {/if}
 
-        {#if !verified}
-            <SparkleBox
-                buttonText={i18nKey("Start verification")}
-                onClick={() => publish("userProfileVerify")}>
-                {#snippet title()}
-                    <MulticolourText
-                        parts={[
-                            {
-                                text: i18nKey("Verify you are a "),
-                                colour: "primaryLight",
-                            },
-                            {
-                                text: i18nKey("real person"),
-                                colour: "primary",
-                            },
-                        ]} />
-                {/snippet}
-                {#snippet body()}
-                    <MulticolourText
-                        parts={[
-                            {
-                                text: i18nKey(
-                                    "Verify your unique personhood as a signal of your trustworthiness to other users! ",
-                                ),
-                                colour: "primaryLight",
-                            },
-                            {
-                                text: i18nKey("It only takes a minute."),
-                                colour: "textPrimary",
-                            },
-                        ]} />
-                {/snippet}
-                {#snippet buttonIcon(color)}
-                    <AccountStar {color} />
-                {/snippet}
-            </SparkleBox>
-        {/if}
+        <!-- Unique person ("verified user") verification is suspended -->
 
         <Container gap={"lg"} direction={"vertical"} padding={["zero", "md"]}>
             <Body colour={"textSecondary"} fontWeight={"bold"}>

--- a/frontend/app/src/components_mobile/home/user_profile/UserProfileSummaryCard.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/UserProfileSummaryCard.svelte
@@ -32,7 +32,6 @@
     import ChitSummary from "./ChitSummary.svelte";
     import Translatable from "../../Translatable.svelte";
     import Progress from "../../Progress.svelte";
-    import Check from "svelte-material-icons/Check.svelte";
     import DiamondOutline from "svelte-material-icons/DiamondOutline.svelte";
     import Lifetime from "svelte-material-icons/DiamondStone.svelte";
     import CopyIcon from "svelte-material-icons/ContentCopy.svelte";
@@ -193,7 +192,7 @@
                     <Subtitle width={"hug"} colour={"textSecondary"}>@{user.username}</Subtitle>
                 </Row>
             </Column>
-            {#if user.isUniquePerson || user.diamondStatus !== "inactive"}
+            {#if user.diamondStatus !== "inactive"}
                 <Container padding={["zero", "zero"]} gap={"sm"}>
                     {#if user.diamondStatus === "active"}
                         {@render accountPill(
@@ -205,9 +204,7 @@
                     {:else if user.diamondStatus === "lifetime"}
                         {@render accountPill(Lifetime, "Lifetime member", ColourVars.gradient)}
                     {/if}
-                    {#if user.isUniquePerson}
-                        {@render accountPill(Check, "Verified account", ColourVars.secondary)}
-                    {/if}
+                    <!-- Verified account (DecideAI unique personhood) pill is suspended. -->
                 </Container>
             {/if}
         </Container>

--- a/frontend/app/src/components_mobile/icons/Verified.svelte
+++ b/frontend/app/src/components_mobile/icons/Verified.svelte
@@ -12,7 +12,10 @@
         borderColor?: string;
     }
 
-    let { verified, size = "default", tooltip, borderColor }: Props = $props();
+    let { size = "default", tooltip, borderColor }: Props = $props();
+
+    // Verified user (DecideAI) concept is suspended - never render the badge.
+    const verified = false;
 </script>
 
 {#snippet renderCheck()}

--- a/frontend/app/src/utils/access.ts
+++ b/frontend/app/src/utils/access.ts
@@ -1,6 +1,7 @@
 import {
     isCompositeGate,
     isLeafGate,
+    isUniquePersonGate,
     type AccessGate,
     type AccessGateConfig,
     type Credential,
@@ -50,7 +51,7 @@ export function getGateBindings(level: Level): GateBinding[] {
         paymentGateFolder,
         balanceGateFolder,
         credentialGate,
-        uniquePersonGate,
+        // uniquePersonGate omitted - DecideAI verification is suspended
         lockedGate,
         chitEarnedGate,
     ];
@@ -152,11 +153,13 @@ const lifetimeDiamondGate: GateBinding = {
     enabled: true,
 };
 
+// Unique person ("verified user", DecideAI) verification is suspended, so this gate is disabled
+// and is no longer offered in getGateBindings. Kept dormant so the concept can be revived.
 export const uniquePersonGate: GateBinding = {
     label: "access.uniquePerson",
     key: "unique_person_gate",
     gate: { kind: "unique_person_gate" },
-    enabled: true,
+    enabled: false,
 };
 
 export const lockedGate: GateBinding = {
@@ -295,12 +298,15 @@ export function mergeAccessGates(
 }
 
 export function flattenGateConfig({ gate }: AccessGateConfig): LeafGate[] {
+    // The unique person ("verified user", DecideAI) concept is suspended, so drop it from the
+    // flattened list - a standalone unique person gate looks like no gate, and inside a composite
+    // gate it is simply omitted.
     if (isLeafGate(gate)) {
-        if (gate.kind === "no_gate") return [];
+        if (gate.kind === "no_gate" || isUniquePersonGate(gate)) return [];
         return [gate];
     }
     if (isCompositeGate(gate)) {
-        return gate.gates;
+        return gate.gates.filter((g) => !isUniquePersonGate(g));
     }
     return [];
 }

--- a/frontend/app/src/utils/preview.svelte.ts
+++ b/frontend/app/src/utils/preview.svelte.ts
@@ -11,7 +11,7 @@ import type {
     MultiUserChat,
     OpenChat,
 } from "openchat-client";
-import { anonUserStore, chatListScopeStore, chatSummariesStore, type PaymentGateApprovals, publish, ROLE_NONE, routeForScope, selectedChatSummaryStore, selectedCommunitySummaryStore } from "openchat-client";
+import { anonUserStore, chatListScopeStore, chatSummariesStore, type PaymentGateApprovals, publish, ROLE_NONE, routeForScope, selectedChatSummaryStore, selectedCommunitySummaryStore, stripSuspendedGate } from "openchat-client";
 import { navigate } from "@utils/navigation";
 
 class ApprovalsAndCredentials {
@@ -202,7 +202,8 @@ class CommunityPreview {
     #community = $state<CommunitySummary>();
     #gatesInEffect = $derived(
         this.#community !== undefined &&
-            this.#community.gateConfig.gate.kind !== "no_gate" &&
+            // Suspended (unique person) gates are stripped, so a lone unique person gate is no gate.
+            stripSuspendedGate(this.#community.gateConfig.gate).kind !== "no_gate" &&
             !this.#community.isInvited,
     );
     #previewing = $derived(

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -4763,9 +4763,14 @@ export class OpenChat {
 
     doesUserMeetAccessGate(gate: AccessGate): boolean {
         if (isCompositeGate(gate)) {
+            // Unique person gates are suspended and filtered out of composites: an OR then requires
+            // another branch (no one is a unique person), an AND is unaffected (everyone is). If
+            // nothing remains the gate collapses to no gate.
+            const gates = gate.gates.filter((g) => g.kind !== "unique_person_gate");
+            if (gates.length === 0) return true;
             return gate.operator === "and"
-                ? gate.gates.every((g) => this.doesUserMeetAccessGate(g))
-                : gate.gates.some((g) => this.doesUserMeetAccessGate(g));
+                ? gates.every((g) => this.doesUserMeetAccessGate(g))
+                : gates.some((g) => this.doesUserMeetAccessGate(g));
         } else {
             if (gate.kind === "diamond_gate") {
                 return currentUserStore.value.diamondStatus.kind !== "inactive";

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -4772,7 +4772,8 @@ export class OpenChat {
             } else if (gate.kind === "lifetime_diamond_gate") {
                 return currentUserStore.value.diamondStatus.kind === "lifetime";
             } else if (gate.kind === "unique_person_gate") {
-                return currentUserStore.value.isUniquePerson;
+                // Unique person verification (DecideAI) is suspended - always pass.
+                return true;
             } else if (gate.kind === "chit_earned_gate") {
                 return currentUserStore.value.totalChitEarned >= gate.minEarned;
             } else if (gate.kind === "token_balance_gate") {

--- a/frontend/openchat-shared/src/domain/access.ts
+++ b/frontend/openchat-shared/src/domain/access.ts
@@ -115,7 +115,7 @@ export function isLeafGate(gate: AccessGate): gate is LeafGate {
 
 export function shouldPreprocessGate(gate: AccessGate): gate is PreprocessedGate {
     return [
-        "unique_person_gate",
+        // "unique_person_gate" omitted - DecideAI verification is suspended
         "credential_gate",
         "payment_gate",
         "lifetime_diamond_gate",
@@ -167,6 +167,26 @@ export function isCredentialGate(gate: AccessGate): gate is CredentialGate {
 
 export function isUniquePersonGate(gate: AccessGate): gate is UniquePersonGate {
     return gate.kind === "unique_person_gate";
+}
+
+// The unique person ("verified user", DecideAI) concept is suspended. For display purposes we
+// strip any unique person gate so that a standalone unique person gate looks like no gate, and a
+// composite gate drops it (collapsing to the single remaining gate, or no gate if none remain).
+export function stripSuspendedGate(gate: AccessGate): AccessGate {
+    if (isUniquePersonGate(gate)) {
+        return { kind: "no_gate" };
+    }
+    if (isCompositeGate(gate)) {
+        const remaining = gate.gates.filter((g) => !isUniquePersonGate(g));
+        if (remaining.length === 0) {
+            return { kind: "no_gate" };
+        }
+        if (remaining.length === 1) {
+            return remaining[0];
+        }
+        return { ...gate, gates: remaining };
+    }
+    return gate;
 }
 
 export function isLifetimeDiamondGate(gate: AccessGate): gate is LifetimeDiamondGate {


### PR DESCRIPTION
Suspends the DecideAI "verified user" / unique personhood verification concept across the product. The backend gate now always passes; this PR removes every frontend surface that exposes the concept, while leaving the underlying gate data, backend fields and UI components intact so the feature can be reinstated later.

## Backend
- `check_unique_person_gate` always passes (community, group).
- Unique-person prize gating suspended — every user eligible (user).

## Frontend
- Strip unique-person gates from all gate displays, join/preview flows and evaluators (desktop + mobile), preserving composite indices so `compositeGateIndex` still maps to the real gate.
- Hide unique-person rows from the editable gate builder without mutating saved gate config.
- Strip suspended gates before "no gate" presence checks (preview mode, join guards, bypass warnings).
- Stop rendering the verified badge / "Verified account" pill; remove the "prove unique personhood" achievement from Learn to Earn.

Verify-humanity components are left dormant (no reachable entry point) for future revival. No data is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)