### PR TITLE
fix(android): reliable notification taps, sane history after taps, push-token cleanup on logout

### DIFF
--- a/backend/canisters/notifications_index/api/src/main.rs
+++ b/backend/canisters/notifications_index/api/src/main.rs
@@ -12,6 +12,7 @@ fn main() {
     generate_ts_method!(notifications_index, subscription_exists);
 
     generate_ts_method!(notifications_index, add_fcm_token);
+    generate_ts_method!(notifications_index, remove_fcm_token);
     generate_ts_method!(notifications_index, mark_subscription_active);
     generate_ts_method!(notifications_index, push_subscription);
     generate_ts_method!(notifications_index, remove_subscription);

--- a/backend/canisters/notifications_index/api/src/updates/mod.rs
+++ b/backend/canisters/notifications_index/api/src/updates/mod.rs
@@ -4,6 +4,7 @@ pub mod c2c_user_index;
 pub mod mark_subscription_active;
 pub mod notify_local_index_added;
 pub mod push_subscription;
+pub mod remove_fcm_token;
 pub mod remove_fcm_tokens;
 pub mod remove_subscription;
 pub mod remove_subscriptions;

--- a/backend/canisters/notifications_index/api/src/updates/remove_fcm_token.rs
+++ b/backend/canisters/notifications_index/api/src/updates/remove_fcm_token.rs
@@ -1,0 +1,13 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+use ts_export::ts_export;
+use types::FcmToken;
+use types::UnitResult;
+
+#[ts_export(notifications_index, remove_fcm_token)]
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct Args {
+    pub fcm_token: FcmToken,
+}
+
+pub type Response = UnitResult;

--- a/backend/canisters/notifications_index/impl/src/lib.rs
+++ b/backend/canisters/notifications_index/impl/src/lib.rs
@@ -13,7 +13,7 @@ use types::{
     BuildVersion, CanisterId, Cycles, FcmToken, IdempotentEnvelope, SubscriptionInfo, TimestampMillis, Timestamped, UserId,
 };
 use utils::env::Environment;
-use utils::fcm_token_store::FcmTokenStore;
+use utils::fcm_token_store::{FcmTokenAddResult, FcmTokenStore};
 use utils::idempotency_checker::IdempotencyChecker;
 
 mod guards;
@@ -90,11 +90,23 @@ impl RuntimeState {
         self.push_event_to_local_indexes(event, now);
     }
 
-    pub fn add_fcm_token(&mut self, user_id: UserId, fcm_token: FcmToken) -> Result<(), String> {
-        // Add token locally
-        self.data.fcm_token_store.add(user_id, fcm_token.clone()).map(|_| {
-            self.push_event_to_local_indexes(NotificationsIndexEvent::FcmTokenAdded(user_id, fcm_token), self.env.now());
-        })
+    pub fn add_fcm_token(&mut self, user_id: UserId, fcm_token: FcmToken) {
+        let now = self.env.now();
+        match self.data.fcm_token_store.add(user_id, fcm_token.clone()) {
+            FcmTokenAddResult::Added => {
+                self.push_event_to_local_indexes(NotificationsIndexEvent::FcmTokenAdded(user_id, fcm_token), now);
+            }
+            FcmTokenAddResult::Reassigned(previous_owner) => {
+                // Keep the local index replicas consistent: drop the old owner's
+                // mapping before adding the new one.
+                self.push_event_to_local_indexes(
+                    NotificationsIndexEvent::FcmTokenRemoved(previous_owner, fcm_token.clone()),
+                    now,
+                );
+                self.push_event_to_local_indexes(NotificationsIndexEvent::FcmTokenAdded(user_id, fcm_token), now);
+            }
+            FcmTokenAddResult::AlreadyOwned => {}
+        }
     }
 
     // Called when a push to Firebase fails because the token is no longer valid

--- a/backend/canisters/notifications_index/impl/src/updates/add_fcm_token.rs
+++ b/backend/canisters/notifications_index/impl/src/updates/add_fcm_token.rs
@@ -3,7 +3,6 @@ use crate::updates::get_user_id;
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use notifications_index_canister::add_fcm_token::{Args, Response};
-use oc_error_codes::OCErrorCode;
 use types::UnitResult;
 
 #[update(msgpack = true)]
@@ -11,10 +10,11 @@ use types::UnitResult;
 async fn add_fcm_token(args: Args) -> Response {
     match get_user_id().await {
         Ok(user_id) => mutate_state(|state| {
-            state
-                .add_fcm_token(user_id, args.fcm_token)
-                .map(|_| UnitResult::Success)
-                .unwrap_or_else(|_| UnitResult::Error(OCErrorCode::AlreadyAdded.into()))
+            // Registration is last-login-wins: a token held by a previous
+            // account on the same device is re-assigned to the caller, and
+            // re-registering an owned token is a no-op — both are Success.
+            state.add_fcm_token(user_id, args.fcm_token);
+            UnitResult::Success
         }),
         Err(err) => UnitResult::Error(err),
     }

--- a/backend/canisters/notifications_index/impl/src/updates/mod.rs
+++ b/backend/canisters/notifications_index/impl/src/updates/mod.rs
@@ -2,6 +2,7 @@ mod add_fcm_token;
 mod mark_subscription_active;
 mod notify_local_index_added;
 mod push_subscription;
+mod remove_fcm_token;
 mod remove_fcm_tokens;
 mod remove_subscription;
 mod remove_subscriptions;

--- a/backend/canisters/notifications_index/impl/src/updates/remove_fcm_token.rs
+++ b/backend/canisters/notifications_index/impl/src/updates/remove_fcm_token.rs
@@ -1,0 +1,22 @@
+use crate::mutate_state;
+use crate::updates::get_user_id;
+use canister_api_macros::update;
+use canister_tracing_macros::trace;
+use notifications_index_canister::remove_fcm_token::{Args, Response};
+use types::UnitResult;
+
+/// Removes the caller's own FCM token, e.g. when signing out on a device so
+/// that pushes for this account stop reaching it. Removal is idempotent: a
+/// token that is already gone (or was re-assigned to another account in the
+/// meantime) still results in Success.
+#[update(msgpack = true)]
+#[trace]
+async fn remove_fcm_token(args: Args) -> Response {
+    match get_user_id().await {
+        Ok(user_id) => mutate_state(|state| {
+            let _ = state.remove_fcm_token(user_id, args.fcm_token);
+            UnitResult::Success
+        }),
+        Err(err) => UnitResult::Error(err),
+    }
+}

--- a/backend/libraries/utils/src/fcm_token_store.rs
+++ b/backend/libraries/utils/src/fcm_token_store.rs
@@ -39,11 +39,7 @@ impl FcmTokenStore {
             return FcmTokenAddResult::AlreadyOwned;
         }
 
-        let previous_owner = self
-            .fcm_user_tokens
-            .iter()
-            .find(|(_, t)| t == &token)
-            .map(|(user, _)| *user);
+        let previous_owner = self.fcm_user_tokens.iter().find(|(_, t)| t == &token).map(|(user, _)| *user);
 
         if let Some(previous_owner) = previous_owner {
             self.fcm_user_tokens.remove(&(previous_owner, token.clone()));

--- a/backend/libraries/utils/src/fcm_token_store.rs
+++ b/backend/libraries/utils/src/fcm_token_store.rs
@@ -8,23 +8,50 @@ pub struct FcmTokenStore {
     fcm_user_tokens: BTreeSet<(UserId, FcmToken)>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum FcmTokenAddResult {
+    /// The token was not in the store and is now assigned to the user.
+    Added,
+    /// The user already owns this token; nothing changed.
+    AlreadyOwned,
+    /// The token was assigned to another user (e.g. a previous account on the
+    /// same device) and has been re-assigned to the caller. Holds the previous
+    /// owner so callers can propagate the removal.
+    Reassigned(UserId),
+}
+
 impl FcmTokenStore {
     /// Checks if a given FCM token is contained within the store!
     pub fn contains(&self, token: &FcmToken) -> bool {
         self.fcm_user_tokens.iter().any(|(_, t)| t == token)
     }
 
-    /// Add a new FCM token, and assign it to a user.
+    /// Add an FCM token, and assign it to a user.
     ///
-    /// If the token already exists, it will not be added again - this also
-    /// ensures that the user does not have duplicate tokens, or that the same
-    /// token is not assigned to multiple users.
-    pub fn add(&mut self, user_id: UserId, token: FcmToken) -> Result<(), String> {
-        if !self.contains(&token) {
-            self.fcm_user_tokens.insert((user_id, token.clone()));
-            Ok(())
+    /// A device token identifies an app install, not an account, so the last
+    /// user to register it wins: if the token is currently assigned to a
+    /// different user (a previous account on the same device that didn't
+    /// cleanly sign out), the old mapping is replaced. This keeps a token from
+    /// pushing one account's notifications to a device now used by another,
+    /// and ensures the new account actually receives pushes.
+    pub fn add(&mut self, user_id: UserId, token: FcmToken) -> FcmTokenAddResult {
+        if self.fcm_user_tokens.contains(&(user_id, token.clone())) {
+            return FcmTokenAddResult::AlreadyOwned;
+        }
+
+        let previous_owner = self
+            .fcm_user_tokens
+            .iter()
+            .find(|(_, t)| t == &token)
+            .map(|(user, _)| *user);
+
+        if let Some(previous_owner) = previous_owner {
+            self.fcm_user_tokens.remove(&(previous_owner, token.clone()));
+            self.fcm_user_tokens.insert((user_id, token));
+            FcmTokenAddResult::Reassigned(previous_owner)
         } else {
-            Err("Token already exists".to_string())
+            self.fcm_user_tokens.insert((user_id, token));
+            FcmTokenAddResult::Added
         }
     }
 
@@ -81,12 +108,21 @@ mod test {
         let token4 = FcmToken::from("token4".to_string());
 
         // Assert tokens can be added
-        assert_eq!(store.add(user_id1, token1.clone()), Ok(()));
-        assert_eq!(store.add(user_id3, token4.clone()), Ok(()));
-        assert_eq!(store.add(user_id1, token2.clone()), Ok(()));
+        assert_eq!(store.add(user_id1, token1.clone()), FcmTokenAddResult::Added);
+        assert_eq!(store.add(user_id3, token4.clone()), FcmTokenAddResult::Added);
+        assert_eq!(store.add(user_id1, token2.clone()), FcmTokenAddResult::Added);
 
-        // Assert that adding the same token for a different user fails
-        assert_eq!(store.add(user_id2, token1.clone()), Err("Token already exists".to_string()));
+        // Re-adding a token the user already owns is a no-op
+        assert_eq!(store.add(user_id1, token1.clone()), FcmTokenAddResult::AlreadyOwned);
+
+        // Adding a token owned by a different user re-assigns it (last login wins)
+        assert_eq!(store.add(user_id2, token4.clone()), FcmTokenAddResult::Reassigned(user_id3));
+        assert!(store.get_for_user(&user_id3).is_empty());
+        assert_eq!(store.get_for_user(&user_id2), vec![&token4]);
+        assert_eq!(store.len(), 3);
+
+        // ...and re-assigning it back works the same way
+        assert_eq!(store.add(user_id3, token4.clone()), FcmTokenAddResult::Reassigned(user_id2));
 
         // Assert that we can check if the store contains a token
         assert!(store.contains(&token1));

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -47,7 +47,12 @@
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
-    import { getFcmToken, svelteReady } from "tauri-plugin-oc-api";
+    import {
+        clearAllNotifications,
+        deleteFcmToken,
+        getFcmToken,
+        svelteReady,
+    } from "tauri-plugin-oc-api";
     import Head from "./Head.svelte";
     import Profiler from "./Profiler.svelte";
     import Router from "./Router.svelte";
@@ -260,6 +265,20 @@
                 }
 
                 addFcmToken(token);
+            });
+
+            // Best-effort push hygiene on sign-out, while the identity is
+            // still valid: unbind this device's token from the account,
+            // delete the device token (pushes to it then dead-end at FCM,
+            // and the next login mints + registers a fresh one), and empty
+            // the tray so nothing from this account lingers.
+            client.onLogout(async () => {
+                const token = await getFcmToken().catch(() => null);
+                if (token) {
+                    await client.removeFcmToken(token).catch(console.error);
+                }
+                await deleteFcmToken().catch(console.error);
+                await clearAllNotifications().catch(console.error);
             });
         }
     }

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -233,6 +233,12 @@
         };
     });
 
+    // Guards the one-time native setup (listeners + logout hook) so it runs once
+    // per page session. setupNativeApp() itself runs again on every userLoggedIn
+    // (account switch), but only the FCM token registration should repeat —
+    // re-registering listeners or the logout hook would stack duplicate handlers.
+    let nativeSetupDone = false;
+
     // Sets up push notifications and FCM token management for native apps
     function setupNativeApp() {
         const addFcmToken = (token: string) => {
@@ -242,45 +248,53 @@
                 .catch(console.error);
         };
 
-        if (client.isNativeApp()) {
-            // Listen for incoming push notifications from Firebase; also asks
-            // for permission to show notifications if not already granted.
-            expectPushNotifications().catch(console.error);
-
-            // Listen for notifications user has tapped on
-            expectNotificationTap().catch(console.error);
-
-            // Expect FCM token refreshes
-            expectNewFcmToken(addFcmToken);
-
-            // Ask for the current FCM token and register it unconditionally.
-            // Registration is last-login-wins on the backend, so this also
-            // reclaims a token still bound to a previous account on this
-            // device (a fcm_token_exists pre-check would wrongly skip that).
-            getFcmToken().then((token) => {
-                if (!token) {
-                    // TODO do we handle this somehow? Debounce, try again?
-                    console.error("No FCM token received");
-                    return;
-                }
-
-                addFcmToken(token);
-            });
-
-            // Best-effort push hygiene on sign-out, while the identity is
-            // still valid: unbind this device's token from the account,
-            // delete the device token (pushes to it then dead-end at FCM,
-            // and the next login mints + registers a fresh one), and empty
-            // the tray so nothing from this account lingers.
-            client.onLogout(async () => {
-                const token = await getFcmToken().catch(() => null);
-                if (token) {
-                    await client.removeFcmToken(token).catch(console.error);
-                }
-                await deleteFcmToken().catch(console.error);
-                await clearAllNotifications().catch(console.error);
-            });
+        if (!client.isNativeApp()) {
+            return;
         }
+
+        // Ask for the current FCM token and register it unconditionally on every
+        // login. Registration is last-login-wins on the backend, so this also
+        // reclaims a token still bound to a previous account on this device (a
+        // fcm_token_exists pre-check would wrongly skip that).
+        getFcmToken().then((token) => {
+            if (!token) {
+                // TODO do we handle this somehow? Debounce, try again?
+                console.error("No FCM token received");
+                return;
+            }
+
+            addFcmToken(token);
+        });
+
+        // Everything below registers session-scoped handlers and must run once.
+        if (nativeSetupDone) {
+            return;
+        }
+        nativeSetupDone = true;
+
+        // Listen for incoming push notifications from Firebase; also asks
+        // for permission to show notifications if not already granted.
+        expectPushNotifications().catch(console.error);
+
+        // Listen for notifications user has tapped on
+        expectNotificationTap().catch(console.error);
+
+        // Expect FCM token refreshes
+        expectNewFcmToken(addFcmToken);
+
+        // Best-effort push hygiene on sign-out, while the identity is
+        // still valid: unbind this device's token from the account,
+        // delete the device token (pushes to it then dead-end at FCM,
+        // and the next login mints + registers a fresh one), and empty
+        // the tray so nothing from this account lingers.
+        client.onLogout(async () => {
+            const token = await getFcmToken().catch(() => null);
+            if (token) {
+                await client.removeFcmToken(token).catch(console.error);
+            }
+            await deleteFcmToken().catch(console.error);
+            await clearAllNotifications().catch(console.error);
+        });
     }
 
     if ($identityStateStore.kind === "logged_in") {

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -248,7 +248,10 @@
             // Expect FCM token refreshes
             expectNewFcmToken(addFcmToken);
 
-            // Ask for the current FCM token
+            // Ask for the current FCM token and register it unconditionally.
+            // Registration is last-login-wins on the backend, so this also
+            // reclaims a token still bound to a previous account on this
+            // device (a fcm_token_exists pre-check would wrongly skip that).
             getFcmToken().then((token) => {
                 if (!token) {
                     // TODO do we handle this somehow? Debounce, try again?
@@ -256,14 +259,7 @@
                     return;
                 }
 
-                client.checkFcmTokenExists(token).then((exists) => {
-                    if (!exists) {
-                        console.log("Adding FCM token for the first time!");
-                        addFcmToken(token);
-                    } else {
-                        console.log("FCM token already registered");
-                    }
-                });
+                addFcmToken(token);
             });
         }
     }

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -220,7 +220,10 @@
                     .forEach((r) => console.error("Native listener setup failed", r.reason));
             });
 
-            // Ask for the current FCM token
+            // Ask for the current FCM token and register it unconditionally.
+            // Registration is last-login-wins on the backend, so this also
+            // reclaims a token still bound to a previous account on this
+            // device (a fcm_token_exists pre-check would wrongly skip that).
             getFcmToken().then((token) => {
                 if (!token) {
                     // TODO do we handle this somehow? Debounce, try again?
@@ -228,14 +231,7 @@
                     return;
                 }
 
-                client.checkFcmTokenExists(token).then((exists) => {
-                    if (!exists) {
-                        console.log("Adding FCM token for the first time!");
-                        addFcmToken(token);
-                    } else {
-                        console.log("FCM token already registered");
-                    }
-                });
+                addFcmToken(token);
             });
 
             // Push the top recent chats to the Android Sharing Shortcuts API

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -190,24 +190,35 @@
         };
 
         if (client.isNativeApp()) {
-            // Listen for incoming push notifications from Firebase; also asks
-            // for permission to show notifications if not already granted.
-            expectPushNotifications().catch(console.error);
+            // Register every native event listener BEFORE signalling svelteReady:
+            // the native side flushes its queued events the moment svelteReady
+            // fires, and a flush that beats an in-flight listener registration
+            // silently drops the event (e.g. a cold-start notification tap).
+            const listenersRegistered = Promise.allSettled([
+                // Listen for incoming push notifications from Firebase; also asks
+                // for permission to show notifications if not already granted.
+                expectPushNotifications(),
 
-            // Listen for notifications user has tapped on
-            expectNotificationTap().catch(console.error);
+                // Listen for notifications user has tapped on
+                expectNotificationTap(),
 
-            // Listen for content shared into OpenChat from the system share sheet
-            // (or via a Direct Share chat shortcut). Cold-start shares are queued
-            // by the native side and delivered once svelteReady fires below.
-            expectShareTarget((share) => handleShareTarget(client, share)).catch(console.error);
+                // Listen for content shared into OpenChat from the system share sheet
+                // (or via a Direct Share chat shortcut). Cold-start shares are queued
+                // by the native side and delivered once svelteReady fires below.
+                expectShareTarget((share) => handleShareTarget(client, share)),
 
-            // Listen for deep links (e.g. https://oc.app/group/xyz tapped from another app).
-            // Cold-start deep links are queued by MainActivity and delivered once svelteReady fires.
-            expectDeepLinks().catch(console.error);
+                // Listen for deep links (e.g. https://oc.app/group/xyz tapped from another app).
+                // Cold-start deep links are queued by MainActivity and delivered once svelteReady fires.
+                expectDeepLinks(),
 
-            // Expect FCM token refreshes
-            expectNewFcmToken(addFcmToken);
+                // Expect FCM token refreshes
+                expectNewFcmToken(addFcmToken),
+            ]);
+            listenersRegistered.then((results) => {
+                results
+                    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+                    .forEach((r) => console.error("Native listener setup failed", r.reason));
+            });
 
             // Ask for the current FCM token
             getFcmToken().then((token) => {
@@ -232,12 +243,10 @@
             // WhatsApp's per-chat tiles).
             startChatShortcutPusher(client);
 
-            // Inform the native android app that svelte code is ready! SetTimeout
-            // delays the fn execution until the call stack is empty, just to
-            // make sure anything else non-async that needs to run is done.
-            //
-            // Once Svelte app is ready, native code can start pushing events.
-            setTimeout(svelteReady);
+            // Inform the native android app that svelte code is ready — but only
+            // once all the listeners above are registered, so the native event
+            // queue flushes into handlers that actually exist.
+            listenersRegistered.then(() => svelteReady());
         }
     }
 

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -40,7 +40,12 @@
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
-    import { getFcmToken, svelteReady } from "tauri-plugin-oc-api";
+    import {
+        clearAllNotifications,
+        deleteFcmToken,
+        getFcmToken,
+        svelteReady,
+    } from "tauri-plugin-oc-api";
     import { clearChatShortcuts, startChatShortcutPusher } from "@stores/chatShortcuts";
     import Head from "./Head.svelte";
     import NotificationsBar from "./home/NotificationsBar.svelte";
@@ -232,6 +237,20 @@
                 }
 
                 addFcmToken(token);
+            });
+
+            // Best-effort push hygiene on sign-out, while the identity is
+            // still valid: unbind this device's token from the account,
+            // delete the device token (pushes to it then dead-end at FCM,
+            // and the next login mints + registers a fresh one), and empty
+            // the tray so nothing from this account lingers.
+            client.onLogout(async () => {
+                const token = await getFcmToken().catch(() => null);
+                if (token) {
+                    await client.removeFcmToken(token).catch(console.error);
+                }
+                await deleteFcmToken().catch(console.error);
+                await clearAllNotifications().catch(console.error);
             });
 
             // Push the top recent chats to the Android Sharing Shortcuts API

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -185,6 +185,13 @@
         setStatusAndNavBarSizesForNativeApp();
     }
 
+    // Guards the one-time native setup (listeners, logout hook, svelteReady)
+    // so it runs once per page session. setupNativeApp() itself runs again on
+    // every userLoggedIn (account switch), but only the FCM token registration
+    // should repeat — re-registering listeners or the logout hook would stack
+    // duplicate handlers (e.g. a single warm tap firing multiple times).
+    let nativeSetupDone = false;
+
     // Sets up push notifications and FCM token management for native apps
     function setupNativeApp() {
         const addFcmToken = (token: string) => {
@@ -194,75 +201,83 @@
                 .catch(console.error);
         };
 
-        if (client.isNativeApp()) {
-            // Register every native event listener BEFORE signalling svelteReady:
-            // the native side flushes its queued events the moment svelteReady
-            // fires, and a flush that beats an in-flight listener registration
-            // silently drops the event (e.g. a cold-start notification tap).
-            const listenersRegistered = Promise.allSettled([
-                // Listen for incoming push notifications from Firebase; also asks
-                // for permission to show notifications if not already granted.
-                expectPushNotifications(),
-
-                // Listen for notifications user has tapped on
-                expectNotificationTap(),
-
-                // Listen for content shared into OpenChat from the system share sheet
-                // (or via a Direct Share chat shortcut). Cold-start shares are queued
-                // by the native side and delivered once svelteReady fires below.
-                expectShareTarget((share) => handleShareTarget(client, share)),
-
-                // Listen for deep links (e.g. https://oc.app/group/xyz tapped from another app).
-                // Cold-start deep links are queued by MainActivity and delivered once svelteReady fires.
-                expectDeepLinks(),
-
-                // Expect FCM token refreshes
-                expectNewFcmToken(addFcmToken),
-            ]);
-            listenersRegistered.then((results) => {
-                results
-                    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-                    .forEach((r) => console.error("Native listener setup failed", r.reason));
-            });
-
-            // Ask for the current FCM token and register it unconditionally.
-            // Registration is last-login-wins on the backend, so this also
-            // reclaims a token still bound to a previous account on this
-            // device (a fcm_token_exists pre-check would wrongly skip that).
-            getFcmToken().then((token) => {
-                if (!token) {
-                    // TODO do we handle this somehow? Debounce, try again?
-                    console.error("No FCM token received");
-                    return;
-                }
-
-                addFcmToken(token);
-            });
-
-            // Best-effort push hygiene on sign-out, while the identity is
-            // still valid: unbind this device's token from the account,
-            // delete the device token (pushes to it then dead-end at FCM,
-            // and the next login mints + registers a fresh one), and empty
-            // the tray so nothing from this account lingers.
-            client.onLogout(async () => {
-                const token = await getFcmToken().catch(() => null);
-                if (token) {
-                    await client.removeFcmToken(token).catch(console.error);
-                }
-                await deleteFcmToken().catch(console.error);
-                await clearAllNotifications().catch(console.error);
-            });
-
-            // Push the top recent chats to the Android Sharing Shortcuts API
-            // so they appear directly in the system share sheet (like
-            // WhatsApp's per-chat tiles).
-            startChatShortcutPusher(client);
-
-            // Inform the native android app that svelte code is ready — but only
-            // once all the listeners above are registered, so the native event
-            // queue flushes into handlers that actually exist.
-            listenersRegistered.then(() => svelteReady());
+        if (!client.isNativeApp()) {
+            return;
         }
+
+        // Ask for the current FCM token and register it unconditionally on every
+        // login. Registration is last-login-wins on the backend, so this also
+        // reclaims a token still bound to a previous account on this device (a
+        // fcm_token_exists pre-check would wrongly skip that).
+        getFcmToken().then((token) => {
+            if (!token) {
+                // TODO do we handle this somehow? Debounce, try again?
+                console.error("No FCM token received");
+                return;
+            }
+
+            addFcmToken(token);
+        });
+
+        // Everything below registers session-scoped handlers and must run once.
+        if (nativeSetupDone) {
+            return;
+        }
+        nativeSetupDone = true;
+
+        // Register every native event listener BEFORE signalling svelteReady:
+        // the native side flushes its queued events the moment svelteReady
+        // fires, and a flush that beats an in-flight listener registration
+        // silently drops the event (e.g. a cold-start notification tap).
+        const listenersRegistered = Promise.allSettled([
+            // Listen for incoming push notifications from Firebase; also asks
+            // for permission to show notifications if not already granted.
+            expectPushNotifications(),
+
+            // Listen for notifications user has tapped on
+            expectNotificationTap(),
+
+            // Listen for content shared into OpenChat from the system share sheet
+            // (or via a Direct Share chat shortcut). Cold-start shares are queued
+            // by the native side and delivered once svelteReady fires below.
+            expectShareTarget((share) => handleShareTarget(client, share)),
+
+            // Listen for deep links (e.g. https://oc.app/group/xyz tapped from another app).
+            // Cold-start deep links are queued by MainActivity and delivered once svelteReady fires.
+            expectDeepLinks(),
+
+            // Expect FCM token refreshes
+            expectNewFcmToken(addFcmToken),
+        ]);
+        listenersRegistered.then((results) => {
+            results
+                .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+                .forEach((r) => console.error("Native listener setup failed", r.reason));
+        });
+
+        // Best-effort push hygiene on sign-out, while the identity is
+        // still valid: unbind this device's token from the account,
+        // delete the device token (pushes to it then dead-end at FCM,
+        // and the next login mints + registers a fresh one), and empty
+        // the tray so nothing from this account lingers.
+        client.onLogout(async () => {
+            const token = await getFcmToken().catch(() => null);
+            if (token) {
+                await client.removeFcmToken(token).catch(console.error);
+            }
+            await deleteFcmToken().catch(console.error);
+            await clearAllNotifications().catch(console.error);
+        });
+
+        // Push the top recent chats to the Android Sharing Shortcuts API
+        // so they appear directly in the system share sheet (like
+        // WhatsApp's per-chat tiles).
+        startChatShortcutPusher(client);
+
+        // Inform the native android app that svelte code is ready — but only
+        // once all the listeners above are registered, so the native event
+        // queue flushes into handlers that actually exist.
+        listenersRegistered.then(() => svelteReady());
     }
 
     if ($identityStateStore.kind === "logged_in") {

--- a/frontend/app/src/components_mobile/Router.svelte
+++ b/frontend/app/src/components_mobile/Router.svelte
@@ -1,7 +1,10 @@
 
 <script lang="ts">
     import { initNavigationHistoryTracking, navigate } from "@src/utils/navigation";
-    import { consumePendingDeepLink } from "@utils/native/notification_channels";
+    import {
+        consumePendingDeepLink,
+        consumePendingNotificationTap,
+    } from "@utils/native/notification_channels";
     import { handleLinkClick, removeQueryStringParam } from "@src/utils/urls";
     import type { TransitionType } from "component-lib";
     import { type ChatIdentifier, OpenChat, type RouteParams, adminRoute, chatIdentifiersEqual, chatListRoute, chatListScopeStore, chatsInitialisedStore, communitesRoute, communitiesStore, communityIdentifiersEqual, exploringStore, globalDirectChatSelectedRoute, globalGroupChatSelectedRoute, isMessageIndexRoute, messageIndexStore, notFoundStore, notificationsRoute, profileSummaryRoute, publish, routeKindStore, routeStore, routerReadyStore, selectedChannelRoute, selectedChatIdStore, selectedCommunityIdStore, selectedCommunityRoute, selectedServerChatStore, shareRoute, threadMessageIndexStore, threadOpenStore, walletRoute, welcomeRoute } from "openchat-client";
@@ -313,6 +316,7 @@
             !$exploringStore
         ) {
             const deepLink = consumePendingDeepLink();
+            const tapPath = deepLink === null ? consumePendingNotificationTap() : null;
             if (deepLink) {
                 untrack(() => {
                     try {
@@ -323,6 +327,8 @@
                         client.selectDefaultChat();
                     }
                 });
+            } else if (tapPath) {
+                untrack(() => navigate(tapPath, "notification"));
             } else {
                 client.selectDefaultChat();
             }

--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -15,6 +15,13 @@ import App from "./components/App.svelte";
 import AppV2 from "./components_mobile/App.svelte";
 import { setNativeTheme, writeNativeCssVariables } from "./theme/themes";
 
+// Picks the app variant once at startup. The native Android build ships
+// OC_MOBILE_LAYOUT=v2, so phones (viewport < 768px) always mount AppV2
+// (components_mobile). AppV2 is where the native cold-start machinery lives —
+// reliable notification-tap routing, pending deep-link/tap consumption in
+// Router.svelte, and the listeners-before-svelteReady sequencing. The v1 App
+// (components) only renders on >=768px viewports (desktop web, large tablets)
+// and intentionally does not implement that native cold-start routing.
 const v2 = import.meta.env.OC_MOBILE_LAYOUT === "v2" && mobileWidth.value;
 
 if (v2) {

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -167,19 +167,22 @@ export async function expectNotificationTap(): Promise<PluginListener> {
 
     // Pull any tap stored during cold start (before the listener was ready).
     // Stored for Router.svelte to consume instead of auto-selecting the default chat.
+    let pending: { payload?: string } | undefined;
     try {
-        const pending = await invoke<{ payload?: string }>(
-            "plugin:oc|get_pending_notification_tap",
-        );
-        if (pending?.payload) {
+        pending = await invoke<{ payload?: string }>("plugin:oc|get_pending_notification_tap");
+    } catch (e) {
+        console.error("Notification tap: get_pending_notification_tap invoke failed", e);
+    }
+    if (pending?.payload) {
+        try {
             const path = notificationPath(JSON.parse(pending.payload) as PushNotification);
             if (path) {
                 console.log("Notification tap: cold-start pending path stored", path);
                 pendingColdStartTapPath = path;
             }
+        } catch (e) {
+            console.error("Notification tap: failed to parse pending payload", pending.payload, e);
         }
-    } catch (e) {
-        console.error("Notification tap: get_pending_notification_tap invoke failed", e);
     }
 
     return listener;

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -106,50 +106,82 @@ export async function expectPushNotifications(): Promise<PluginListener> {
 }
 
 /**
+ * Maps a tapped notification to its in-app route, or null if the payload
+ * doesn't describe a navigable destination.
+ */
+function notificationPath(notification: PushNotification): string | null {
+    const threadIndexPath = notification.threadIndex ? `/${notification.threadIndex}` : "";
+    switch (notification.type) {
+        case "DM":
+            return notification.senderId ? `/user/${notification.senderId}` : null;
+        case "GROUP":
+            return notification.groupId
+                ? `/group/${notification.groupId}${threadIndexPath}`
+                : null;
+        case "CHANNEL":
+            return notification.communityId && notification.channelId
+                ? `/community/${notification.communityId}/channel/${notification.channelId}${threadIndexPath}`
+                : null;
+        default:
+            return null;
+    }
+}
+
+// Holds the route of a notification tapped during cold start (delivered before
+// the tap listener was registered). Consumed by Router.svelte's auto-selection
+// effect so it navigates to the tapped chat instead of the default chat —
+// same pattern as pendingColdStartUrl below.
+let pendingColdStartTapPath: string | null = null;
+
+export function consumePendingNotificationTap(): string | null {
+    const path = pendingColdStartTapPath;
+    pendingColdStartTapPath = null;
+    return path;
+}
+
+/**
  * Listens for any notifications tapped by the users.
  *
- * Once the notification is tapped, native Kotlin code will pick it up, and
- * then raise an event and send the notification data to the Svelte UI.
- *
- * Once the UI receives the notification, we can show the appropriate context.
+ * Warm taps arrive as a "notification-tap" event; taps that happened before
+ * the WebView was ready are persisted natively and pulled here once the
+ * listener is registered, so nothing is lost to the startup race.
  *
  * @returns
  */
 export async function expectNotificationTap(): Promise<PluginListener> {
-    return addPluginListener(
+    const listener = await addPluginListener(
         TAURI_PLUGIN_NAME,
         NOTIFICATION_TAP_EVENT,
         (notification: PushNotification) => {
-            const threadIndexPath = notification.threadIndex ? `/${notification.threadIndex}` : "";
-            switch (notification.type) {
-                case "DM": {
-                    if (notification.senderId) {
-                        navigate(`/user/${notification.senderId}`, "notification");
-                    }
-                    break;
-                }
-                case "GROUP": {
-                    if (notification.groupId) {
-                        navigate(`/group/${notification.groupId}${threadIndexPath}`, "notification");
-                    }
-                    break;
-                }
-                case "CHANNEL": {
-                    if (notification.communityId && notification.channelId) {
-                        navigate(
-                            `/community/${notification.communityId}/channel/${notification.channelId}${threadIndexPath}`,
-                            "notification",
-                        );
-                    }
-                    break;
-                }
-                default:
-                    console.error(
-                        "Not available or unknown notification type! I don't know how to handle it.",
-                    );
+            const path = notificationPath(notification);
+            if (path) {
+                navigate(path, "notification");
+            } else {
+                console.error(
+                    "Not available or unknown notification type! I don't know how to handle it.",
+                );
             }
         },
     );
+
+    // Pull any tap stored during cold start (before the listener was ready).
+    // Stored for Router.svelte to consume instead of auto-selecting the default chat.
+    try {
+        const pending = await invoke<{ payload?: string }>(
+            "plugin:oc|get_pending_notification_tap",
+        );
+        if (pending?.payload) {
+            const path = notificationPath(JSON.parse(pending.payload) as PushNotification);
+            if (path) {
+                console.log("Notification tap: cold-start pending path stored", path);
+                pendingColdStartTapPath = path;
+            }
+        }
+    } catch (e) {
+        console.error("Notification tap: get_pending_notification_tap invoke failed", e);
+    }
+
+    return listener;
 }
 
 async function askForPermission(): Promise<boolean> {

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -124,13 +124,13 @@ export async function expectNotificationTap(): Promise<PluginListener> {
             switch (notification.type) {
                 case "DM": {
                     if (notification.senderId) {
-                        navigate(`/user/${notification.senderId}`);
+                        navigate(`/user/${notification.senderId}`, "notification");
                     }
                     break;
                 }
                 case "GROUP": {
                     if (notification.groupId) {
-                        navigate(`/group/${notification.groupId}${threadIndexPath}`);
+                        navigate(`/group/${notification.groupId}${threadIndexPath}`, "notification");
                     }
                     break;
                 }
@@ -138,6 +138,7 @@ export async function expectNotificationTap(): Promise<PluginListener> {
                     if (notification.communityId && notification.channelId) {
                         navigate(
                             `/community/${notification.communityId}/channel/${notification.channelId}${threadIndexPath}`,
+                            "notification",
                         );
                     }
                     break;

--- a/frontend/app/src/utils/native/notification_channels.ts
+++ b/frontend/app/src/utils/native/notification_channels.ts
@@ -6,7 +6,8 @@ import { isLandingPagePath } from "@utils/urls";
 
 const TAURI_PLUGIN_NAME = "oc";
 const PUSH_NOTIFICATION_EVENT = "push-notification";
-const NEW_FCM_TOKEN_EVENT = "fcm-token";
+// Must match the event name Kotlin fires in OCPluginCompanion.cacheNewFcmToken.
+const NEW_FCM_TOKEN_EVENT = "fcm-token-refresh";
 const NOTIFICATION_TAP_EVENT = "notification-tap";
 const BACK_PRESS_EVENT = "back-pressed";
 const WINDOW_INSET_CHANGE_EVENT = "window-inset-change";
@@ -210,9 +211,22 @@ async function askForPermission(): Promise<boolean> {
  * @param handler the function to call when a new FCM token is received.
  * @returns
  */
-export async function expectNewFcmToken<T>(handler: (data: T) => void): Promise<PluginListener> {
-    // Set up the listener for new FCM tokens!
-    return addPluginListener(TAURI_PLUGIN_NAME, NEW_FCM_TOKEN_EVENT, handler);
+export async function expectNewFcmToken(
+    handler: (token: string) => void,
+): Promise<PluginListener> {
+    // Set up the listener for new FCM tokens! The native side sends
+    // { fcmToken: "..." }, the handler wants the bare token.
+    return addPluginListener(
+        TAURI_PLUGIN_NAME,
+        NEW_FCM_TOKEN_EVENT,
+        (data: { fcmToken?: string }) => {
+            if (data?.fcmToken) {
+                handler(data.fcmToken);
+            } else {
+                console.error("FCM token refresh event carried no token", data);
+            }
+        },
+    );
 }
 
 /**

--- a/frontend/openchat-agent/src/services/notifications/notifications.client.ts
+++ b/frontend/openchat-agent/src/services/notifications/notifications.client.ts
@@ -6,6 +6,7 @@ import {
     NotificationsIndexMarkSubscriptionActiveArgs,
     NotificationsIndexPushSubscriptionArgs,
     NotificationsIndexPushSubscriptionResponse,
+    NotificationsIndexRemoveFcmTokenArgs,
     NotificationsIndexRemoveSubscriptionArgs,
     NotificationsIndexSubscriptionExistsArgs,
     NotificationsIndexSubscriptionExistsResponse,
@@ -83,6 +84,16 @@ export class NotificationsClient extends SingleCanisterMsgpackAgent {
                 }
             },
             NotificationsIndexAddFcmTokenArgs,
+            UnitResult,
+        );
+    }
+
+    removeFcmToken(fcmToken: string): Promise<void> {
+        return this.update(
+            "remove_fcm_token",
+            { fcm_token: fcmToken },
+            toVoid,
+            NotificationsIndexRemoveFcmTokenArgs,
             UnitResult,
         );
     }

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -2589,6 +2589,10 @@ export class OpenChatAgent extends EventTarget {
         return this._notificationClient.addFcmToken(fcmToken, onResponseError);
     }
 
+    removeFcmToken(fcmToken: string): Promise<void> {
+        return this._notificationClient.removeFcmToken(fcmToken);
+    }
+
     toggleMuteNotifications(
         id: ChatIdentifier | CommunityIdentifier,
         mute: boolean | undefined,

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -227,11 +227,6 @@ export const GroupRegisterWebhookArgs = Type.Object({
     avatar: Type.Optional(Type.String()),
 });
 
-export type GroupDeleteHistoryArgs = Static<typeof GroupDeleteHistoryArgs>;
-export const GroupDeleteHistoryArgs = Type.Object({
-    before: Type.BigInt(),
-});
-
 export type GroupSelectedUpdatesArgs = Static<typeof GroupSelectedUpdatesArgs>;
 export const GroupSelectedUpdatesArgs = Type.Object({
     updates_since: Type.BigInt(),
@@ -918,7 +913,6 @@ export const ChatEventType = Type.Union([
     Type.Literal("Frozen"),
     Type.Literal("Unfrozen"),
     Type.Literal("DisappearingMessagesUpdated"),
-    Type.Literal("HistoryDeleted"),
     Type.Literal("MessagePinned"),
     Type.Literal("MessageUnpinned"),
     Type.Literal("MembersJoined"),
@@ -2927,12 +2921,6 @@ export const CommunityDeleteMessagesArgs = Type.Object({
     message_ids: Type.Array(MessageId),
     as_platform_moderator: Type.Optional(Type.Boolean()),
     new_achievement: Type.Boolean(),
-});
-
-export type CommunityDeleteChannelHistoryArgs = Static<typeof CommunityDeleteChannelHistoryArgs>;
-export const CommunityDeleteChannelHistoryArgs = Type.Object({
-    channel_id: ChannelId,
-    before: Type.BigInt(),
 });
 
 export type CommunityRemoveMemberFromChannelArgs = Static<
@@ -5568,12 +5556,6 @@ export const MembersResponse = Type.Union([
         Error: OCError,
     }),
 ]);
-
-export type HistoryDeleted = Static<typeof HistoryDeleted>;
-export const HistoryDeleted = Type.Object({
-    before: Type.BigInt(),
-    deleted_by: UserId,
-});
 
 export type RoleChanged = Static<typeof RoleChanged>;
 export const RoleChanged = Type.Object({
@@ -8871,9 +8853,6 @@ export const ChatEvent = Type.Union([
     }),
     Type.Object({
         BotUpdated: BotUpdated,
-    }),
-    Type.Object({
-        HistoryDeleted: HistoryDeleted,
     }),
     Type.Literal("FailedToDeserialize"),
 ]);

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -227,6 +227,11 @@ export const GroupRegisterWebhookArgs = Type.Object({
     avatar: Type.Optional(Type.String()),
 });
 
+export type GroupDeleteHistoryArgs = Static<typeof GroupDeleteHistoryArgs>;
+export const GroupDeleteHistoryArgs = Type.Object({
+    before: Type.BigInt(),
+});
+
 export type GroupSelectedUpdatesArgs = Static<typeof GroupSelectedUpdatesArgs>;
 export const GroupSelectedUpdatesArgs = Type.Object({
     updates_since: Type.BigInt(),
@@ -913,6 +918,7 @@ export const ChatEventType = Type.Union([
     Type.Literal("Frozen"),
     Type.Literal("Unfrozen"),
     Type.Literal("DisappearingMessagesUpdated"),
+    Type.Literal("HistoryDeleted"),
     Type.Literal("MessagePinned"),
     Type.Literal("MessageUnpinned"),
     Type.Literal("MembersJoined"),
@@ -2923,6 +2929,12 @@ export const CommunityDeleteMessagesArgs = Type.Object({
     new_achievement: Type.Boolean(),
 });
 
+export type CommunityDeleteChannelHistoryArgs = Static<typeof CommunityDeleteChannelHistoryArgs>;
+export const CommunityDeleteChannelHistoryArgs = Type.Object({
+    channel_id: ChannelId,
+    before: Type.BigInt(),
+});
+
 export type CommunityRemoveMemberFromChannelArgs = Static<
     typeof CommunityRemoveMemberFromChannelArgs
 >;
@@ -3366,6 +3378,13 @@ export type NotificationsIndexRemoveSubscriptionArgs = Static<
 >;
 export const NotificationsIndexRemoveSubscriptionArgs = Type.Object({
     endpoint: Type.String(),
+});
+
+export type NotificationsIndexRemoveFcmTokenArgs = Static<
+    typeof NotificationsIndexRemoveFcmTokenArgs
+>;
+export const NotificationsIndexRemoveFcmTokenArgs = Type.Object({
+    fcm_token: FcmToken,
 });
 
 export type NotificationsIndexAddFcmTokenArgs = Static<typeof NotificationsIndexAddFcmTokenArgs>;
@@ -5549,6 +5568,12 @@ export const MembersResponse = Type.Union([
         Error: OCError,
     }),
 ]);
+
+export type HistoryDeleted = Static<typeof HistoryDeleted>;
+export const HistoryDeleted = Type.Object({
+    before: Type.BigInt(),
+    deleted_by: UserId,
+});
 
 export type RoleChanged = Static<typeof RoleChanged>;
 export const RoleChanged = Type.Object({
@@ -8846,6 +8871,9 @@ export const ChatEvent = Type.Union([
     }),
     Type.Object({
         BotUpdated: BotUpdated,
+    }),
+    Type.Object({
+        HistoryDeleted: HistoryDeleted,
     }),
     Type.Literal("FailedToDeserialize"),
 ]);

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1185,11 +1185,31 @@ export class OpenChat {
         this.#preLogoutTasks.push(task);
     }
 
+    // Resolves when `promise` settles or after `ms`, whichever comes first,
+    // always clearing the timer afterwards so it never dangles.
+    #withTimeout(promise: Promise<unknown>, ms: number): Promise<void> {
+        let timer: number | undefined;
+        const timeout = new Promise<void>((resolve) => {
+            timer = window.setTimeout(resolve, ms);
+        });
+        return Promise.race([promise.then(() => undefined), timeout]).finally(() =>
+            window.clearTimeout(timer),
+        );
+    }
+
     async logout(): Promise<void> {
-        await Promise.race([
-            Promise.allSettled(this.#preLogoutTasks.map((task) => task())),
-            new Promise((resolve) => window.setTimeout(resolve, 5000)),
-        ]).catch(() => undefined);
+        // Run any registered pre-logout tasks (e.g. push-token cleanup) while
+        // the identity is still valid. Best-effort: Promise.resolve().then wraps
+        // each task so a synchronous throw becomes a rejection that allSettled
+        // can absorb, and a 5s cap stops a slow task from blocking sign-out.
+        // Take + clear the list so tasks don't accumulate across
+        // login → logout → login within a single page session.
+        const tasks = this.#preLogoutTasks;
+        this.#preLogoutTasks = [];
+        await this.#withTimeout(
+            Promise.allSettled(tasks.map((task) => Promise.resolve().then(task))),
+            5000,
+        );
 
         await Promise.all([
             this.#worker.send({ kind: "logout" }),

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1173,7 +1173,24 @@ export class OpenChat {
         );
     }
 
+    #preLogoutTasks: (() => Promise<unknown>)[] = [];
+
+    /**
+     * Registers a task to run at the start of logout, while the caller's
+     * identity is still valid — e.g. removing this device's push token from
+     * the notifications canister. Tasks are best-effort: failures are
+     * swallowed and a timeout stops them from blocking sign-out.
+     */
+    onLogout(task: () => Promise<unknown>): void {
+        this.#preLogoutTasks.push(task);
+    }
+
     async logout(): Promise<void> {
+        await Promise.race([
+            Promise.allSettled(this.#preLogoutTasks.map((task) => task())),
+            new Promise((resolve) => window.setTimeout(resolve, 5000)),
+        ]).catch(() => undefined);
+
         await Promise.all([
             this.#worker.send({ kind: "logout" }),
             this.#authClient.then((c) => c.logout()),
@@ -5331,6 +5348,10 @@ export class OpenChat {
 
     addFcmToken(fcmToken: string, onResponseError?: (error: string | null) => void): Promise<void> {
         return this.#worker.send({ kind: "addFcmToken", fcmToken, onResponseError });
+    }
+
+    removeFcmToken(fcmToken: string): Promise<void> {
+        return this.#worker.send({ kind: "removeFcmToken", fcmToken });
     }
 
     inviteUsers(

--- a/frontend/openchat-shared/src/domain/worker.ts
+++ b/frontend/openchat-shared/src/domain/worker.ts
@@ -463,6 +463,7 @@ export type WorkerRequest =
     | UpdateProposalTallies
     | FcmTokenExists
     | AddFcmToken
+    | RemoveFcmToken
     | CreateAccountLinkingCode
     | ReinstateMissedDailyClaims
     | VerifyAccountLinkingCode
@@ -1085,6 +1086,11 @@ type AddFcmToken = {
     kind: "addFcmToken";
     fcmToken: string;
     onResponseError?: (error: string | null) => void;
+};
+
+type RemoveFcmToken = {
+    kind: "removeFcmToken";
+    fcmToken: string;
 };
 
 type RegisterUser = {

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -594,6 +594,9 @@ function getAction(
         case "addFcmToken":
             return agent.addFcmToken(payload.fcmToken, payload.onResponseError);
 
+        case "removeFcmToken":
+            return agent.removeFcmToken(payload.fcmToken);
+
         case "markNotificationSubscriptionActive":
             return agent.markNotificationSubscriptionActive(payload.endpoint);
 

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oc/app/MainActivity.kt
@@ -34,8 +34,8 @@ class MainActivity : TauriActivity() {
         // We neutralize the intent so tao ignores it, then deliver the URL via
         // OCPluginCompanion (which queues it until the WebView is ready).
         val deepLinkUrl = extractDeepLinkUrl(intent)
-        if (deepLinkUrl != null) {
-            setIntent(Intent(intent).apply { action = Intent.ACTION_MAIN; data = null })
+        if (deepLinkUrl != null || isViewWithoutData(intent)) {
+            setIntent(neutralized(intent))
         }
 
         super.onCreate(savedInstanceState)
@@ -70,8 +70,8 @@ class MainActivity : TauriActivity() {
         // Same tao null getType() crash applies to warm starts; pass a neutralized
         // copy to super but deliver the URL via OCPluginCompanion.
         val deepLinkUrl = extractDeepLinkUrl(intent)
-        val safeIntent = if (deepLinkUrl != null) {
-            Intent(intent).apply { action = Intent.ACTION_MAIN; data = null }
+        val safeIntent = if (deepLinkUrl != null || isViewWithoutData(intent)) {
+            neutralized(intent)
         } else intent
 
         super.onNewIntent(safeIntent)
@@ -89,6 +89,20 @@ class MainActivity : TauriActivity() {
             Log.e(LOG_TAG, "Error occurred $e")
         }
     }
+
+    // A VIEW intent with no data URI can't be a real deep link but still hits
+    // the tao null getType() crash. Notification conversation shortcuts are the
+    // known source: a shortcut intent must carry an action, so they use VIEW
+    // with only a notificationPayload extra, which handleNotificationIntent
+    // reads regardless of the action.
+    private fun isViewWithoutData(intent: Intent): Boolean =
+        intent.action == Intent.ACTION_VIEW && intent.data == null
+
+    private fun neutralized(intent: Intent): Intent =
+        Intent(intent).apply {
+            action = Intent.ACTION_MAIN
+            data = null
+        }
 
     private fun extractDeepLinkUrl(intent: Intent): String? {
         if (intent.action != Intent.ACTION_VIEW) return null

--- a/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/NotificationsManager.kt
@@ -239,7 +239,15 @@ object NotificationsManager {
             if (isTaped) {
 
                 Log.d(OC_TAG_NOT, "#### Notification tap: $notificationJson")
-                OCPluginCompanion.triggerRef("notification-tap", notificationJson)
+                if (OCPluginCompanion.svelteReady) {
+                    OCPluginCompanion.triggerRef("notification-tap", notificationJson)
+                } else {
+                    // WebView not ready (cold start): persist the payload for JS to
+                    // pull once its listener is registered. Queueing the event instead
+                    // races the svelteReady flush against listener registration, and a
+                    // lost race drops the tap — the app opens without the chat.
+                    OCPluginCompanion.pendingNotificationTap = notificationJson.toString()
+                }
             }
         } catch (e: Exception) {
             Log.e(OC_TAG_NOT, "Error processing notification tap", e)

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
@@ -77,6 +77,16 @@ class OpenChatPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
+    fun clearAllNotifications(invoke: Invoke) {
+        ClearAllNotifications(activity).handler(invoke)
+    }
+
+    @Command
+    fun deleteFcmToken(invoke: Invoke) {
+        DeleteFcmToken().handler(invoke)
+    }
+
+    @Command
     fun minimizeApp(invoke: Invoke) {
         MinimizeApp(activity).handler(invoke)
     }

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
@@ -125,6 +125,17 @@ class OpenChatPlugin(private val activity: Activity) : Plugin(activity) {
             invoke.resolve(JSObject())
         }
     }
+
+    @Command
+    fun getPendingNotificationTap(invoke: Invoke) {
+        val payload = OCPluginCompanion.pendingNotificationTap
+        OCPluginCompanion.pendingNotificationTap = null
+        if (payload != null) {
+            invoke.resolve(JSObject().put("payload", payload))
+        } else {
+            invoke.resolve(JSObject())
+        }
+    }
 }
 
 object OCPluginCompanion {
@@ -143,6 +154,13 @@ object OCPluginCompanion {
     // Deep link URL received during cold start (before the WebView was ready).
     // JS pulls this via getPendingDeepLink() once mounted.
     var pendingDeepLinkUrl: String? = null
+
+    // Notification tap payload received before the WebView was ready. Taps are
+    // NOT sent through the event queue in that case: the queue flushes the
+    // moment svelteReady fires, which can beat the async listener registration
+    // and silently drop the event. JS pulls this via getPendingNotificationTap()
+    // once its listener is in place.
+    var pendingNotificationTap: String? = null
 
     fun initFcmTokenCache() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->

--- a/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/OpenChatPlugin.kt
@@ -151,6 +151,11 @@ class OpenChatPlugin(private val activity: Activity) : Plugin(activity) {
 object OCPluginCompanion {
 
     // Indicates that the UI is ready!
+    //
+    // @Volatile: written by the SvelteReady command and read from the
+    // notification-tap handler (see NotificationsManager) on a different thread;
+    // without it the store-vs-trigger decision could read a stale value.
+    @Volatile
     var svelteReady: Boolean = false
 
     // Allows the viewport to resize when keyboard pops up
@@ -162,14 +167,18 @@ object OCPluginCompanion {
     var fcmToken: String? = null
 
     // Deep link URL received during cold start (before the WebView was ready).
-    // JS pulls this via getPendingDeepLink() once mounted.
+    // JS pulls this via getPendingDeepLink() once mounted. @Volatile: written on
+    // the intent-handling thread, read on the command-invoke thread.
+    @Volatile
     var pendingDeepLinkUrl: String? = null
 
     // Notification tap payload received before the WebView was ready. Taps are
     // NOT sent through the event queue in that case: the queue flushes the
     // moment svelteReady fires, which can beat the async listener registration
     // and silently drop the event. JS pulls this via getPendingNotificationTap()
-    // once its listener is in place.
+    // once its listener is in place. @Volatile: written on the tap-handling
+    // thread, read on the command-invoke thread.
+    @Volatile
     var pendingNotificationTap: String? = null
 
     fun initFcmTokenCache() {

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/ClearAllNotifications.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/ClearAllNotifications.kt
@@ -1,9 +1,7 @@
 package com.ocplugin.app.commands
 
 import android.app.Activity
-import android.util.Log
 import app.tauri.plugin.Invoke
-import com.ocplugin.app.LOG_TAG
 import com.ocplugin.app.NotificationsManager
 
 import kotlinx.coroutines.SupervisorJob
@@ -23,15 +21,14 @@ class ClearAllNotifications(private val activity: Activity) {
 
     fun handler(invoke: Invoke) {
         scope.launch {
-            val success = withContext(Dispatchers.IO) {
-                runCatching {
-                    NotificationsManager.releaseAllNotificationsAfterSummaryDismissed(activity)
-                }.onFailure {
-                    Log.e(LOG_TAG, "Error clearing all notifications", it)
-                }.isSuccess
+            // Best-effort: releaseAllNotificationsAfterSummaryDismissed logs and
+            // swallows its own failures, so there is no meaningful success/failure
+            // to report back — clearing the tray must never block or fail sign-out.
+            // Resolve once it has run.
+            withContext(Dispatchers.IO) {
+                NotificationsManager.releaseAllNotificationsAfterSummaryDismissed(activity)
             }
-
-            if (success) invoke.resolve(null) else invoke.reject("EXCEPTION")
+            invoke.resolve(null)
         }
     }
 }

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/ClearAllNotifications.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/ClearAllNotifications.kt
@@ -1,0 +1,37 @@
+package com.ocplugin.app.commands
+
+import android.app.Activity
+import android.util.Log
+import app.tauri.plugin.Invoke
+import com.ocplugin.app.LOG_TAG
+import com.ocplugin.app.NotificationsManager
+
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// Clears every displayed notification (per-chat + summary) and releases the
+// local notification store. Used on sign-out, so nothing belonging to the
+// previous account lingers in the tray or routes taps into the wrong session.
+@Suppress("UNUSED")
+class ClearAllNotifications(private val activity: Activity) {
+
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.Main + job)
+
+    fun handler(invoke: Invoke) {
+        scope.launch {
+            val success = withContext(Dispatchers.IO) {
+                runCatching {
+                    NotificationsManager.releaseAllNotificationsAfterSummaryDismissed(activity)
+                }.onFailure {
+                    Log.e(LOG_TAG, "Error clearing all notifications", it)
+                }.isSuccess
+            }
+
+            if (success) invoke.resolve(null) else invoke.reject("EXCEPTION")
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/android/src/main/java/commands/DeleteFcmToken.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/commands/DeleteFcmToken.kt
@@ -1,0 +1,29 @@
+package com.ocplugin.app.commands
+
+import android.util.Log
+import app.tauri.plugin.Invoke
+import com.google.firebase.messaging.FirebaseMessaging
+import com.ocplugin.app.LOG_TAG
+import com.ocplugin.app.OCPluginCompanion
+
+// Deletes the device's FCM token and clears the local cache. Used on
+// sign-out: even if the server-side token removal fails or races, pushes
+// aimed at the deleted token dead-end at FCM. Firebase mints a fresh token
+// the next time one is requested, so the next login re-registers cleanly.
+@Suppress("UNUSED")
+class DeleteFcmToken {
+
+    fun handler(invoke: Invoke) {
+        FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener { task ->
+            // Clear the cache either way — a stale token must not be re-registered.
+            OCPluginCompanion.fcmToken = null
+
+            if (task.isSuccessful) {
+                invoke.resolve(null)
+            } else {
+                Log.e(LOG_TAG, "Failed to delete FCM token", task.exception)
+                invoke.reject("FAILED")
+            }
+        }
+    }
+}

--- a/frontend/tauri-plugin-oc/build.rs
+++ b/frontend/tauri-plugin-oc/build.rs
@@ -17,6 +17,8 @@ const COMMANDS: &[&str] = &[
     "disable_viewport_resize",
     "save_media",
     "update_chat_shortcuts",
+    "get_pending_deep_link",
+    "get_pending_notification_tap",
 ];
 
 fn main() {

--- a/frontend/tauri-plugin-oc/build.rs
+++ b/frontend/tauri-plugin-oc/build.rs
@@ -19,6 +19,8 @@ const COMMANDS: &[&str] = &[
     "update_chat_shortcuts",
     "get_pending_deep_link",
     "get_pending_notification_tap",
+    "clear_all_notifications",
+    "delete_fcm_token",
 ];
 
 fn main() {

--- a/frontend/tauri-plugin-oc/guest-js/commands/clearAllNotifications.ts
+++ b/frontend/tauri-plugin-oc/guest-js/commands/clearAllNotifications.ts
@@ -1,0 +1,10 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Clears every displayed notification (per-chat + summary) and releases the
+ * native notification store. Call on sign-out so nothing belonging to the
+ * previous account lingers in the tray.
+ */
+export async function clearAllNotifications(): Promise<void> {
+    await invoke("plugin:oc|clear_all_notifications");
+}

--- a/frontend/tauri-plugin-oc/guest-js/commands/deleteFcmToken.ts
+++ b/frontend/tauri-plugin-oc/guest-js/commands/deleteFcmToken.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Deletes the device's FCM token and clears the native cache. Call on
+ * sign-out: pushes aimed at the deleted token dead-end at FCM even if the
+ * server-side removal failed. Firebase mints a fresh token on the next
+ * getFcmToken() call, so the next login re-registers cleanly.
+ */
+export async function deleteFcmToken(): Promise<void> {
+    await invoke("plugin:oc|delete_fcm_token");
+}

--- a/frontend/tauri-plugin-oc/guest-js/index.ts
+++ b/frontend/tauri-plugin-oc/guest-js/index.ts
@@ -1,3 +1,5 @@
+export { clearAllNotifications } from "./commands/clearAllNotifications";
+export { deleteFcmToken } from "./commands/deleteFcmToken";
 export { getFcmToken } from "./commands/getFcmToken";
 export { minimizeApp } from "./commands/minimizeApp";
 export { openUrl } from "./commands/openUrl";

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/clear_all_notifications.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/clear_all_notifications.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-clear-all-notifications"
+description = "Enables the clear_all_notifications command without any pre-configured scope."
+commands.allow = ["clear_all_notifications"]
+
+[[permission]]
+identifier = "deny-clear-all-notifications"
+description = "Denies the clear_all_notifications command without any pre-configured scope."
+commands.deny = ["clear_all_notifications"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/delete_fcm_token.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/delete_fcm_token.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-delete-fcm-token"
+description = "Enables the delete_fcm_token command without any pre-configured scope."
+commands.allow = ["delete_fcm_token"]
+
+[[permission]]
+identifier = "deny-delete-fcm-token"
+description = "Denies the delete_fcm_token command without any pre-configured scope."
+commands.deny = ["delete_fcm_token"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/get_pending_notification_tap.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/get_pending_notification_tap.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-pending-notification-tap"
+description = "Enables the get_pending_notification_tap command without any pre-configured scope."
+commands.allow = ["get_pending_notification_tap"]
+
+[[permission]]
+identifier = "deny-get-pending-notification-tap"
+description = "Denies the get_pending_notification_tap command without any pre-configured scope."
+commands.deny = ["get_pending_notification_tap"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
@@ -23,6 +23,7 @@ Default permissions for the plugin
 - `allow-save-media`
 - `allow-update-chat-shortcuts`
 - `allow-get-pending-deep-link`
+- `allow-get-pending-notification-tap`
 
 ## Permission Table
 
@@ -159,6 +160,32 @@ Enables the get_pending_deep_link command without any pre-configured scope.
 <td>
 
 Denies the get_pending_deep_link command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:allow-get-pending-notification-tap`
+
+</td>
+<td>
+
+Enables the get_pending_notification_tap command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-get-pending-notification-tap`
+
+</td>
+<td>
+
+Denies the get_pending_notification_tap command without any pre-configured scope.
 
 </td>
 </tr>

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
@@ -24,6 +24,8 @@ Default permissions for the plugin
 - `allow-update-chat-shortcuts`
 - `allow-get-pending-deep-link`
 - `allow-get-pending-notification-tap`
+- `allow-clear-all-notifications`
+- `allow-delete-fcm-token`
 
 ## Permission Table
 
@@ -33,6 +35,58 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`oc:allow-clear-all-notifications`
+
+</td>
+<td>
+
+Enables the clear_all_notifications command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-clear-all-notifications`
+
+</td>
+<td>
+
+Denies the clear_all_notifications command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:allow-delete-fcm-token`
+
+</td>
+<td>
+
+Enables the delete_fcm_token command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-delete-fcm-token`
+
+</td>
+<td>
+
+Denies the delete_fcm_token command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/frontend/tauri-plugin-oc/permissions/default.toml
+++ b/frontend/tauri-plugin-oc/permissions/default.toml
@@ -20,4 +20,5 @@ permissions = [
     "allow-save-media",
     "allow-update-chat-shortcuts",
     "allow-get-pending-deep-link",
+    "allow-get-pending-notification-tap",
 ]

--- a/frontend/tauri-plugin-oc/permissions/default.toml
+++ b/frontend/tauri-plugin-oc/permissions/default.toml
@@ -21,4 +21,6 @@ permissions = [
     "allow-update-chat-shortcuts",
     "allow-get-pending-deep-link",
     "allow-get-pending-notification-tap",
+    "allow-clear-all-notifications",
+    "allow-delete-fcm-token",
 ]

--- a/frontend/tauri-plugin-oc/permissions/schemas/schema.json
+++ b/frontend/tauri-plugin-oc/permissions/schemas/schema.json
@@ -355,6 +355,18 @@
           "markdownDescription": "Denies the get_pending_deep_link command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_pending_notification_tap command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-pending-notification-tap",
+          "markdownDescription": "Enables the get_pending_notification_tap command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_pending_notification_tap command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-pending-notification-tap",
+          "markdownDescription": "Denies the get_pending_notification_tap command without any pre-configured scope."
+        },
+        {
           "description": "Enables the get_server_version command without any pre-configured scope.",
           "type": "string",
           "const": "allow-get-server-version",
@@ -523,10 +535,10 @@
           "markdownDescription": "Denies the update_chat_shortcuts command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`"
         }
       ]
     }

--- a/frontend/tauri-plugin-oc/permissions/schemas/schema.json
+++ b/frontend/tauri-plugin-oc/permissions/schemas/schema.json
@@ -295,6 +295,30 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the clear_all_notifications command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-clear-all-notifications",
+          "markdownDescription": "Enables the clear_all_notifications command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_all_notifications command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-clear-all-notifications",
+          "markdownDescription": "Denies the clear_all_notifications command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the delete_fcm_token command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-delete-fcm-token",
+          "markdownDescription": "Enables the delete_fcm_token command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the delete_fcm_token command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-delete-fcm-token",
+          "markdownDescription": "Denies the delete_fcm_token command without any pre-configured scope."
+        },
+        {
           "description": "Enables the disable_viewport_resize command without any pre-configured scope.",
           "type": "string",
           "const": "allow-disable-viewport-resize",
@@ -535,10 +559,10 @@
           "markdownDescription": "Denies the update_chat_shortcuts command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`"
         }
       ]
     }


### PR DESCRIPTION
Fixes three reported problems with Android notifications, plus two latent bugs found along the way:

1. **Notification taps didn't reliably open the destination chat** (cold/background taps sometimes opened just the app).
2. **FCM tokens weren't cleared on logout** — worse, the previous account's pushes kept flowing to the device and the next account got none.
3. **Navigation corrupted after a tap** — switching from Communities to Chats landed on the previously tapped chat instead of `/chats`.

## Navigation (problems 1 & 3)

- **Taps navigate with the `notification` intent** (`replace`), matching deep links. Previously the default `in-app` intent **pushed** the tapped chat onto the history stack, and since "go to Chats" from a community is a pop (`history.back()`), that injected entry is exactly what the back landed on.
- **`doNavigate`'s pop branch now verifies its target**: it mirrors the session's route entries and only uses `history.back()` when the entry beneath actually matches the destination (same route kind for tab roots, same path otherwise); anything else falls back to `page.replace()`. Tab switches always land where the user asked — worst case is a duplicate history entry. This also fixes a latent bug where navigating from an open thread to a *different* chat rewound to the old chat and dropped the navigation entirely.
- **Cold-start taps get the deep-link treatment**: the tap payload is persisted natively (`pendingNotificationTap`) and pulled via a new `get_pending_notification_tap` command once the JS listener is registered, then consumed by `Router.svelte` ahead of `selectDefaultChat`. Previously the tap was fire-and-forget through the native event queue, which flushes the moment `svelteReady` fires — racing the un-awaited `addPluginListener` registrations; a lost race silently dropped the tap. `App.svelte` now also signals `svelteReady` only after **all** native listeners are registered, closing that race for every queued event type (shares, deep links, insets, …).
- `build.rs` COMMANDS gains the new command plus the previously missing `get_pending_deep_link`, so their permissions survive regeneration.

## Push tokens (problem 2)

- **Last-login-wins registration (⚠️ backend)**: an FCM token identifies a device install, not an account, but `FcmTokenStore` enforced global uniqueness and `add_fcm_token` rejected a token owned by anyone else. After an unclean logout, the next account's registration was skipped by the `fcm_token_exists` pre-check — so the old account's notifications kept arriving while the new account received none. `FcmTokenStore::add` now re-assigns the token and reports the previous owner; the notifications_index emits `FcmTokenRemoved` (old owner) before `FcmTokenAdded` so local index replicas stay consistent. The apps register unconditionally on startup instead of pre-checking `fcm_token_exists` (which can't distinguish "mine" from "someone else's").
- **Sign-out hygiene**: new user-callable `remove_fcm_token` update on the notifications_index (the existing removal path was reserved for the push service's dead-token GC). `OpenChat.logout()` gained a pre-logout task hook (best-effort, 5s cap, runs while the identity is still valid); the app registers a task that removes the token server-side, deletes the device token via the new `delete_fcm_token` plugin command (pushes to it then dead-end at FCM; Firebase mints a fresh token on next login), and empties the tray + native store via the new `clear_all_notifications` plugin command.
- **Token refreshes now actually reach JS**: Kotlin fires `fcm-token-refresh` with a `{ fcmToken }` payload, but the JS listener subscribed to `fcm-token` and passed the raw payload object to the handler — rotated tokens were never re-registered (and would have sent an object to the backend if they had been). Event name aligned, payload unwrapped.

## Bonus fix

- **Conversation-shortcut taps no longer hit the tao null-`getType()` crash**: shortcut intents must carry an action, so they use `ACTION_VIEW` with no data URI — a shape MainActivity's deep-link neutralization didn't cover. Any dataless VIEW intent is now neutralized before tao sees it; the `notificationPayload` extra still routes the tap.

## Testing

- Unit/build: tsc + svelte-check clean, `navigation.spec.ts` 33/33, `FcmTokenStore` tests updated & passing, affected canister crates compile, Kotlin (plugin + app) compiles, typebox bindings regenerated.
- **Needs emulator/device verification**:
  - [ ] Tap routing: cold / background / foreground each open the right chat
  - [ ] Repro from the report: Chats → Communities → tap DM notification → Communities → Chats lands on `/chats` (not the DM)
  - [ ] Conversation shortcut (Direct Share tile) tap opens the chat without crashing
  - [ ] Sign out: tray empties, pushes stop; sign back in: pushes resume (fresh token)
  - [ ] Account switch on one device: old account's pushes stop, new account's arrive (requires backend deploy)
- **Deploy note**: the last-login-wins + `remove_fcm_token` changes need a notifications_index (+ local_user_index) release; until then the client-side cleanup still works, but token re-assignment and server-side removal won't take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqUcYRgRc7yn6NkosngirP
