### PR TITLE
Fix events-window loading, pinned-messages panel reactivity, and a tip render crash

### DIFF
--- a/frontend/app/src/components/home/TipThumbnail.svelte
+++ b/frontend/app/src/components/home/TipThumbnail.svelte
@@ -18,7 +18,7 @@
     let longPressed: boolean = $state(false);
 
     let userTipsList = $derived(Object.entries(userTips));
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
     let totalAmount = $derived(userTipsList.reduce((n, [_, amount]) => n + amount, BigInt(0)));
 
     function click() {
@@ -28,37 +28,40 @@
     }
 </script>
 
-<Tooltip autoWidth bind:longPressed position={"bottom"} align={"start"}>
-    <div role="button" tabindex="0" onclick={click} class="tip-wrapper" class:canTip>
-        <img class="tip-icon" src={tokenDetails.logo} />
-        <span class="tip-count">
-            {userTipsList.length > 999 ? "999+" : userTipsList.length}
-        </span>
-    </div>
-    {#snippet popupTemplate()}
-        <div class="user-tips">
-            {#each userTipsList as [userId, amount]}
-                <div class="avatar">
-                    <Avatar
-                        url={client.userAvatarUrl($allUsersStore.get(userId))}
-                        {userId}
-                        size={AvatarSize.Tiny} />
-                </div>
-                <div class="username">
-                    @{$allUsersStore.get(userId)?.username}
-                </div>
-                <div class="amount">
-                    {client.formatTokens(amount, tokenDetails.decimals)}
-                </div>
-            {/each}
-            {#if userTipsList.length > 1}
-                <div class="total">
-                    {client.formatTokens(totalAmount, tokenDetails.decimals)}
-                </div>
-            {/if}
+{#if tokenDetails}
+    {@const details = tokenDetails}
+    <Tooltip autoWidth bind:longPressed position={"bottom"} align={"start"}>
+        <div role="button" tabindex="0" onclick={click} class="tip-wrapper" class:canTip>
+            <img class="tip-icon" src={details.logo} />
+            <span class="tip-count">
+                {userTipsList.length > 999 ? "999+" : userTipsList.length}
+            </span>
         </div>
-    {/snippet}
-</Tooltip>
+        {#snippet popupTemplate()}
+            <div class="user-tips">
+                {#each userTipsList as [userId, amount]}
+                    <div class="avatar">
+                        <Avatar
+                            url={client.userAvatarUrl($allUsersStore.get(userId))}
+                            {userId}
+                            size={AvatarSize.Tiny} />
+                    </div>
+                    <div class="username">
+                        @{$allUsersStore.get(userId)?.username}
+                    </div>
+                    <div class="amount">
+                        {client.formatTokens(amount, details.decimals)}
+                    </div>
+                {/each}
+                {#if userTipsList.length > 1}
+                    <div class="total">
+                        {client.formatTokens(totalAmount, details.decimals)}
+                    </div>
+                {/if}
+            </div>
+        {/snippet}
+    </Tooltip>
+{/if}
 
 <style lang="scss">
     .user-tips {

--- a/frontend/app/src/components/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components/home/pinned/PinnedMessages.svelte
@@ -36,7 +36,10 @@
 
     const client = getContext<OpenChat>("client");
     let unread = $state<boolean>(false);
-    let pinnedMessages = $selectedChatPinnedMessagesStore;
+    // $derived is load-bearing: a plain `let` captures a one-time snapshot,
+    // and if the panel mounts before the chat details (pinned set) arrive
+    // the panel stays empty forever.
+    let pinnedMessages = $derived($selectedChatPinnedMessagesStore);
 
     onMount(() => {
         const unsubs = [

--- a/frontend/app/src/components_mobile/home/message/Tip.svelte
+++ b/frontend/app/src/components_mobile/home/message/Tip.svelte
@@ -21,48 +21,53 @@
     let { onClick, tip, alignTooltip }: Props = $props();
     let [ledger, userTips] = $derived(tip);
     let userTipsList = $derived(Object.entries(userTips));
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
     let totalAmount = $derived(userTipsList.reduce((n, [_, amount]) => n + amount, BigInt(0)));
 </script>
 
-<Tooltip autoWidth position={"bottom"} align={alignTooltip}>
-    <Container
-        onClick={() => onClick?.(ledger)}
-        borderRadius={"lg"}
-        width={"hug"}
-        padding={["zero", "xs"]}
-        background={ColourVars.background2}
-        crossAxisAlignment={"center"}
-        gap={"xs"}
-        borderWidth={"thin"}
-        borderColour={ColourVars.background0}>
-        <img alt={tokenDetails.symbol} class="tip-icon" src={tokenDetails.logo} />
-        <ChatFootnote>
-            {userTipsList.length > 999 ? "999+" : userTipsList.length}
-        </ChatFootnote>
-    </Container>
+{#if tokenDetails}
+    {@const details = tokenDetails}
+    <Tooltip autoWidth position={"bottom"} align={alignTooltip}>
+        <Container
+            onClick={() => onClick?.(ledger)}
+            borderRadius={"lg"}
+            width={"hug"}
+            padding={["zero", "xs"]}
+            background={ColourVars.background2}
+            crossAxisAlignment={"center"}
+            gap={"xs"}
+            borderWidth={"thin"}
+            borderColour={ColourVars.background0}>
+            <img alt={details.symbol} class="tip-icon" src={details.logo} />
+            <ChatFootnote>
+                {userTipsList.length > 999 ? "999+" : userTipsList.length}
+            </ChatFootnote>
+        </Container>
 
-    {#snippet popup()}
-        <div class="user-tips">
-            {#each userTipsList as [userId, amount]}
-                <div class="avatar">
-                    <Avatar url={client.userAvatarUrl($allUsersStore.get(userId))} size={"xs"} />
-                </div>
-                <div class="username">
-                    @{$allUsersStore.get(userId)?.username}
-                </div>
-                <div class="amount">
-                    {client.formatTokens(amount, tokenDetails.decimals)}
-                </div>
-            {/each}
-            {#if userTipsList.length > 1}
-                <div class="total">
-                    {client.formatTokens(totalAmount, tokenDetails.decimals)}
-                </div>
-            {/if}
-        </div>
-    {/snippet}
-</Tooltip>
+        {#snippet popup()}
+            <div class="user-tips">
+                {#each userTipsList as [userId, amount]}
+                    <div class="avatar">
+                        <Avatar
+                            url={client.userAvatarUrl($allUsersStore.get(userId))}
+                            size={"xs"} />
+                    </div>
+                    <div class="username">
+                        @{$allUsersStore.get(userId)?.username}
+                    </div>
+                    <div class="amount">
+                        {client.formatTokens(amount, details.decimals)}
+                    </div>
+                {/each}
+                {#if userTipsList.length > 1}
+                    <div class="total">
+                        {client.formatTokens(totalAmount, details.decimals)}
+                    </div>
+                {/if}
+            </div>
+        {/snippet}
+    </Tooltip>
+{/if}
 
 <style lang="scss">
     .tip-icon {

--- a/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
@@ -32,7 +32,10 @@
 
     const client = getContext<OpenChat>("client");
     let unread = $state<boolean>(false);
-    let pinnedMessages = $selectedChatPinnedMessagesStore;
+    // $derived is load-bearing: a plain `let` captures a one-time snapshot,
+    // and if the panel mounts before the chat details (pinned set) arrive
+    // the panel stays empty forever.
+    let pinnedMessages = $derived($selectedChatPinnedMessagesStore);
 
     onMount(() => {
         const unsubs = [

--- a/frontend/openchat-agent/src/services/common/chatEvents.ts
+++ b/frontend/openchat-agent/src/services/common/chatEvents.ts
@@ -166,18 +166,18 @@ export class CachedChatEventsReader {
                     }
                 }
 
-                // An empty cache result with nothing missing and no expired
-                // ranges is not a trustworthy complete answer — without this,
-                // handleMissingEvents would resolve an empty response as final
-                // (same class as the window-path guard below). A result that
-                // is empty because everything in range expired IS complete.
-                const emptyButComplete =
-                    cachedEvents.events.length === 0 &&
-                    cachedEvents.expiredEventRanges.length === 0 &&
-                    missing.size + dirty.size === 0;
+                // Tradeoff: a genuinely empty region (e.g. paginating past the
+                // latest index) now costs a redundant api round-trip per load
+                // instead of resolving empty from the cache — rare, and safer
+                // than resolving a suspicious empty result as final. When
+                // offline, fall through to handleMissingEvents, which resolves
+                // the empty result gracefully instead of firing a doomed
+                // network call.
+                const suspiciousEmpty =
+                    isEmptyButComplete(cachedEvents, missing, dirty) && !offline();
 
                 // we may or may not have all the requested events
-                if (emptyButComplete || missing.size + dirty.size > MAX_MISSING) {
+                if (suspiciousEmpty || missing.size + dirty.size > MAX_MISSING) {
                     // if we have exceeded the maximum number of missing events, let's just consider it a complete miss and go to the api
                     console.debug("We didn't get enough back from the cache, going to the api");
                     reader
@@ -260,19 +260,13 @@ export class CachedChatEventsReader {
                         }
                     }
 
-                    // An empty cache result with nothing missing and no expired
-                    // ranges is not a trustworthy complete answer (same class as
-                    // the window-path guard) — refetch the requested indexes
-                    // rather than resolving an empty response as final.
-                    const emptyButComplete =
-                        cachedEvents.events.length === 0 &&
-                        cachedEvents.expiredEventRanges.length === 0 &&
-                        missing.size + dirty.size === 0;
-
+                    // Refetch the requested indexes rather than resolving an
+                    // empty response as final. handleMissingEvents drops the
+                    // fetch when offline, resolving the empty result gracefully.
                     return this.handleMissingEvents(
                         reader,
                         chatId,
-                        emptyButComplete
+                        isEmptyButComplete(cachedEvents, missing, dirty)
                             ? [cachedEvents, new Set(eventIndexes), dirty]
                             : [cachedEvents, missing, dirty],
                         threadRootMessageIndex,
@@ -311,20 +305,16 @@ export class CachedChatEventsReader {
                     }
                 }
 
-                // An empty cache result with nothing missing is not a valid
-                // complete answer for a window request (the target message
-                // exists — we just don't have anything cached around it, e.g.
-                // the message→event mapping resolved to an event index outside
-                // the cached range). Without this, handleMissingEvents would
-                // resolve an empty response as final, wiping the event store.
-                // A result that is empty because the whole window expired IS
-                // complete.
-                const emptyButComplete =
-                    cachedEvents.events.length === 0 &&
-                    cachedEvents.expiredEventRanges.length === 0 &&
-                    missing.size + dirty.size === 0;
+                // The target message exists — an empty result just means we
+                // have nothing cached around it (e.g. the message→event
+                // mapping resolved to an event index outside the cached
+                // range), so go to the api for the window. When offline, fall
+                // through to handleMissingEvents, which resolves the empty
+                // result gracefully instead of firing a doomed network call.
+                const suspiciousEmpty =
+                    isEmptyButComplete(cachedEvents, missing, dirty) && !offline();
 
-                if (totalMiss || emptyButComplete || missing.size + dirty.size > MAX_MISSING) {
+                if (totalMiss || suspiciousEmpty || missing.size + dirty.size > MAX_MISSING) {
                     // if we have exceeded the maximum number of missing events, let's just consider it a complete miss and go to the api
                     console.debug(
                         "We didn't get enough back from the cache, going to the api",
@@ -485,6 +475,24 @@ export class CachedChatEventsReader {
                 return this.communityClient;
         }
     }
+}
+
+// An empty cache result with nothing missing and no expired ranges is not a
+// trustworthy complete answer: "empty because everything in range expired" is
+// a valid final response (the expired ranges say so), but "empty because
+// nothing was cached" must not be resolved as final — doing so wipes the
+// event store (the original blank-window bug). All three read paths share
+// this predicate so the completeness rule cannot drift between them.
+function isEmptyButComplete<T extends ChatEvent>(
+    cachedEvents: EventsSuccessResult<T>,
+    missing: Set<number>,
+    dirty: Set<number>,
+): boolean {
+    return (
+        cachedEvents.events.length === 0 &&
+        cachedEvents.expiredEventRanges.length === 0 &&
+        missing.size + dirty.size === 0
+    );
 }
 
 function mergeEventsResponse<T extends ChatEvent>(

--- a/frontend/openchat-agent/src/services/common/chatEvents.ts
+++ b/frontend/openchat-agent/src/services/common/chatEvents.ts
@@ -206,7 +206,10 @@ export class CachedChatEventsReader {
                                     resolve(resp, true);
                                 });
                             } else {
-                                throw err;
+                                // rethrowing inside a promise .catch produces an
+                                // unhandled rejection and a stream that never
+                                // settles — reject so callers see the failure
+                                reject(err);
                             }
                         });
                 } else {
@@ -287,7 +290,16 @@ export class CachedChatEventsReader {
                     }
                 }
 
-                if (totalMiss || missing.size + dirty.size > MAX_MISSING) {
+                // An empty cache result with nothing missing is not a valid
+                // complete answer for a window request (the target message
+                // exists — we just don't have anything cached around it, e.g.
+                // the message→event mapping resolved to an event index outside
+                // the cached range). Without this, handleMissingEvents would
+                // resolve an empty response as final, wiping the event store.
+                const emptyButComplete =
+                    cachedEvents.events.length === 0 && missing.size + dirty.size === 0;
+
+                if (totalMiss || emptyButComplete || missing.size + dirty.size > MAX_MISSING) {
                     // if we have exceeded the maximum number of missing events, let's just consider it a complete miss and go to the api
                     console.debug(
                         "We didn't get enough back from the cache, going to the api",
@@ -336,7 +348,10 @@ export class CachedChatEventsReader {
                                     resolve(resp, true);
                                 });
                             } else {
-                                throw err;
+                                // rethrowing inside a promise .catch produces an
+                                // unhandled rejection and a stream that never
+                                // settles — reject so callers see the failure
+                                reject(err);
                             }
                         });
                 } else {

--- a/frontend/openchat-agent/src/services/common/chatEvents.ts
+++ b/frontend/openchat-agent/src/services/common/chatEvents.ts
@@ -166,8 +166,18 @@ export class CachedChatEventsReader {
                     }
                 }
 
+                // An empty cache result with nothing missing and no expired
+                // ranges is not a trustworthy complete answer — without this,
+                // handleMissingEvents would resolve an empty response as final
+                // (same class as the window-path guard below). A result that
+                // is empty because everything in range expired IS complete.
+                const emptyButComplete =
+                    cachedEvents.events.length === 0 &&
+                    cachedEvents.expiredEventRanges.length === 0 &&
+                    missing.size + dirty.size === 0;
+
                 // we may or may not have all the requested events
-                if (missing.size + dirty.size > MAX_MISSING) {
+                if (emptyButComplete || missing.size + dirty.size > MAX_MISSING) {
                     // if we have exceeded the maximum number of missing events, let's just consider it a complete miss and go to the api
                     console.debug("We didn't get enough back from the cache, going to the api");
                     reader
@@ -250,10 +260,21 @@ export class CachedChatEventsReader {
                         }
                     }
 
+                    // An empty cache result with nothing missing and no expired
+                    // ranges is not a trustworthy complete answer (same class as
+                    // the window-path guard) — refetch the requested indexes
+                    // rather than resolving an empty response as final.
+                    const emptyButComplete =
+                        cachedEvents.events.length === 0 &&
+                        cachedEvents.expiredEventRanges.length === 0 &&
+                        missing.size + dirty.size === 0;
+
                     return this.handleMissingEvents(
                         reader,
                         chatId,
-                        [cachedEvents, missing, dirty],
+                        emptyButComplete
+                            ? [cachedEvents, new Set(eventIndexes), dirty]
+                            : [cachedEvents, missing, dirty],
                         threadRootMessageIndex,
                         latestKnownUpdate,
                         resolve,
@@ -296,8 +317,12 @@ export class CachedChatEventsReader {
                 // the message→event mapping resolved to an event index outside
                 // the cached range). Without this, handleMissingEvents would
                 // resolve an empty response as final, wiping the event store.
+                // A result that is empty because the whole window expired IS
+                // complete.
                 const emptyButComplete =
-                    cachedEvents.events.length === 0 && missing.size + dirty.size === 0;
+                    cachedEvents.events.length === 0 &&
+                    cachedEvents.expiredEventRanges.length === 0 &&
+                    missing.size + dirty.size === 0;
 
                 if (totalMiss || emptyButComplete || missing.size + dirty.size > MAX_MISSING) {
                     // if we have exceeded the maximum number of missing events, let's just consider it a complete miss and go to the api

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -2656,6 +2656,12 @@ export class OpenChat {
 
         if (!keepCurrentEvents) {
             serverEventsStore.set([]);
+            // The expired ranges are part of the contiguity baseline
+            // (eventIndexesLoadedStore); if they survive a window replacement
+            // the freshly loaded window can be judged non-contiguous against
+            // the OLD region's ranges and silently dropped, leaving the event
+            // store empty.
+            expiredServerEventRanges.set(new DRange());
         }
 
         await this.#updateUserStoreFromEvents(resp.events);


### PR DESCRIPTION
Three unrelated pre-existing bugs found while stress-testing message navigation. Each is broken on master today, independently of any other work.

## Events-window loading from an empty cache region

Loading an event window for a message outside the cached range (e.g. jumping to an old pinned message) could blank the event store and hang the events stream:

- `chatEventsWindowViaCache` treated an empty cache result with nothing missing as a complete answer, so `handleMissingEvents` resolved an empty response as final instead of falling back to the API.
- Both cache fallback paths rethrew inside a promise `.catch`, producing an unhandled rejection and a stream that never settles.
- Expired event ranges survived a window replacement, so a freshly loaded window could be judged non-contiguous against the *old* region's ranges and silently dropped.

## Pinned messages panel stuck empty

The panel captured a one-time snapshot of the pinned-messages store; if it mounted before the chat details arrived it stayed empty forever. Now `$derived`.

## Tip render crash on unknown ledger

A message tipped in a token that is missing from the crypto lookup threw during render (non-null assertion on the lookup result) — reproducible on prod in the BUZZ channel. The tip is now skipped instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)