### PR TITLE
Only pop to a route that is actually behind us in the history stack

### DIFF
--- a/frontend/app/src/utils/navigation.ts
+++ b/frontend/app/src/utils/navigation.ts
@@ -290,6 +290,25 @@ function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
             // (same route kind). Otherwise the stack has diverged from the tab
             // discipline and going back would land somewhere unexpected —
             // replace instead. backStack is popped by the popstate handler.
+            //
+            // Two accepted tradeoffs:
+            //
+            // 1. The replace fallback strands the intermediate entry: after
+            //    /chats → /community → tap Chats, history is
+            //    [/chats, /community, /chats], so the browser Back button
+            //    revisits the community before leaving. Collapsing it would
+            //    need an async back()-then-replace dance across a popstate
+            //    (racy with page.js); a forward tap landing in the wrong
+            //    place was the worse bug, a redundant Back stop is benign.
+            //
+            // 2. The kind match is deliberately coarse. It can approve a pop
+            //    to a *different* instance of the same route kind, e.g. open a
+            //    thread in chat B, switch to a thread in chat C (replace),
+            //    close the thread: the entry behind is chat B, same kind as
+            //    the chat C destination, so back() lands on chat B. That
+            //    behaviour predates this fix, and matching full paths instead
+            //    would break the common close-thread pop (the path legitimately
+            //    differs by its thread segment).
             const behind = backStack[backStack.length - 1];
             if (behind !== undefined && pathToRouteKind(behind) === pathToRouteKind(to)) {
                 history.back();

--- a/frontend/app/src/utils/navigation.ts
+++ b/frontend/app/src/utils/navigation.ts
@@ -2,7 +2,7 @@ import { publish, routeStore, routerReadyStore, subscribe } from "openchat-clien
 import type { RouteParams } from "openchat-shared";
 import page from "page";
 import { get } from "svelte/store";
-import { onPopstate, syncCurrentHistoryState } from "./history";
+import { getHistoryStateAction, onPopstate, syncCurrentHistoryState } from "./history";
 
 export type NavigationIntent = "in-app" | "notification" | "auto";
 export type NavigationMode = "push" | "pop" | "replace";
@@ -253,20 +253,41 @@ export function navigationMode(
 const backStack: string[] = [];
 let pendingNavigation: PendingNavigation | null = null;
 
-// Set just before a deliberate multi-entry history.go(-depth) unwind so the
-// single popstate it fires trims the matching number of backStack entries.
-let pendingPopDepth = 0;
+// Set just before a deliberate multi-entry history.go() unwind so the single
+// popstate it fires trims the route entries from backStack and verifies the
+// landing. `trim` counts route entries; the actual go() distance may be one
+// more when a dummy history state sat on top of the current entry.
+let pendingPop: { trim: number; to: string; at: number } | null = null;
 
 function handlePopstate(event: PopStateEvent) {
     const { previousAction } = onPopstate(event);
 
-    if (previousAction !== undefined) {
-        return;
+    // A deliberate unwind must be handled before the previousAction
+    // early-return: when a dummy state (emoji picker, zoom, input tray) was
+    // live at unwind time we necessarily left FROM it, so previousAction is
+    // defined even though this popstate is our own route navigation.
+    if (pendingPop !== null) {
+        const { trim, to, at } = pendingPop;
+        pendingPop = null;
+        if (Date.now() - at < 3000) {
+            backStack.length = Math.max(0, backStack.length - trim);
+            // Self-heal: the browser stack can hold untracked entries the
+            // route-only count cannot see (e.g. nested dummy states — only
+            // the top one is visible synchronously), and a pre-thread entry
+            // may have been recorded without the destination's message index.
+            // If the unwind landed anywhere other than the intended target,
+            // rewrite the landed entry with it.
+            if (location.pathname !== to.split(/[?#]/)[0]) {
+                page.replace(to);
+                syncCurrentHistoryState(history.state);
+            }
+            return;
+        }
+        // The marker outlived any plausible unwind (its popstate never
+        // arrived) — ignore it and treat this as an ordinary popstate.
     }
 
-    if (pendingPopDepth > 0) {
-        backStack.length = Math.max(0, backStack.length - pendingPopDepth);
-        pendingPopDepth = 0;
+    if (previousAction !== undefined) {
         return;
     }
 
@@ -342,16 +363,23 @@ function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
             // tap still lands correctly and the stack stays safe, at the
             // cost of leaving the old trail beneath the new entry.
             const toKind = pathToRouteKind(to);
-            let depth = 0;
+            let trim = 0;
             for (let i = backStack.length - 1; i >= 0; i--) {
                 if (popTargetMatches(backStack[i], to, toKind)) {
-                    depth = backStack.length - i;
+                    trim = backStack.length - i;
                     break;
                 }
             }
-            if (depth > 0) {
-                pendingPopDepth = depth;
-                history.go(-depth);
+            if (trim > 0) {
+                // Dummy history states (zoom, emoji picker, input tray) are
+                // pushed on top of the current entry and never recorded in
+                // backStack; if one is live it adds a real entry the unwind
+                // must also traverse. Only the top state is visible
+                // synchronously — any deeper miscount is corrected by the
+                // landing check in handlePopstate.
+                const dummies = getHistoryStateAction(history.state) !== undefined ? 1 : 0;
+                pendingPop = { trim, to, at: Date.now() };
+                history.go(-(trim + dummies));
             } else {
                 page.replace(to);
                 syncCurrentHistoryState(history.state);

--- a/frontend/app/src/utils/navigation.ts
+++ b/frontend/app/src/utils/navigation.ts
@@ -253,6 +253,10 @@ export function navigationMode(
 const backStack: string[] = [];
 let pendingNavigation: PendingNavigation | null = null;
 
+// Set just before a deliberate multi-entry history.go(-depth) unwind so the
+// single popstate it fires trims the matching number of backStack entries.
+let pendingPopDepth = 0;
+
 function handlePopstate(event: PopStateEvent) {
     const { previousAction } = onPopstate(event);
 
@@ -260,7 +264,45 @@ function handlePopstate(event: PopStateEvent) {
         return;
     }
 
-    backStack.pop();
+    if (pendingPopDepth > 0) {
+        backStack.length = Math.max(0, backStack.length - pendingPopDepth);
+        pendingPopDepth = 0;
+        return;
+    }
+
+    // popstate also fires for FORWARD navigation; only unwind the stack when
+    // we actually landed on the entry it predicts (a genuine back). After an
+    // external back+forward the stack can lose an entry — the pop guard then
+    // simply degrades to a safe replace.
+    if (backStack[backStack.length - 1] === location.pathname) {
+        backStack.pop();
+    }
+}
+
+/**
+ * For chat-like kinds, "same destination" means the same chat — a message
+ * index / thread suffix is fine, a different chat of the same kind is not
+ * (e.g. closing chat B's thread must not pop back to chat A). Returns the
+ * path prefix that identifies the chat, or undefined for non-chat kinds
+ * (where matching on kind alone is sufficient).
+ */
+function chatBasePath(path: string, kind: RouteParams["kind"]): string | undefined {
+    const segs = path.split(/[?#]/)[0].split("/").filter(Boolean);
+    if (kind === "selected_channel_route") {
+        const i = segs.indexOf("channel");
+        return i >= 0 ? segs.slice(0, i + 2).join("/") : undefined;
+    }
+    if (kind === "global_chat_selected_route") {
+        const i = segs.findIndex((s) => s === "user" || s === "group");
+        return i >= 0 ? segs.slice(0, i + 2).join("/") : undefined;
+    }
+    return undefined;
+}
+
+function popTargetMatches(behind: string, to: string, toKind: RouteParams["kind"]): boolean {
+    if (pathToRouteKind(behind) !== toKind) return false;
+    const toBase = chatBasePath(to, toKind);
+    return toBase === undefined || chatBasePath(behind, toKind) === toBase;
 }
 
 function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
@@ -286,32 +328,30 @@ function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
             syncCurrentHistoryState(history.state);
             break;
         case "pop": {
-            // Only actually go back if the entry behind us is the destination
-            // (same route kind). Otherwise the stack has diverged from the tab
-            // discipline and going back would land somewhere unexpected —
-            // replace instead. backStack is popped by the popstate handler.
+            // Unwind to the nearest history entry that actually IS the
+            // destination (same route kind, and for chat routes the same
+            // chat), however deep it sits — a single history.go(-depth)
+            // fires one popstate and discards the abandoned trail, so the
+            // hardware Back button doesn't walk back through entries the
+            // user has already left (e.g. chats → chatA → chatB →
+            // community: tapping Chats lands on the original /chats entry
+            // with nothing stranded above it).
             //
-            // Two accepted tradeoffs:
-            //
-            // 1. The replace fallback strands the intermediate entry: after
-            //    /chats → /community → tap Chats, history is
-            //    [/chats, /community, /chats], so the browser Back button
-            //    revisits the community before leaving. Collapsing it would
-            //    need an async back()-then-replace dance across a popstate
-            //    (racy with page.js); a forward tap landing in the wrong
-            //    place was the worse bug, a redundant Back stop is benign.
-            //
-            // 2. The kind match is deliberately coarse. It can approve a pop
-            //    to a *different* instance of the same route kind, e.g. open a
-            //    thread in chat B, switch to a thread in chat C (replace),
-            //    close the thread: the entry behind is chat B, same kind as
-            //    the chat C destination, so back() lands on chat B. That
-            //    behaviour predates this fix, and matching full paths instead
-            //    would break the common close-thread pop (the path legitimately
-            //    differs by its thread segment).
-            const behind = backStack[backStack.length - 1];
-            if (behind !== undefined && pathToRouteKind(behind) === pathToRouteKind(to)) {
-                history.back();
+            // If no matching entry exists (deep link, external
+            // back/forward desynced the stack), fall back to replace: the
+            // tap still lands correctly and the stack stays safe, at the
+            // cost of leaving the old trail beneath the new entry.
+            const toKind = pathToRouteKind(to);
+            let depth = 0;
+            for (let i = backStack.length - 1; i >= 0; i--) {
+                if (popTargetMatches(backStack[i], to, toKind)) {
+                    depth = backStack.length - i;
+                    break;
+                }
+            }
+            if (depth > 0) {
+                pendingPopDepth = depth;
+                history.go(-depth);
             } else {
                 page.replace(to);
                 syncCurrentHistoryState(history.state);

--- a/frontend/app/src/utils/navigation.ts
+++ b/frontend/app/src/utils/navigation.ts
@@ -242,11 +242,15 @@ export function navigationMode(
 }
 
 /**
- * Tracks how many entries this session has pushed onto the history stack.
- * Used to detect whether a pop has a real entry to go back to, or whether
- * we should fall back to a replace (e.g. user arrived via deep link).
+ * The paths this session has pushed beneath the current history entry — i.e.
+ * backStack[backStack.length - 1] is what history.back() would land on.
+ * A "pop" navigation may only use history.back() when that entry really is
+ * the destination; the history stack does not follow the strict tab
+ * discipline the navigation rules assume (e.g. chats → chatA → chatB →
+ * community → channel), so popping blindly can land the user on a previous
+ * community/chat entry instead of the tab they tapped.
  */
-let pushDepth = 0;
+const backStack: string[] = [];
 let pendingNavigation: PendingNavigation | null = null;
 
 function handlePopstate(event: PopStateEvent) {
@@ -256,9 +260,7 @@ function handlePopstate(event: PopStateEvent) {
         return;
     }
 
-    if (pushDepth > 0) {
-        pushDepth--;
-    }
+    backStack.pop();
 }
 
 function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
@@ -275,7 +277,7 @@ function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
     console.debug("ROUTER: navigating", { from: routeStore.value, to, mode, intent });
     switch (mode) {
         case "push":
-            pushDepth++;
+            backStack.push(location.pathname);
             page(to);
             syncCurrentHistoryState(history.state);
             break;
@@ -283,14 +285,20 @@ function doNavigate(to: string, intent: NavigationIntent, retries = 0) {
             page.replace(to);
             syncCurrentHistoryState(history.state);
             break;
-        case "pop":
-            if (pushDepth > 0) {
+        case "pop": {
+            // Only actually go back if the entry behind us is the destination
+            // (same route kind). Otherwise the stack has diverged from the tab
+            // discipline and going back would land somewhere unexpected —
+            // replace instead. backStack is popped by the popstate handler.
+            const behind = backStack[backStack.length - 1];
+            if (behind !== undefined && pathToRouteKind(behind) === pathToRouteKind(to)) {
                 history.back();
             } else {
                 page.replace(to);
                 syncCurrentHistoryState(history.state);
             }
             break;
+        }
     }
 }
 


### PR DESCRIPTION
Tapping the Chats tab from inside a community could leave you inside the community. `doNavigate`'s "pop" mode did a blind `history.back()` whenever `pushDepth > 0`, but the history stack doesn't reliably follow the assumed tab discipline, so back() could land on an arbitrary previous entry.

Navigation now tracks the paths it pushed from (`backStack`) and only pops when the entry actually behind us matches the destination's route kind; otherwise it replaces.

Verified scenarios: channel → Chats, community → Chats, chat → Chats, and back-from-chat all land in the `/chats` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)