### PR TITLE
Virtual list: cross-platform fixes from device testing

### DIFF
--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -253,21 +253,24 @@
         return flat;
     });
 
-    // if the messageIndex has changed but the chatId has not, scroll to the specified message
+    // Scroll to the route's message index when it changes — and also on the
+    // effect's FIRST run: on single-column layouts the pinned/details panels
+    // unmount the chat view, so a pinned-message tap navigates while the old
+    // instance is being destroyed (where it is silently swallowed) and the
+    // remounted instance must pick the navigation up from the route.
     let previousChatId: ChatIdentifier | undefined = undefined;
+    let previousMessageIndex: number | undefined = undefined;
     $effect(() => {
         void $threadOpenStore;
-        if (
-            $chatsInitialisedStore &&
-            $messageIndexStore !== undefined &&
-            chatIdentifiersEqual($selectedChatIdStore, previousChatId)
-        ) {
-            const idx = $messageIndexStore;
+        const idx = $messageIndexStore;
+        const sameChat = chatIdentifiersEqual($selectedChatIdStore, previousChatId);
+        if ($chatsInitialisedStore && idx !== undefined && (!sameChat || idx !== previousMessageIndex)) {
             untrack(() => {
                 scrollToMessageIndex(idx, false);
             });
         }
         previousChatId = $selectedChatIdStore;
+        previousMessageIndex = idx;
     });
 </script>
 

--- a/frontend/app/src/components/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components/home/pinned/PinnedMessages.svelte
@@ -11,6 +11,7 @@
         iconSize,
         messagesRead,
         selectedChatPinnedMessagesStore,
+        selectedServerChatStore,
         subscribe,
     } from "openchat-client";
     import { isSuccessfulEventsResponse } from "openchat-shared";
@@ -108,6 +109,13 @@
     }
 
     $effect(() => {
+        // Until the chat details arrive the pinned set is UNKNOWN, not empty —
+        // rendering the empty state here made the panel show "no pins" for the
+        // first second on a first open (cold cache / slow connection).
+        if ($selectedServerChatStore === undefined) {
+            messages = { kind: "loading" };
+            return;
+        }
         reloadPinned(pinnedMessages);
         unread = client.unreadPinned(chatId, dateLastPinned);
     });

--- a/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
@@ -291,23 +291,28 @@
         return flat;
     });
 
-    // if the messageIndex has changed but the chatId has not, scroll to the specified message
-    // We should *only* do this if the thread is not open
+    // Scroll to the route's message index when it changes — and also on the
+    // effect's FIRST run: panels/modal pages can unmount the chat view, so a
+    // pinned-message tap navigates while the old instance is being destroyed
+    // (where it is silently swallowed) and the remounted instance must pick
+    // the navigation up from the route. Only when the thread is not open.
     let previousChatId: ChatIdentifier | undefined = undefined;
+    let previousMessageIndex: number | undefined = undefined;
     $effect(() => {
-        // void $threadOpenStore;
+        const idx = $messageIndexStore;
+        const sameChat = chatIdentifiersEqual($selectedChatIdStore, previousChatId);
         if (
             !$threadOpenStore &&
             $chatsInitialisedStore &&
-            $messageIndexStore !== undefined &&
-            chatIdentifiersEqual($selectedChatIdStore, previousChatId)
+            idx !== undefined &&
+            (!sameChat || idx !== previousMessageIndex)
         ) {
-            const idx = $messageIndexStore;
             untrack(() => {
                 scrollToMessageIndex(idx, false);
             });
         }
         previousChatId = $selectedChatIdStore;
+        previousMessageIndex = idx;
     });
 </script>
 

--- a/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
@@ -11,6 +11,7 @@
         currentUserStore,
         messagesRead,
         selectedChatPinnedMessagesStore,
+        selectedServerChatStore,
         subscribe,
     } from "openchat-client";
     import { isSuccessfulEventsResponse, publish } from "openchat-shared";
@@ -99,6 +100,13 @@
     }
 
     $effect(() => {
+        // Until the chat details arrive the pinned set is UNKNOWN, not empty —
+        // rendering the empty state here made the panel show "no pins" for the
+        // first second on a first open (cold cache / slow connection).
+        if ($selectedServerChatStore === undefined) {
+            messages = { kind: "loading" };
+            return;
+        }
         reloadPinned(pinnedMessages);
         unread = client.unreadPinned(chat.id, chat.dateLastPinned);
     });

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -424,6 +424,13 @@
     async function loadNew(): Promise<void> {
         const el = messagesDiv;
         const preLoadScrollHeight = el?.scrollHeight;
+        // At the bottom the view must FOLLOW new content, not preserve the
+        // reading position: scrollTop=0 is the column-reverse scroll origin
+        // (the old list stayed pinned there for free), so an anchor restore
+        // would push the view away from the bottom by the height of every
+        // arriving batch — in a busy channel that reads as the list
+        // repeatedly jumping ~a viewport up from the bottom.
+        const preAtBottom = fromBottom < 10;
         // Capture the bottom-most rendered row as a position anchor. After the
         // load we restore its exact on-screen position from the DOM — the only
         // coordinate system that mixes no estimates.
@@ -466,7 +473,9 @@
             // estimates) with the virtual window, unlike the scrollHeight delta.
             let target = -fromBottom;
             let anchored = false;
-            if (anchorKey !== undefined && anchorTop !== undefined) {
+            if (preAtBottom) {
+                target = 0;
+            } else if (anchorKey !== undefined && anchorTop !== undefined) {
                 const again = rowByKey(el, anchorKey);
                 if (again) {
                     target = el.scrollTop + (again.getBoundingClientRect().top - anchorTop);
@@ -481,6 +490,7 @@
                 fb: Math.round(fromBottom),
                 target: Math.round(target),
                 anchored,
+                atBottom: preAtBottom,
             });
             if (delta > 0) {
                 if (mobileOperatingSystem === "iOS") {

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -173,6 +173,8 @@
         void messageContext;
         scrollingToMessage = false;
         navToken++;
+        // a hidden-time navigation belongs to the chat it was issued in
+        pendingHiddenNav = undefined;
     });
     const insideTopThreshold = () => fromTop() < LOADING_THRESHOLD;
 
@@ -195,6 +197,24 @@
             loadingPrevMessages = false;
             requireScrollStop = false;
             pinToBottom = false;
+        }
+    });
+
+    // A navigation that arrived while the list was hidden (covering panel);
+    // executed as soon as the list is visible again, with a real viewport to
+    // position against.
+    let pendingHiddenNav: { context: MessageContext; index: number; preserveFocus: boolean }
+        | undefined;
+
+    $effect(() => {
+        if (visible && pendingHiddenNav !== undefined) {
+            const nav = pendingHiddenNav;
+            untrack(() => {
+                pendingHiddenNav = undefined;
+                destroyed = false;
+                vclDebug.log("scroll-to-msg-revive", { index: nav.index });
+                scrollToMessageIndex(nav.context, nav.index, nav.preserveFocus);
+            });
         }
     });
 
@@ -821,7 +841,15 @@
                 return Promise.resolve();
             }
         } else if (destroyed) {
-            vclDebug.log("scroll-to-msg-exit", { index, why: "destroyed" });
+            // The chat is hidden behind a covering panel (which marks the
+            // list destroyed to emulate the old unmount semantics). A
+            // navigation arriving in this state is usually the very act of
+            // returning to the chat — on single-column layouts the pinned
+            // panel's tap updates the route several ms before the panel
+            // finishes closing — so defer it until the list is visible again
+            // instead of swallowing it.
+            vclDebug.log("scroll-to-msg-deferred", { index });
+            pendingHiddenNav = { context, index, preserveFocus };
         } else if (!destroyed) {
             // check whether we have already loaded the event we are looking for
             // (an isolated island hit does not count — we want the window load)

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -493,10 +493,16 @@
             // estimates) with the virtual window, unlike the scrollHeight delta.
             let target = -fromBottom;
             let anchored = false;
-            // preAtBottom must be re-checked against the CURRENT position: the
-            // user may have scrolled away while the load was in flight, and
-            // forcing them back to the bottom then is a visible yank.
-            if (preAtBottom && -el.scrollTop < 200) {
+            // Follow-to-bottom applies ONLY at the live bottom of the chat:
+            // preAtBottom re-checked against the current position (the user
+            // may have scrolled away mid-load), AND the load must have caught
+            // us up. At the catch-up WALL (scrollTop=0 mid-history because
+            // the newer content is not loaded yet) preAtBottom is also true,
+            // but forcing the bottom there teleports the user ~a batch of
+            // messages forward on every load — position preservation is what
+            // riding the wall needs.
+            const caughtUp = !client.moreNewMessagesAvailable(chat.id, threadRootEvent);
+            if (preAtBottom && caughtUp && -el.scrollTop < 200) {
                 target = 0;
             } else if (anchorKey !== undefined && anchorTop !== undefined) {
                 const again = rowByKey(el, anchorKey);

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -548,10 +548,6 @@
 
     async function loadPrev(initialLoad: boolean): Promise<void> {
         const el = messagesDiv;
-        // Capture scrollTop before the load. The browser may fire an async scroll
-        // adjustment after the topSpacer grows (column-reverse layout quirk), even
-        // with overflow-anchor: none. interruptScroll restores in the rAF, after
-        // the browser adjustment has happened.
         const preLoadScrollTop = el?.scrollTop;
 
         await client.loadPreviousMessages(chat.id, threadRootEvent, initialLoad);
@@ -559,9 +555,19 @@
         vclDebug.log("load-prev", {
             preTop: preLoadScrollTop !== undefined ? Math.round(preLoadScrollTop) : undefined,
             postTop: el ? Math.round(el.scrollTop) : undefined,
+            fb: Math.round(fromBottom),
             initialLoad,
         });
-        await interruptScroll(preLoadScrollTop);
+        // Restore against the browser's async post-growth scroll adjustment
+        // (column-reverse quirk after the topSpacer grows), but to where the
+        // user actually IS — not to the position captured at load start. On
+        // iOS the user keeps scrolling while the load is in flight, and
+        // restoring the stale scrollTop yanked the view forward by exactly
+        // the distance scrolled during the load (the top message ducked off
+        // the top of the screen). fromBottom tracks the last scroll event and
+        // is frozen while the interrupt gates the handler, so it is the
+        // pre-quirk, post-user-scroll position.
+        await interruptScroll(-fromBottom);
     }
 
     async function loadNewMessagesIfRequired(fromScroll = false): Promise<boolean> {

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -39,7 +39,7 @@
         type OpenChat,
     } from "openchat-client";
     import { getContext, onMount, tick, untrack, type Snippet } from "svelte";
-    import { mobileOperatingSystem } from "@utils/devices";
+    import { isSafari, mobileOperatingSystem } from "@utils/devices";
     import type { FlatChatItem } from "./flatChatItems";
     import { vclDebug } from "./vclDebug";
     import { rowByKey } from "./virtualListUtils";
@@ -473,7 +473,10 @@
             // estimates) with the virtual window, unlike the scrollHeight delta.
             let target = -fromBottom;
             let anchored = false;
-            if (preAtBottom) {
+            // preAtBottom must be re-checked against the CURRENT position: the
+            // user may have scrolled away while the load was in flight, and
+            // forcing them back to the bottom then is a visible yank.
+            if (preAtBottom && -el.scrollTop < 200) {
                 target = 0;
             } else if (anchorKey !== undefined && anchorTop !== undefined) {
                 const again = rowByKey(el, anchorKey);
@@ -493,13 +496,21 @@
                 atBottom: preAtBottom,
             });
             if (delta > 0) {
-                if (mobileOperatingSystem === "iOS") {
-                    // the one-frame overflow-y:hidden halts iOS momentum so the
-                    // programmatic write cannot be swallowed by native physics
+                if (mobileOperatingSystem === "iOS" || isSafari) {
+                    // the one-frame overflow-y:hidden halts iOS momentum / macOS
+                    // Safari trackpad inertia, so the programmatic write cannot
+                    // be swallowed by native physics. Safari desktop needs this
+                    // too: unlike Chrome (whose wheel animation a write cancels),
+                    // Safari's inertia keeps running and clobbers the restore a
+                    // frame later — the viewport teleports by the prepend height
+                    // and the suddenly-near-bottom position triggers a cascade of
+                    // further loads (observed as forward scroll "skipping").
                     await interruptScroll(target);
                 } else {
-                    // on desktop the freeze itself is a visible hitch mid-glide;
-                    // a plain write is safe and onScroll resyncs the window
+                    // on Chrome desktop the freeze itself is a visible hitch
+                    // mid-glide; a plain write is safe (it cancels the wheel
+                    // animation) and onScroll resyncs the window
+                    virtualList?.markProgrammaticScroll();
                     el.scrollTop = target;
                 }
             }
@@ -917,6 +928,7 @@
                         from: Math.round(el.scrollTop),
                         to: Math.round(restoreScrollTop),
                     });
+                    virtualList?.markProgrammaticScroll();
                     el.scrollTop = restoreScrollTop;
                 }
                 interrupt = false;

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -754,9 +754,17 @@
         filling: boolean = false,
         hasLookedUpEvent: boolean = false,
     ): Promise<void> {
-        // it is possible for the chat to change while this function is recursing so double check
-        if (token !== navToken) return Promise.resolve();
-        if (!messageContextsEqual(context, messageContext)) return Promise.resolve();
+        // it is possible for the chat to change while this function is recursing so double check.
+        // Every early exit logs: three separate debugging sessions were burned
+        // on navigations that died silently between two log lines.
+        if (token !== navToken) {
+            vclDebug.log("scroll-to-msg-exit", { index, why: "superseded", token, navToken });
+            return Promise.resolve();
+        }
+        if (!messageContextsEqual(context, messageContext)) {
+            vclDebug.log("scroll-to-msg-exit", { index, why: "context-changed" });
+            return Promise.resolve();
+        }
 
         if (index < 0) {
             focusIndex = undefined;
@@ -786,9 +794,15 @@
             // Delegate positioning to the virtual list: it positions on estimated
             // heights immediately and fires debounced corrective re-scrolls as
             // real measurements arrive.
+            if (virtualList === undefined) {
+                vclDebug.log("scroll-to-msg-exit", { index, why: "no-virtual-list" });
+            }
             virtualList?.scrollToIndex(flatIndex, "instant");
             await tick();
-            if (!messageContextsEqual(context, messageContext)) return Promise.resolve();
+            if (!messageContextsEqual(context, messageContext)) {
+                vclDebug.log("scroll-to-msg-exit", { index, why: "context-changed-post-tick" });
+                return Promise.resolve();
+            }
             if (!filling) {
                 // if we are not filling in extra events around the target then check if we need to open a thread
                 checkIfTargetMessageHasAThread(index);
@@ -806,6 +820,8 @@
                 scrollingToMessage = false;
                 return Promise.resolve();
             }
+        } else if (destroyed) {
+            vclDebug.log("scroll-to-msg-exit", { index, why: "destroyed" });
         } else if (!destroyed) {
             // check whether we have already loaded the event we are looking for
             // (an isolated island hit does not count — we want the window load)
@@ -825,7 +841,12 @@
                     // navigation has even positioned itself.
                     interrupt = true;
                     try {
-                        await client.loadEventWindow(context.chatId, index, threadRootEvent);
+                        const loadedIdx = await client.loadEventWindow(
+                            context.chatId,
+                            index,
+                            threadRootEvent,
+                        );
+                        vclDebug.log("scroll-to-msg-window", { index, loadedIdx });
                         await tick();
                     } finally {
                         await interruptScroll();
@@ -839,6 +860,7 @@
                         true,
                     );
                 }
+                vclDebug.log("scroll-to-msg-exit", { index, why: "not-found-after-window-load" });
                 scrollingToMessage = false;
                 // A failed event-window load clears the event store before it
                 // fails, which would otherwise leave the user staring at an

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -202,9 +202,12 @@
 
     // A navigation that arrived while the list was hidden (covering panel);
     // executed as soon as the list is visible again, with a real viewport to
-    // position against.
-    let pendingHiddenNav: { context: MessageContext; index: number; preserveFocus: boolean }
-        | undefined;
+    // position against. $state is load-bearing: the revive effect must fire
+    // when the navigation is stashed, not only when `visible` next changes —
+    // depending on layout the visibility flip can precede the stash.
+    let pendingHiddenNav = $state<
+        { context: MessageContext; index: number; preserveFocus: boolean } | undefined
+    >(undefined);
 
     $effect(() => {
         if (visible && pendingHiddenNav !== undefined) {

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -468,6 +468,11 @@
         if (!interrupt && viewport) {
             untrack(() => {
                 vclDebug.log("interrupt-end", { st: Math.round(viewport!.scrollTop) });
+                // Deferred adjustments were computed against the pre-interrupt
+                // positions; the restore has just resynced everything, so
+                // flushing them now would be a stale jolt on landing.
+                pendingScrollAdjustment = 0;
+                pendingSnapToBottom = false;
                 fromBottom = clampFromBottom(-viewport!.scrollTop);
                 updateWindowFull("interrupt-end");
             });
@@ -535,13 +540,26 @@
     // debt = canonicalSpacerHeight - domSpacerHeight
     let spacerDebt = 0;
     let lastUserScrollTime = 0;
+    // Time of the last scroll event of ANY origin. lastUserScrollTime alone is
+    // not a safe activity signal: each of our own scrollTop writes suppresses
+    // the genuine-scroll detection for 100ms, so during a busy stretch (repay,
+    // then per-entering-item compensations) the user clock goes stale while
+    // the user is still mid-gesture — absorption switches off and every
+    // correction becomes a write, each of which re-poisons the next window (a
+    // self-sustaining write storm, observed on iOS as per-item jolts).
+    let lastScrollEventTime = 0;
     let debtIdleTimer: ReturnType<typeof setTimeout> | undefined;
     const MAX_SPACER_DEBT = 400;
 
     // The window in which a scrollTop write would disturb the user: an active
     // touch, native momentum, or the tail of a wheel glide.
     function scrollingActive(): boolean {
-        return isTouching || isMomentumScrolling || Date.now() - lastUserScrollTime < 200;
+        return (
+            isTouching ||
+            isMomentumScrolling ||
+            Date.now() - lastUserScrollTime < 200 ||
+            Date.now() - lastScrollEventTime < 150
+        );
     }
 
     function canAbsorbIntoSpacer(delta: number): boolean {
@@ -1094,6 +1112,7 @@
     let prevScrollEventTime = 0;
     function onScroll() {
         if (!viewport || interrupt) return;
+        lastScrollEventTime = Date.now();
         if (vclDebug.enabled) {
             const st = viewport.scrollTop;
             const delta = st - prevScrollEventTop;

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -622,7 +622,11 @@
         clearTimeout(debtIdleTimer);
         debtIdleTimer = undefined;
         if (spacerDebt === 0 || !viewport) return;
-        if (!force && (isTouching || isMomentumScrolling || Date.now() - lastUserScrollTime < 250)) {
+        // scrollingActive() covers touch, momentum, AND the any-origin scroll
+        // event stream — the user-scroll clock alone goes stale when our own
+        // writes suppress genuine detection, and repays were observed firing
+        // milliseconds apart in the middle of a live iOS scroll stream.
+        if (!force && (scrollingActive() || Date.now() - lastUserScrollTime < 250)) {
             debtIdleTimer = setTimeout(() => settleSpacerDebt(), 300);
             return;
         }

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -658,13 +658,23 @@
 
             const numNew = items.length - oldLen;
 
-            // Detect prepend: items grew, first key changed, and the old first
-            // item is now at index (newLen - oldLen) — i.e. it was shifted right.
-            const isPrepend =
-                numNew > 0 &&
-                oldLen > 0 &&
-                oldFirstKey !== undefined &&
-                items[numNew]?.key === oldFirstKey;
+            // Detect prepend: items grew and the old first item was shifted
+            // right. Its new index is USUALLY numNew, but a date marker can be
+            // inserted or moved at the join (the new batch starts a new day),
+            // so search a small neighbourhood for the old first key instead of
+            // requiring exact equality — a strict check silently misses the
+            // prepend and the position teleports by the batch height.
+            let prependCount = 0;
+            if (numNew > 0 && oldLen > 0 && oldFirstKey !== undefined) {
+                const scanMax = Math.min(items.length - 1, numNew + 8);
+                for (let i = 1; i <= scanMax; i++) {
+                    if (items[i]?.key === oldFirstKey) {
+                        prependCount = i;
+                        break;
+                    }
+                }
+            }
+            const isPrepend = prependCount > 0;
 
             // Detect pure append: items grew, first key unchanged, AND the
             // previously-last item is still at its old index. This guards against
@@ -700,12 +710,13 @@
                 // in column-reverse). Adjust fromBottom so updateWindowFull
                 // targets the same visual position in the new index space.
                 let offset = 0;
-                for (let i = 0; i < numNew; i++) {
+                for (let i = 0; i < prependCount; i++) {
                     offset += getHeight(i);
                 }
-                // Include gaps: numNew new items add numNew gaps (one per item
-                // plus the gap between last new item and old first item).
-                offset += numNew * gapPx;
+                // Include gaps: prependCount new items add prependCount gaps
+                // (one per item plus the gap between last new item and old
+                // first item).
+                offset += prependCount * gapPx;
                 fromBottom += offset;
                 prependOffset = offset;
             }
@@ -1145,6 +1156,15 @@
         scrollCorrectCount = 0;
         pendingScrollStartedAt = Date.now();
         _doScrollToIndex(flatIndex, behavior);
+    }
+
+    // The owner performs some scrollTop writes of its own (the loadNew
+    // restore, the interrupt restore). They must be marked as programmatic or
+    // their scroll events read as genuine user scrolls: logged as !jump,
+    // releasing the bottom pin, and updating the user-scroll clock that debt
+    // absorption keys off.
+    export function markProgrammaticScroll() {
+        lastProgrammaticScrollTime = Date.now();
     }
 
     export function scrollToBottom(behavior: "auto" | "instant" | "smooth" = "instant") {

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -539,6 +539,14 @@
     // longer matters) or at the next full window recompute.
     // debt = canonicalSpacerHeight - domSpacerHeight
     let spacerDebt = 0;
+    // While a touch/momentum gesture is active the settle cannot run anyway
+    // (a write would kill native physics), so the only hard constraint on the
+    // debt is the overscan margin — beyond it the rendered window and the
+    // scroll position disagree visibly. The tight cap forced mid-gesture
+    // corrections onto the deferred-write path (an uncompensated shift per
+    // entering item — observed on iOS as choppiness once the estimate bias
+    // accumulated ~400px over ~10 items).
+    const MAX_SPACER_DEBT_GESTURE = OVERSCAN_PX;
     let lastUserScrollTime = 0;
     // Time of the last scroll event of ANY origin. lastUserScrollTime alone is
     // not a safe activity signal: each of our own scrollTop writes suppresses
@@ -572,19 +580,23 @@
         if (!scrollingActive() || bottomSpacerHeight - delta < 0) {
             return false;
         }
+        // During touch/momentum a settle write would kill the native physics,
+        // so the gesture cap is the overscan margin; outside a gesture the
+        // tight cap keeps the repayment write small.
+        const cap =
+            isTouching || isMomentumScrolling ? MAX_SPACER_DEBT_GESTURE : MAX_SPACER_DEBT;
         // A single correction bigger than the cap (a very tall item measured
         // against the average estimate) must go straight to the scroll
         // adjustment path — if we absorbed it we would immediately be forced
         // to repay it mid-scroll.
-        if (Math.abs(delta) >= MAX_SPACER_DEBT) {
+        if (Math.abs(delta) >= cap) {
             return false;
         }
         // On a long sustained scroll the debt never gets an idle moment to be
         // repaid; once the cap would be exceeded, force a single repayment
-        // write rather than degrading to a write per entering item. Except
-        // during touch/momentum, where a settle write would kill the native
-        // physics — fall through to the deferred-adjustment path instead.
-        if (Math.abs(spacerDebt + delta) >= MAX_SPACER_DEBT) {
+        // write rather than degrading to a write per entering item — except
+        // mid-gesture, where only the deferred path remains beyond the cap.
+        if (Math.abs(spacerDebt + delta) >= cap) {
             if (isTouching || isMomentumScrolling) {
                 return false;
             }

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -755,6 +755,14 @@
     function flushScrollAdjustment() {
         clearTimeout(momentumEndTimer);
         momentumEndTimer = undefined;
+        // iOS fires scrollend on momentary pauses while the finger is still
+        // down — flushing then writes the deferred adjustment straight into
+        // the live gesture (observed as a jolt mid-drag). Re-defer until the
+        // touch actually ends.
+        if (isTouching) {
+            momentumEndTimer = setTimeout(flushScrollAdjustment, 100);
+            return;
+        }
         isMomentumScrolling = false;
         if (!viewport) return;
         settleSpacerDebt();
@@ -975,16 +983,27 @@
                                     viewport.scrollTo({ top: 0 });
                                     lastProgrammaticScrollTime = Date.now();
                                 }
+                            } else if (
+                                (isTouching || isMomentumScrolling) &&
+                                canAbsorbIntoSpacer(h - prev)
+                            ) {
+                                // Mid-touch/momentum a scrollTop write is not an
+                                // option (it kills native physics) and the
+                                // deferred adjustment is flushed later as a
+                                // visible double-jolt (grow-shift, then the
+                                // correction jerking it back). A one-frame-late
+                                // spacer absorb is the least bad option here.
+                                absorbIntoSpacer(h - prev);
                             } else {
-                                // NOTE: unlike the entry path above, do NOT absorb
+                                // NOTE: outside a touch gesture, do NOT absorb
                                 // this into the spacer. A ResizeObserver-driven
                                 // resize has already been laid out (and possibly
                                 // painted) by the time we hear about it, so a
                                 // spacer adjustment lands a frame late and shows
-                                // as a visible bounce. The immediate scrollTop
-                                // write is the lesser evil here — these resizes
-                                // (images/settling content) are far rarer than
-                                // entries during a scroll.
+                                // as a visible bounce on a wheel glide. The
+                                // immediate scrollTop write is the lesser evil —
+                                // these resizes (images/settling content) are far
+                                // rarer than entries during a scroll.
                                 adjustScrollTop(h - prev);
                             }
                         }


### PR DESCRIPTION
Twelve fixes from a day of device testing against the merged virtual list (#9066), every one backed by a trace from the failing device or a scripted reproduction. Verified state at this branch head: Chrome desktop, Safari desktop, and Android forward/backward scrolling confirmed smooth by hand; pinned-message navigation 6/6 on both wide and single-column layouts including the first-tap case; full desktop regression suite green.

## Navigation

- **Single-column pinned taps did nothing** — the tap navigates while the covering panel is still closing, so the (visibility-emulated) destroyed guard swallowed it. Navigations arriving while hidden are now stashed and executed when the list becomes visible (`$state` on the stash is load-bearing; a plain let left the revive effect un-triggered — the first-tap failure).
- The chat view picks a route message-index up on remount (genuine unmounts, e.g. layout switches).
- Every silent exit from the navigation logs its reason (`scroll-to-msg-exit why=…`) — three separate debugging sessions were lost to unlogged returns before this.

## Load boundaries

- **Safari desktop**: trackpad inertia clobbers a plain scrollTop restore a frame after the write (Chrome cancels its wheel animation instead), teleporting the viewport by the prepend height and cascading further loads. Safari now uses the same one-frame overflow-hidden interrupt as iOS.
- **Android**: the follow-to-bottom restore misfired at the catch-up *wall* (scrollTop=0 mid-history), teleporting ~a batch forward per load. Follow now additionally requires the load to have caught us up.
- **iOS backward**: the restore used the scrollTop captured at load *start*; scrolling during the in-flight load meant every backward boundary yanked the view forward by that distance. Restores now target the live position.
- Busy-channel bottom: an arriving batch pushed the reading position up by its height when sitting at the live bottom (the anchor restore preserving position where following is wanted).
- Prepend detection survives a date marker inserted at the batch join (previously the position adjustment was silently skipped).
- The at-bottom check is re-verified at restore time so a user who scrolled away mid-load isn't yanked back.

## Gesture feel (iOS)

- Our own scrollTop writes suppressed genuine-scroll detection, which switched absorption off mid-gesture and degraded every correction to a write — a self-sustaining storm felt as per-item jolts. Activity detection now also uses the any-origin scroll event stream, and debt repayment holds while that stream is live.
- The spacer-debt cap during gestures is the overscan margin (1200px) instead of 400px — the tight cap forced deferred writes once the estimate bias accumulated (~10 items).
- `scrollend` fires on momentary mid-touch pauses; the deferred-adjustment flush now waits for the touch to actually end, and mid-gesture resize compensations absorb into the spacer instead of double-jolting.
- Stale deferred adjustments are cleared at interrupt end instead of being flushed as a jolt after the restore repositioned everything.
- The owner's own writes (loadNew/interrupt restores) are marked programmatic.

## Pinned panel

- Shows the loading state (not "no pins") until the chat details arrive.
- One final rect refinement when the corrective-scroll rounds run out, so late measurements can't leave a navigation landing off-screen.

## Known residuals (documented, deliberately deferred)

- iOS forward-boundary momentum kill: WebKit clobbers programmatic writes during native physics, so the restore requires the interrupt, which ends the fling. Possible future softening: synthetic momentum continuation.
- Small (≤~200px) clamp jolts near the bottom under active absorption (`!negative-spacer`): bookkeeping drift to be fixed with fresh eyes.
- Frame drops at peak fling velocity in heavy channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)