### PR TITLE
Virtual list: boundary correctness, fixed-height media, estimate accuracy

### DIFF
--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -140,8 +140,6 @@
     }: Props = $props();
 
     let msgElement: HTMLElement | undefined;
-    let msgBubbleWrapperElement: HTMLElement | undefined;
-    let msgBubbleElement: HTMLElement | undefined;
     let messageMenu: ChatMessageMenu | undefined;
 
     let multiUserChat = chatType === "group_chat" || chatType === "channel";
@@ -155,8 +153,6 @@
     let showReport = $state(false);
     let tipping: string | undefined = $state(undefined);
     let percentageExpired = $state(100);
-    let mediaCalculatedHeight = $state(undefined as number | undefined);
-    let msgBubbleCalculatedWidth = $state(undefined as number | undefined);
     let botProfile: BotProfileProps | undefined = $state(undefined);
     let confirmedReadByThem = $derived(client.messageIsReadByThem(chatId, msg.messageIndex));
     let readByThem = $derived(confirmedReadByThem || $unconfirmedReadByThem.has(msg.messageId));
@@ -180,8 +176,6 @@
                 }
             });
         }
-
-        recalculateMediaDimensions();
 
         if (expiresAt !== undefined) {
             return now.subscribe((t) => {
@@ -310,34 +304,6 @@
         showEmojiPicker = false;
     }
 
-    function recalculateMediaDimensions() {
-        if (mediaDimensions === undefined || !msgBubbleElement) {
-            return;
-        }
-
-        let msgBubblePaddingWidth = 0;
-        if (!fill) {
-            let msgBubbleStyle = getComputedStyle(msgBubbleElement);
-            msgBubblePaddingWidth =
-                parseFloat(msgBubbleStyle.paddingLeft) +
-                parseFloat(msgBubbleStyle.paddingRight) +
-                parseFloat(msgBubbleStyle.borderRightWidth) +
-                parseFloat(msgBubbleStyle.borderLeftWidth);
-        }
-
-        const messageWrapperWidth = msgBubbleWrapperElement?.parentElement?.offsetWidth ?? 0;
-
-        let targetMediaDimensions = client.calculateMediaDimensions(
-            mediaDimensions,
-            messageWrapperWidth,
-            msgBubblePaddingWidth,
-            window.innerHeight,
-            maxWidthFraction,
-        );
-        mediaCalculatedHeight = targetMediaDimensions.height;
-        msgBubbleCalculatedWidth = targetMediaDimensions.width + msgBubblePaddingWidth;
-    }
-
     function openUserProfile(ev: Event) {
         if (sender?.kind === "bot") {
             botProfile = {
@@ -398,7 +364,6 @@
             ? undefined
             : threadRootMessage?.messageIndex,
     );
-    let mediaDimensions = $derived(client.extractDimensionsFromMessageContent(msg.content));
     let fill = $derived(client.fillMessage(msg));
     let showAvatar = $derived($screenWidth !== ScreenWidth.ExtraExtraSmall);
     let translated = $derived($translationsStore.has(msg.messageId));
@@ -447,7 +412,6 @@
     let canTranslate = $derived((client.getMessageText(msg.content) ?? "").length > 0);
 </script>
 
-<svelte:window onresize={recalculateMediaDimensions} />
 
 {#if botProfile !== undefined}
     <BotProfile {...botProfile} />
@@ -537,18 +501,12 @@
                     {/if}
 
                     <div
-                        bind:this={msgBubbleWrapperElement}
                         class="bubble-wrapper"
-                        style={`--max-width: ${maxWidthFraction * 100}%; ${
-                            msgBubbleCalculatedWidth !== undefined
-                                ? `flex: 0 0 ${msgBubbleCalculatedWidth}px`
-                                : undefined
-                        }`}
+                        style={`--max-width: ${maxWidthFraction * 100}%;`}
                         class:p2pSwap={isP2PSwap}
                         class:proposal={isProposal && !inert}>
                         <!-- svelte-ignore a11y_no_static_element_interactions -->
                         <div
-                            bind:this={msgBubbleElement}
                             ondblclick={doubleClickMessage}
                             use:longpress={() => messageMenu?.showMenu()}
                             class="message-bubble"
@@ -649,7 +607,6 @@
                                 messageId={msg.messageId}
                                 content={msg.content}
                                 {edited}
-                                height={mediaCalculatedHeight}
                                 blockLevelMarkdown={msg.blockLevelMarkdown}
                                 {onRemovePreview}
                                 {onRegisterVote}

--- a/frontend/app/src/components/home/GiphyContent.svelte
+++ b/frontend/app/src/components/home/GiphyContent.svelte
@@ -3,6 +3,7 @@
     import { i18nKey } from "../../i18n/i18n";
     import { rtlStore } from "../../stores/rtl";
     import { lowBandwidth } from "../../stores/settings";
+    import { reservedMediaStyle } from "../../utils/media";
     import Button from "../Button.svelte";
     import Translatable from "../Translatable.svelte";
     import ContentCaption from "./ContentCaption.svelte";
@@ -33,7 +34,12 @@
     let image = $derived($mobileWidth ? content.mobile : content.desktop);
     let landscape = $derived(image.height < image.width);
     let style = $derived(
-        `${height === undefined ? "" : `height: ${height}px;`} max-width: ${image.width}px;`,
+        height !== undefined
+            ? `height: ${height}px; max-width: ${image.width}px;`
+            : draft || reply
+              ? `max-width: ${image.width}px;`
+              : (reservedMediaStyle(image.width, image.height) ??
+                `max-width: ${image.width}px;`),
     );
 
     let hidden = $derived($lowBandwidth);

--- a/frontend/app/src/components/home/ImageContent.svelte
+++ b/frontend/app/src/components/home/ImageContent.svelte
@@ -6,6 +6,7 @@
     import { rtlStore } from "../../stores/rtl";
     import { lowBandwidth } from "../../stores/settings";
     import { isTouchDevice } from "../../utils/devices";
+    import { reservedMediaStyle } from "../../utils/media";
     import Button from "../Button.svelte";
     import ModalContent from "../ModalContent.svelte";
     import Overlay from "../Overlay.svelte";
@@ -149,7 +150,11 @@
             class:reply
             class:zoomable={zoomable && !hidden}
             class:rtl={$rtlStore}
-            style={height === undefined ? undefined : `height: ${height}px`}
+            style={height !== undefined
+                ? `height: ${height}px`
+                : draft || reply || pinned
+                  ? undefined
+                  : reservedMediaStyle(content.width, content.height)}
             src={intersecting && !hidden ? normalised.url : normalised.fallback}
             alt={normalised.caption} />
 

--- a/frontend/app/src/components/home/VideoContent.svelte
+++ b/frontend/app/src/components/home/VideoContent.svelte
@@ -2,7 +2,7 @@
     import { rtlStore } from "../../stores/rtl";
     import type { VideoContent } from "openchat-client";
     import ContentCaption from "./ContentCaption.svelte";
-    import { setPlayingMedia } from "../../utils/media";
+    import { reservedMediaStyle, setPlayingMedia } from "../../utils/media";
 
     interface Props {
         content: VideoContent;
@@ -44,7 +44,11 @@
         class:withCaption
         class:draft
         class:reply
-        style={height === undefined ? undefined : `height: ${height}px`}
+        style={height !== undefined
+            ? `height: ${height}px`
+            : draft || reply
+              ? undefined
+              : reservedMediaStyle(content.width, content.height)}
         controls
         onplay={onPlay}
         bind:this={videoPlayer}>

--- a/frontend/app/src/components_mobile/home/ChatMessage.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessage.svelte
@@ -166,7 +166,6 @@
     let showReport = $state(false);
     let tipping: string | undefined = $state(undefined);
     let percentageExpired = $state(100);
-    let mediaCalculatedHeight = $state(undefined as number | undefined);
     let botProfile: BotProfileProps | undefined = $state(undefined);
     let confirmedReadByThem = $derived(client.messageIsReadByThem(chatId, msg.messageIndex));
     let readByThem = $derived(confirmedReadByThem || $unconfirmedReadByThem.has(msg.messageId));
@@ -188,8 +187,6 @@
                 }
             });
         }
-
-        recalculateMediaDimensions();
 
         if (expiresAt !== undefined) {
             return now.subscribe((t) => {
@@ -309,32 +306,6 @@
         popHistoryStateWithAction("emoji_picker_action");
     }
 
-    function recalculateMediaDimensions() {
-        if (mediaDimensions === undefined || !msgBubbleElement) {
-            return;
-        }
-
-        let msgBubblePaddingWidth = 0;
-        if (!fill) {
-            let msgBubbleStyle = getComputedStyle(msgBubbleElement);
-            msgBubblePaddingWidth =
-                parseFloat(msgBubbleStyle.paddingLeft) +
-                parseFloat(msgBubbleStyle.paddingRight) +
-                parseFloat(msgBubbleStyle.borderRightWidth) +
-                parseFloat(msgBubbleStyle.borderLeftWidth);
-        }
-
-        const messageWrapperWidth = msgElement?.offsetWidth ?? 0;
-
-        let targetMediaDimensions = client.calculateMediaDimensions(
-            mediaDimensions,
-            messageWrapperWidth,
-            msgBubblePaddingWidth,
-            window.innerHeight,
-            maxWidthFraction,
-        );
-        mediaCalculatedHeight = targetMediaDimensions.height;
-    }
 
     function openUserProfile(ev?: Event) {
         if (sender?.kind === "bot") {
@@ -384,7 +355,6 @@
         showRemindMe = true;
     }
 
-    const maxWidthFraction = 0.85;
     let inert = $derived(
         msg.content.kind === "deleted_content" ||
             msg.content.kind === "blocked_content" ||
@@ -400,7 +370,6 @@
             ? undefined
             : threadRootMessage?.messageIndex,
     );
-    let mediaDimensions = $derived(client.extractDimensionsFromMessageContent(msg.content));
     let fill = $derived(client.fillMessage(msg));
     let showAvatar = $derived(
         chatType !== "direct_chat" && !me && $screenWidth !== ScreenWidth.ExtraExtraSmall,
@@ -489,8 +458,6 @@
         panFactor = factor;
     }
 </script>
-
-<svelte:window onresize={recalculateMediaDimensions} />
 
 {#if botProfile !== undefined}
     <BotProfile {...botProfile} />
@@ -785,7 +752,6 @@
                                     messageId={msg.messageId}
                                     content={msg.content}
                                     {edited}
-                                    height={mediaCalculatedHeight}
                                     blockLevelMarkdown={msg.blockLevelMarkdown}
                                     {onRemovePreview}
                                     {onRegisterVote}

--- a/frontend/app/src/components_mobile/home/GiphyContent.svelte
+++ b/frontend/app/src/components_mobile/home/GiphyContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { type GiphyContent, type TextContent as TextContentType } from "openchat-client";
     import { rtlStore } from "../../stores/rtl";
+    import { reservedMediaStyle } from "../../utils/media";
     import TextContent from "./TextContent.svelte";
 
     interface Props {
@@ -37,7 +38,11 @@
         withCaption ? { kind: "text_content", text: content.caption ?? "" } : undefined,
     );
     let style = $derived(
-        `${height === undefined ? "" : `height: ${height}px;`} max-width: ${videoWidth}px;`,
+        height !== undefined
+            ? `height: ${height}px; max-width: ${videoWidth}px;`
+            : reply || isPreview
+              ? `max-width: ${videoWidth}px;`
+              : (reservedMediaStyle(image.width, image.height) ?? `max-width: ${videoWidth}px;`),
     );
 </script>
 

--- a/frontend/app/src/components_mobile/home/ImageContent.svelte
+++ b/frontend/app/src/components_mobile/home/ImageContent.svelte
@@ -14,7 +14,7 @@
     import { i18nKey } from "../../i18n/i18n";
     import { rtlStore } from "../../stores/rtl";
     import { lowBandwidth } from "../../stores/settings";
-    import { getProxyAdjustedBlobUrl } from "../../utils/media";
+    import { getProxyAdjustedBlobUrl, reservedMediaStyle } from "../../utils/media";
     import Translatable from "../Translatable.svelte";
     import MessageRenderer from "./MessageRenderer.svelte";
 
@@ -210,7 +210,11 @@
                     class:reply
                     class:zoomable={zoomable && !hidden}
                     class:rtl={$rtlStore}
-                    style={height === undefined ? undefined : `height: ${height}px`}
+                    style={height !== undefined
+                        ? `height: ${height}px`
+                        : draft || reply || pinned
+                          ? undefined
+                          : reservedMediaStyle(content.width, content.height)}
                     src={intersecting && !hidden ? normalised.url : normalised.fallback}
                     alt={normalised.caption} />
             {:else}

--- a/frontend/app/src/components_mobile/home/VideoContent.svelte
+++ b/frontend/app/src/components_mobile/home/VideoContent.svelte
@@ -7,7 +7,12 @@
     import PlayCircleOutline from "svelte-material-icons/PlayCircleOutline.svelte";
     import VideoOutline from "svelte-material-icons/VideoOutline.svelte";
     import { rtlStore } from "../../stores/rtl";
-    import { getProxyAdjustedBlobUrl, getVideoDuration, setPlayingMedia } from "../../utils/media";
+    import {
+        getProxyAdjustedBlobUrl,
+        getVideoDuration,
+        reservedMediaStyle,
+        setPlayingMedia,
+    } from "../../utils/media";
     import Translatable from "../Translatable.svelte";
     import MessageRenderer from "./MessageRenderer.svelte";
 
@@ -43,14 +48,20 @@
         onRemove,
     }: Props = $props();
 
-    let poster: HTMLImageElement | undefined = $state();
     let videoPlayer: HTMLVideoElement | undefined = $state();
     let landscape = $derived(content.height < content.width);
     let imageUrl = $derived(getProxyAdjustedBlobUrl(content.imageData.blobUrl));
     let videoUrl = $derived(getProxyAdjustedBlobUrl(content.videoData.blobUrl));
     let videoDuration = $state<string>();
+    let ratio = $derived(content.width / content.height);
     let posterHeight = $derived(draft || reply ? 70 : (height ?? 400));
-    let posterWidth = $derived((posterHeight * content.width) / content.height);
+    // mirrors reservedMediaStyle's width formula (used for the caption cap;
+    // the container clamp is applied by CSS)
+    let posterWidth = $derived(
+        draft || reply
+            ? posterHeight * ratio
+            : Math.min(Math.max(200, content.width), 400 * ratio),
+    );
 
     $effect(() => {
         contentWidth = posterWidth;
@@ -141,15 +152,16 @@
     <!-- svelte-ignore a11y_interactive_supports_focus -->
     <div role="button" class="video_regular" class:reply class:rtl={$rtlStore} onclick={playVideo}>
         <img
-            bind:this={poster}
             alt="..."
             class="preview_img"
             class:landscape
             class:fill
             class:me
             src={imageUrl}
-            style:height={`${posterHeight}px`}
-            style:width={poster && poster.complete ? undefined : `${MIN_VIDEO_WIDTH}px`} />
+            style={height !== undefined
+                ? `height: ${height}px`
+                : (reservedMediaStyle(content.width, content.height) ??
+                  `height: ${posterHeight}px; width: ${MIN_VIDEO_WIDTH}px`)} />
 
         <div class="play_icon">
             <PlayCircleOutline class="play" size="3rem" color={ColourVars.textPrimary} />

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -43,7 +43,6 @@
     import { isSafari, mobileOperatingSystem } from "@utils/devices";
     import type { FlatChatItem } from "./flatChatItems";
     import { vclDebug } from "./vclDebug";
-    import { rowByKey } from "./virtualListUtils";
     import VirtualChatList from "./VirtualChatList.svelte";
 
     // todo - these thresholds need to be relative to screen height otherwise things get screwed up on (relatively) tall screens
@@ -324,9 +323,14 @@
     }
 
     // Height classes for the virtual list's unmeasured-item estimates. Date
-    // markers are effectively constant-height; media messages are several
-    // times taller than text ones — a single global average is systematically
-    // wrong for all of them (trace: 39px markers against a 261px average).
+    // markers are effectively constant-height and media is several times
+    // taller than text — a single global average is systematically wrong for
+    // everything (trace: 39px markers against a 261px average). Bucket by
+    // content kind, with link-preview texts split out: a text message with an
+    // OG preview measures ~400px against ~80px for plain text, and lumping
+    // them together poisons the shared average from both ends (device trace:
+    // debt railing +892 through a preview cluster and -1183 through plain
+    // text estimated at the inflated shared average).
     function estimateClass(item: FlatChatItem): string {
         switch (item.kind) {
             case "timeline_date":
@@ -336,14 +340,14 @@
             case "event": {
                 const evt = item.event.event;
                 if (evt.kind !== "message") return "event";
-                switch (evt.content.kind) {
-                    case "image_content":
-                    case "video_content":
-                    case "giphy_content":
-                        return "media";
-                    default:
-                        return "text";
+                if (
+                    evt.content.kind === "text_content" &&
+                    ((evt.ogPreviews?.length ?? 0) > 0 ||
+                        (evt.messagePreviews?.length ?? 0) > 0)
+                ) {
+                    return "text_preview";
                 }
+                return evt.content.kind;
             }
         }
     }
@@ -552,12 +556,6 @@
         // arriving batch — in a busy channel that reads as the list
         // repeatedly jumping ~a viewport up from the bottom.
         const preAtBottom = fromBottom < 10;
-        // Capture the bottom-most rendered row as a position anchor. After the
-        // load we restore its exact on-screen position from the DOM — the only
-        // coordinate system that mixes no estimates.
-        const anchorEl = el?.querySelector<HTMLElement>(".vcl-row");
-        const anchorKey = anchorEl?.dataset.key;
-        const anchorTop = anchorEl?.getBoundingClientRect().top;
 
         await client.loadNewMessages(chat.id, threadRootEvent);
 
@@ -589,11 +587,16 @@
         if (el && preLoadScrollHeight !== undefined) {
             await tick();
             const delta = el.scrollHeight - preLoadScrollHeight;
-            // Preferred restore: the anchor row's actual pixel shift. Fallback:
-            // -fromBottom, which at least shares its coordinate system (height
-            // estimates) with the virtual window, unlike the scrollHeight delta.
-            let target = -fromBottom;
-            let anchored = false;
+            // The virtual list pinned the prepend to the user's live position
+            // in the same flush that rendered it (anchor-exact, paint-atomic).
+            // That pin is the restore target. Do NOT recompute from an anchor
+            // rect captured before the load await: the user keeps scrolling
+            // while the load is in flight, and restoring a pre-load position
+            // rewinds them by exactly the distance scrolled during the load —
+            // ~the full load latency's worth of scroll on a cold cache, which
+            // is why boundary feel varied so wildly between sessions.
+            const pinned = virtualList?.lastPrependPin();
+            let target = pinned ?? -fromBottom;
             // Follow-to-bottom applies ONLY at the live bottom of the chat:
             // preAtBottom re-checked against the current position (the user
             // may have scrolled away mid-load), AND the load must have caught
@@ -605,12 +608,6 @@
             const caughtUp = !client.moreNewMessagesAvailable(chat.id, threadRootEvent);
             if (preAtBottom && caughtUp && -el.scrollTop < 200) {
                 target = 0;
-            } else if (anchorKey !== undefined && anchorTop !== undefined) {
-                const again = rowByKey(el, anchorKey);
-                if (again) {
-                    target = el.scrollTop + (again.getBoundingClientRect().top - anchorTop);
-                    anchored = true;
-                }
             }
             vclDebug.log("load-new", {
                 preH: Math.round(preLoadScrollHeight),
@@ -619,10 +616,10 @@
                 st: Math.round(el.scrollTop),
                 fb: Math.round(fromBottom),
                 target: Math.round(target),
-                anchored,
+                pinned: pinned !== undefined ? Math.round(pinned) : undefined,
                 atBottom: preAtBottom,
             });
-            if (delta > 0) {
+            if (delta > 0 && Math.abs(el.scrollTop - target) > 1) {
                 if (mobileOperatingSystem === "iOS" || isSafari) {
                     // the one-frame overflow-y:hidden halts iOS momentum / macOS
                     // Safari trackpad inertia, so the programmatic write cannot
@@ -1184,6 +1181,7 @@
     {onUserScroll}
     {onUserTouch}
     {estimateClass}
+    caughtUp={() => !client.moreNewMessagesAvailable(chat.id, threadRootEvent)}
     {isDateMarker}
     {timestampFor}
     {stickyDateElTop}

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -323,6 +323,31 @@
         return item.kind === "timeline_date";
     }
 
+    // Height classes for the virtual list's unmeasured-item estimates. Date
+    // markers are effectively constant-height; media messages are several
+    // times taller than text ones — a single global average is systematically
+    // wrong for all of them (trace: 39px markers against a 261px average).
+    function estimateClass(item: FlatChatItem): string {
+        switch (item.kind) {
+            case "timeline_date":
+                return "date";
+            case "chat_start":
+                return "chat_start";
+            case "event": {
+                const evt = item.event.event;
+                if (evt.kind !== "message") return "event";
+                switch (evt.content.kind) {
+                    case "image_content":
+                    case "video_content":
+                    case "giphy_content":
+                        return "media";
+                    default:
+                        return "text";
+                }
+            }
+        }
+    }
+
     function timestampFor(item: FlatChatItem): bigint | undefined {
         switch (item.kind) {
             case "timeline_date":
@@ -1158,6 +1183,7 @@
     viewportClass={`scrollable-list ${rootSelector} ${viewportClass ?? ""}`}
     {onUserScroll}
     {onUserTouch}
+    {estimateClass}
     {isDateMarker}
     {timestampFor}
     {stickyDateElTop}

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -619,21 +619,24 @@
                 pinned: pinned !== undefined ? Math.round(pinned) : undefined,
                 atBottom: preAtBottom,
             });
-            if (delta > 0 && Math.abs(el.scrollTop - target) > 1) {
+            if (delta > 0) {
                 if (mobileOperatingSystem === "iOS" || isSafari) {
-                    // the one-frame overflow-y:hidden halts iOS momentum / macOS
-                    // Safari trackpad inertia, so the programmatic write cannot
-                    // be swallowed by native physics. Safari desktop needs this
-                    // too: unlike Chrome (whose wheel animation a write cancels),
-                    // Safari's inertia keeps running and clobbers the restore a
-                    // frame later — the viewport teleports by the prepend height
-                    // and the suddenly-near-bottom position triggers a cascade of
-                    // further loads (observed as forward scroll "skipping").
+                    // ALWAYS interrupt here, even when scrollTop already sits
+                    // at the target (the virtual list's same-flush pin usually
+                    // puts it there): the interrupt's overflow-y:hidden frame
+                    // is what holds the position across WebKit's own
+                    // post-growth scroll anchoring — without it the browser
+                    // snaps scrollTop back toward the pre-load value a moment
+                    // later, teleporting the user into the new batch and
+                    // re-triggering the load threshold (observed as a huge
+                    // forward leap at the boundary even at slow speeds). It
+                    // also stops native physics from swallowing the write.
                     await interruptScroll(target);
-                } else {
+                } else if (Math.abs(el.scrollTop - target) > 1) {
                     // on Chrome desktop the freeze itself is a visible hitch
                     // mid-glide; a plain write is safe (it cancels the wheel
-                    // animation) and onScroll resyncs the window
+                    // animation) and onScroll resyncs the window. Skip it when
+                    // the pin already landed us on target.
                     virtualList?.markProgrammaticScroll();
                     el.scrollTop = target;
                 }

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -25,6 +25,7 @@
     import { portalState } from "component-lib";
     import {
         currentUserIdStore,
+        eventIndexesLoadedStore,
         eventListLastScrolled,
         eventListScrollTop,
         eventListScrolling,
@@ -81,7 +82,7 @@
         rootSelector,
         chat,
         threadRootEvent,
-        items,
+        items: allItems,
         readonly,
         maintainScroll,
         visible,
@@ -140,6 +141,74 @@
         ),
     );
 
+    // The event store can hold disjoint ranges: the window loaded around a
+    // navigation target, an island of the very latest messages (merged from
+    // chat summary updates), and scattered strays in between. The timeline
+    // flattens everything into one list, so the estimates spanning the gaps
+    // are fiction — scrolling forward from an old message crosses the gap in
+    // a screenful, hits a false bottom at the island tip, then grinds
+    // backfill loads whose progress lands invisibly above the viewport.
+    // Render only the contiguous segment containing the anchor: the last
+    // navigation target, or the newest segment when reading the live edge.
+    // Threads are always contiguous — no filtering.
+    let anchorMessageIndex = $state<number | undefined>(undefined);
+
+    let items = $derived.by<FlatChatItem[]>(() => {
+        if (threadRootEvent !== undefined || allItems.length === 0) return allItems;
+        const loaded = $eventIndexesLoadedStore;
+        // Segment boundaries: a split between adjacent event items whose gap
+        // is not fully covered by the loaded ranges (expired/disappeared
+        // events count as loaded). allItems is newest-first, so event
+        // indexes descend as the flat index ascends.
+        const bounds = [0];
+        let prev: number | undefined;
+        for (let i = 0; i < allItems.length; i++) {
+            const item = allItems[i];
+            if (item.kind !== "event") continue;
+            const idx = item.event.index;
+            if (prev !== undefined && prev - idx > 1) {
+                const gap = prev - idx - 1;
+                if (loaded.clone().intersect(idx + 1, prev - 1).length !== gap) {
+                    bounds.push(i);
+                }
+            }
+            prev = idx;
+        }
+        if (bounds.length === 1) return allItems;
+        bounds.push(allItems.length);
+        let chosen = 0;
+        if (anchorMessageIndex !== undefined) {
+            for (let s = 0; s < bounds.length - 1; s++) {
+                let newest: number | undefined;
+                let oldest: number | undefined;
+                for (let i = bounds[s]; i < bounds[s + 1]; i++) {
+                    const item = allItems[i];
+                    if (item.kind === "event" && item.event.event.kind === "message") {
+                        newest ??= item.event.event.messageIndex;
+                        oldest = item.event.event.messageIndex;
+                    }
+                }
+                if (
+                    newest !== undefined &&
+                    anchorMessageIndex <= newest &&
+                    anchorMessageIndex >= (oldest ?? newest)
+                ) {
+                    chosen = s;
+                    break;
+                }
+            }
+        }
+        const seg = allItems.slice(bounds[chosen], bounds[chosen + 1]);
+        vclDebug.log("segment", {
+            segs: bounds.length - 1,
+            chosen,
+            anchor: anchorMessageIndex,
+            len: seg.length,
+            of: allItems.length,
+        });
+        return seg;
+    });
+
     // messageIndex -> flat item index, for programmatic scrolling.
     // Failed messages are excluded (mirrors findMessageEvent).
     let messageIndexToFlat = $derived.by(() => {
@@ -175,6 +244,7 @@
         navToken++;
         // a hidden-time navigation belongs to the chat it was issued in
         pendingHiddenNav = undefined;
+        anchorMessageIndex = undefined;
     });
     const insideTopThreshold = () => fromTop() < LOADING_THRESHOLD;
 
@@ -415,6 +485,9 @@
 
     async function scrollBottom(behavior: ScrollBehavior = "auto"): Promise<void> {
         vclDebug.log("scroll-bottom", { behavior });
+        // going to the bottom means reading the live edge — re-anchor the
+        // rendered segment to the newest range
+        anchorMessageIndex = undefined;
         virtualList?.scrollToBottom(behavior);
         // Protect the jump-to-bottom from iOS momentum: a frame of overflow-y:hidden
         // halts native momentum scrolling and gates onScroll, so stale in-flight
@@ -656,21 +729,6 @@
         }
     }
 
-    // True when the item at flatIndex sits at the newer edge of a gap in the
-    // loaded events — i.e. the next older event is more than a handful of
-    // event indexes away, so the content between them has not been loaded.
-    function isIsolated(flatIndex: number): boolean {
-        const item = items[flatIndex];
-        if (item?.kind !== "event") return false;
-        for (let i = flatIndex + 1; i < items.length && i <= flatIndex + 4; i++) {
-            const older = items[i];
-            if (older.kind === "event") {
-                return item.event.index - older.event.index > 25;
-            }
-        }
-        return false;
-    }
-
     function findMessageEvent(index: number): EventWrapper<Message> | undefined {
         for (const item of items) {
             if (
@@ -807,17 +865,26 @@
         }
 
         scrollingToMessage = true;
+        // Anchor the rendered segment to the navigation target: if the store
+        // holds the target in a range disjoint from the current one, the
+        // filtered timeline must switch segments for the lookup below to see
+        // it. Only anchor once the target is actually loaded — re-anchoring
+        // to an unloaded index would flip the timeline to the newest segment
+        // and flash unrelated content for the duration of the window load.
+        // (After the window load, the recursive call lands here again with
+        // the target present.)
+        if (
+            allItems.some(
+                (it) =>
+                    it.kind === "event" &&
+                    it.event.event.kind === "message" &&
+                    it.event.event.messageIndex === index,
+            )
+        ) {
+            anchorMessageIndex = index;
+        }
 
         let flatIndex = messageIndexToFlat.get(index);
-        // The event store can contain a disjoint island of the very latest
-        // messages (merged from chat summary updates) far from the loaded
-        // window. A target found inside such an island is not really
-        // navigable — the estimates spanning the gap are fiction — so treat
-        // it as not-loaded and load a proper event window around it instead.
-        if (flatIndex !== undefined && !hasLookedUpEvent && isIsolated(flatIndex)) {
-            vclDebug.log("scroll-to-msg-island", { index, flatIndex });
-            flatIndex = undefined;
-        }
         vclDebug.log("scroll-to-msg", {
             index,
             flatIndex,
@@ -866,13 +933,10 @@
             vclDebug.log("scroll-to-msg-deferred", { index });
             pendingHiddenNav = { context, index, preserveFocus };
         } else if (!destroyed) {
-            // check whether we have already loaded the event we are looking for
-            // (an isolated island hit does not count — we want the window load)
-            const flatAgain = messageIndexToFlat.get(index);
-            const loaded =
-                flatAgain !== undefined && !hasLookedUpEvent && isIsolated(flatAgain)
-                    ? undefined
-                    : findMessageEvent(index);
+            // check whether we have already loaded the event we are looking
+            // for (only the anchored segment counts — a hit in a disjoint
+            // island is filtered out above, so we want the window load)
+            const loaded = findMessageEvent(index);
             if (loaded === undefined) {
                 if (!hasLookedUpEvent) {
                     // we must only recurse if we have not already loaded the event, otherwise we will enter an infinite loop.

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -601,6 +601,14 @@
                 // flushing them now would be a stale jolt on landing.
                 pendingScrollAdjustment = 0;
                 pendingSnapToBottom = false;
+                // The interrupt has already killed any native momentum, so a
+                // repay write here is free — and outstanding debt carried into
+                // a wall approach otherwise materialises as a clamp shift per
+                // entering item (device trace: +1070px of debt bled out as ten
+                // successive jolts). Only an active finger forbids the write.
+                if (!isTouching) {
+                    repayDebtInline("interrupt-end");
+                }
                 fromBottom = clampFromBottom(-viewport!.scrollTop);
                 updateWindowFull("interrupt-end");
             });

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -21,6 +21,13 @@
         // fired on touchstart (iOS only — where touch listeners are attached);
         // an unambiguous user gesture, unlike scroll events which may be ours
         onUserTouch?: () => void;
+        // buckets items into height classes ("date", "text", "media", …) so
+        // unmeasured items estimate from their class average instead of the
+        // global one — a global average is systematically wrong for every
+        // class (date markers are ~40px against a media-inflated ~260px
+        // average), and that bias per entering row is what drives scroll
+        // compensation pressure during long rides
+        estimateClass?: (item: T) => string;
         // identifies items that act as date separators for the sticky date
         isDateMarker?: (item: T) => boolean;
         // timestamp for the sticky date; must return a value for date markers
@@ -122,6 +129,7 @@
         row,
         onUserScroll,
         onUserTouch,
+        estimateClass,
         isDateMarker,
         timestampFor,
         stickyDateElTop,
@@ -161,6 +169,41 @@
     let measuredCount = 0;
     let averageHeight = 95;
 
+    // ── Per-class height tracking (active when estimateClass is provided) ──
+    // itemClass[i] caches the class of items[i]; classSum/classCount track
+    // measured heights per class; classSnapshot holds the frozen per-class
+    // estimates (same freeze discipline as spacerAvgHeight); estimateMap[i]
+    // is the frozen estimate for items[i], realigned on items changes.
+    let itemClass: string[] = [];
+    let classSum = new Map<string, number>();
+    let classCount = new Map<string, number>();
+    let classSnapshot = new Map<string, number>();
+    let estimateMap: number[] = [];
+    // a class with too few samples estimates from the global average
+    const MIN_CLASS_SAMPLES = 4;
+
+    function trackClassMeasure(i: number, prev: number, h: number) {
+        if (estimateClass === undefined) return;
+        const cls = itemClass[i];
+        if (cls === undefined) return;
+        if (prev > 0) {
+            classSum.set(cls, (classSum.get(cls) ?? 0) - prev);
+            classCount.set(cls, (classCount.get(cls) ?? 0) - 1);
+        }
+        classSum.set(cls, (classSum.get(cls) ?? 0) + h);
+        classCount.set(cls, (classCount.get(cls) ?? 0) + 1);
+    }
+
+    // Project the frozen class snapshot onto per-index estimates after the
+    // items array changes shape. Does NOT re-freeze the snapshot.
+    function realignEstimates(fromIdx: number = 0) {
+        if (estimateClass === undefined) return;
+        estimateMap.length = items.length;
+        for (let i = fromIdx; i < items.length; i++) {
+            estimateMap[i] = classSnapshot.get(itemClass[i]) ?? spacerAvgHeight;
+        }
+    }
+
     // Full rebuild of heightMap and prune keyToHeight to only keys present in
     // the current items (prevents unbounded growth when items are replaced,
     // e.g. navigating to a different event window).
@@ -168,6 +211,9 @@
         heightMap = new Array(items.length).fill(0);
         totalMeasuredHeight = 0;
         measuredCount = 0;
+        classSum = new Map();
+        classCount = new Map();
+        if (estimateClass !== undefined) itemClass = items.map(estimateClass);
         const prunedHeights = new Map<string, number>();
         for (let i = 0; i < items.length; i++) {
             const item = items[i];
@@ -177,10 +223,12 @@
                 prunedHeights.set(item.key, h);
                 totalMeasuredHeight += h;
                 measuredCount++;
+                trackClassMeasure(i, 0, h);
             }
         }
         keyToHeight = prunedHeights;
         if (measuredCount > 0) averageHeight = totalMeasuredHeight / measuredCount;
+        realignEstimates();
         prefixDirty = true;
     }
 
@@ -189,6 +237,12 @@
     // for indices 0..fromIdx-1 without recomputing.
     function extendHeightMap(fromIdx: number) {
         heightMap.length = items.length;
+        if (estimateClass !== undefined) {
+            itemClass.length = items.length;
+            for (let i = fromIdx; i < items.length; i++) {
+                itemClass[i] = estimateClass(items[i]);
+            }
+        }
         for (let i = fromIdx; i < items.length; i++) {
             const item = items[i];
             const h = keyToHeight.get(item.key);
@@ -196,11 +250,13 @@
                 heightMap[i] = h;
                 totalMeasuredHeight += h;
                 measuredCount++;
+                trackClassMeasure(i, 0, h);
             } else {
                 heightMap[i] = 0;
             }
         }
         if (measuredCount > 0) averageHeight = totalMeasuredHeight / measuredCount;
+        realignEstimates(fromIdx);
         prefixDirty = true;
     }
 
@@ -212,8 +268,32 @@
     // one O(N) rebuild vs O(windowSize × N) total for per-item updates.
     function ensurePrefixSums() {
         if (!prefixDirty) return;
-        prefixSums = buildPrefixSums(items.length, heightMap, spacerAvgHeight);
+        prefixSums = buildPrefixSums(
+            items.length,
+            heightMap,
+            spacerAvgHeight,
+            estimateClass !== undefined ? estimateMap : undefined,
+        );
         prefixDirty = false;
+    }
+
+    // Re-freeze the estimate space: the global average plus each class's
+    // average (classes with too few samples inherit the global), projected
+    // onto per-index estimates. Same freeze points as spacerAvgHeight alone
+    // used to have — estimates must stay stable between these points or every
+    // unmeasured item's contribution drifts under the user (N×δ).
+    function refreshEstimateSnapshot() {
+        spacerAvgHeight = averageHeight;
+        if (estimateClass !== undefined) {
+            classSnapshot = new Map();
+            for (const [cls, count] of classCount) {
+                if (count >= MIN_CLASS_SAMPLES) {
+                    classSnapshot.set(cls, (classSum.get(cls) ?? 0) / count);
+                }
+            }
+            realignEstimates();
+        }
+        prefixDirty = true;
     }
 
     // ── spacerAvgHeight (frozen estimate snapshot) ───────────────────────
@@ -232,11 +312,12 @@
     // at which estimate, so we know the delta when measuring.
     let pendingBottomCorrections = new Map<number, number>();
 
-    // Use spacerAvgHeight (snapshot) for ALL unmeasured item estimates.
+    // Use the frozen estimate space for ALL unmeasured item estimates.
     // This keeps computeWindow and spacer calculations consistent — prevents
     // oscillation when averageHeight drifts from spacerAvgHeight during measurements.
     function getHeight(i: number): number {
-        return heightMap[i] > 0 ? heightMap[i] : spacerAvgHeight;
+        if (heightMap[i] > 0) return heightMap[i];
+        return estimateMap[i] ?? spacerAvgHeight;
     }
 
     function computeWindow(): [number, number] {
@@ -323,12 +404,11 @@
         } else if (!scrollingActive()) {
             repayDebtInline(reason);
         }
-        // Only mark prefix sums dirty if spacerAvgHeight actually changed,
+        // Only re-freeze the estimate space if the average actually changed,
         // to avoid redundant O(N) rebuilds when callers (e.g. _doScrollToIndex)
-        // have already set spacerAvgHeight and rebuilt prefix sums.
+        // have already refreshed it and rebuilt prefix sums.
         if (spacerAvgHeight !== averageHeight) {
-            spacerAvgHeight = averageHeight;
-            prefixDirty = true;
+            refreshEstimateSnapshot();
         }
         const [s, e] = computeWindow();
         let [bh, th] = computeSpacers(s, e);
@@ -807,8 +887,7 @@
             // lands away from the previously-visible content and the caller's
             // post-load anchor row is not even rendered.
             if (spacerAvgHeight !== averageHeight) {
-                spacerAvgHeight = averageHeight;
-                prefixDirty = true;
+                refreshEstimateSnapshot();
             }
 
             let prependOffset = 0;
@@ -895,10 +974,9 @@
         behavior: "auto" | "instant" | "smooth" = "instant",
     ) {
         if (!viewport) return;
-        // Snapshot averageHeight BEFORE computing distance so getHeight,
-        // computeWindow, and computeSpacers all use the same estimate.
-        spacerAvgHeight = averageHeight;
-        prefixDirty = true; // spacerAvgHeight changed
+        // Re-freeze the estimate space BEFORE computing distance so getHeight,
+        // computeWindow, and computeSpacers all use the same estimates.
+        refreshEstimateSnapshot();
         ensurePrefixSums();
         // startPos(flatIndex) = prefix[flatIndex] + flatIndex * gap
         const distFromBottom = prefixSums[flatIndex] + flatIndex * gapPx;
@@ -989,6 +1067,7 @@
                     totalMeasuredHeight += h;
                     measuredCount++;
                     if (measuredCount > 0) averageHeight = totalMeasuredHeight / measuredCount;
+                    trackClassMeasure(currentIdx, prev, h);
 
                     // Mark prefix sums for lazy rebuild rather than updating
                     // incrementally. During initial render or resize bursts,

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -28,6 +28,10 @@
         // average), and that bias per entering row is what drives scroll
         // compensation pressure during long rides
         estimateClass?: (item: T) => string;
+        // true when the newest loaded message is the newest that exists —
+        // distinguishes the genuine live bottom (where prepends are followed)
+        // from the catch-up wall mid-history (where position is preserved)
+        caughtUp?: () => boolean;
         // identifies items that act as date separators for the sticky date
         isDateMarker?: (item: T) => boolean;
         // timestamp for the sticky date; must return a value for date markers
@@ -130,6 +134,7 @@
         onUserScroll,
         onUserTouch,
         estimateClass,
+        caughtUp,
         isDateMarker,
         timestampFor,
         stickyDateElTop,
@@ -407,7 +412,17 @@
         // Only re-freeze the estimate space if the average actually changed,
         // to avoid redundant O(N) rebuilds when callers (e.g. _doScrollToIndex)
         // have already refreshed it and rebuilt prefix sums.
-        if (spacerAvgHeight !== averageHeight) {
+        //
+        // NEVER re-freeze at interrupt-end: the owner's restore just pinned an
+        // anchor row's exact screen position, but the rows rendered for the
+        // new window measure between that restore and this recompute, moving
+        // the live average. Re-freezing here re-estimates every unmeasured row
+        // below the viewport, changing the bottom spacer under the anchor —
+        // a visible position jump at every load boundary, at any speed. The
+        // recompute must run in the same estimate space the restore was
+        // computed against; the next natural refresh point (items change,
+        // navigation, resize — which all compensate) picks up the new average.
+        if (reason !== "interrupt-end" && spacerAvgHeight !== averageHeight) {
             refreshEstimateSnapshot();
         }
         const [s, e] = computeWindow();
@@ -590,10 +605,82 @@
     }
 
 
+    // ── Synthetic momentum continuation (iOS) ─────────────────────────────
+    // Crossing a load boundary needs the scroll interrupt (the restore write
+    // must not be clobbered by native physics), but the interrupt also kills
+    // the user's fling dead — every forward boundary was a hard stop. Native
+    // momentum cannot be restarted, so we continue it ourselves: sample the
+    // fling velocity from genuine scroll events, and when the interrupt ends
+    // JS-animate the remaining glide with iOS's own deceleration curve.
+    // Programmatic writes are safe at that point — there is no native
+    // momentum left to fight — and the glide's scroll events drive loads and
+    // window updates exactly like the native fling did, so the velocity
+    // carries across subsequent boundaries too.
+    let glideRaf: number | undefined;
+    let glideVelocity = 0; // px/ms, positive = towards the bottom
+    let sampleTime = 0; // performance.now() of the last genuine scroll sample
+    let sampleTop = 0;
+    let sampledVelocity = 0;
+    let capturedGlideVelocity = 0;
+    const GLIDE_MIN_START = 0.15; // px/ms — slower flings aren't worth faking
+    const GLIDE_MIN_KEEP = 0.02;
+    const GLIDE_DECAY_PER_MS = 0.998; // UIScrollView's normal deceleration rate
+
+    function cancelGlide() {
+        if (glideRaf !== undefined) cancelAnimationFrame(glideRaf);
+        glideRaf = undefined;
+        glideVelocity = 0;
+    }
+
+    function startGlide(v: number) {
+        cancelGlide();
+        glideVelocity = v;
+        let last = performance.now();
+        vclDebug.log("glide-start", { v: Math.round(v * 1000) });
+        const step = (t: number) => {
+            glideRaf = undefined;
+            if (!viewport || interrupt || isTouching) {
+                glideVelocity = 0;
+                return;
+            }
+            const dt = Math.min(t - last, 64);
+            last = t;
+            const before = viewport.scrollTop;
+            viewport.scrollTop = before + glideVelocity * dt;
+            lastProgrammaticScrollTime = Date.now();
+            glideVelocity *= Math.pow(GLIDE_DECAY_PER_MS, dt);
+            // an unchanged scrollTop means the browser clamped us at an edge
+            if (Math.abs(glideVelocity) < GLIDE_MIN_KEEP || viewport.scrollTop === before) {
+                vclDebug.log("glide-end", { st: Math.round(viewport.scrollTop) });
+                glideVelocity = 0;
+                return;
+            }
+            glideRaf = requestAnimationFrame(step);
+        };
+        glideRaf = requestAnimationFrame(step);
+    }
+
     // After interrupt ends (scroll restored), sync fromBottom and do a full recompute
     // so spacer state is consistent with the restored scroll position.
     $effect(() => {
-        if (!interrupt && viewport) {
+        if (interrupt) {
+            untrack(() => {
+                // Capture the fling for continuation: an active synthetic
+                // glide's velocity, or the freshly sampled native one when
+                // momentum was live as the interrupt began.
+                capturedGlideVelocity = 0;
+                const v =
+                    glideRaf !== undefined
+                        ? glideVelocity
+                        : isMomentumScrolling && performance.now() - sampleTime < 250
+                          ? sampledVelocity
+                          : 0;
+                cancelGlide();
+                if (mobileOperatingSystem === "iOS" && !isTouching && Math.abs(v) > GLIDE_MIN_START) {
+                    capturedGlideVelocity = v;
+                }
+            });
+        } else if (viewport) {
             untrack(() => {
                 vclDebug.log("interrupt-end", { st: Math.round(viewport!.scrollTop) });
                 // Deferred adjustments were computed against the pre-interrupt
@@ -611,6 +698,10 @@
                 }
                 fromBottom = clampFromBottom(-viewport!.scrollTop);
                 updateWindowFull("interrupt-end");
+                if (capturedGlideVelocity !== 0) {
+                    startGlide(capturedGlideVelocity);
+                    capturedGlideVelocity = 0;
+                }
             });
         }
     });
@@ -903,6 +994,16 @@
                 // New items were prepended at the visual bottom (scroll origin
                 // in column-reverse). Adjust fromBottom so updateWindowFull
                 // targets the same visual position in the new index space.
+                // Reset the pin FIRST: if this prepend takes the follow path
+                // (no pin), the owner must not read a previous boundary's pin.
+                lastPrependPinTarget = undefined;
+                const preFromBottom = fromBottom;
+                // Anchor on the bottom-most rendered row's CURRENT position —
+                // this pre-effect runs before the DOM updates, so the rect is
+                // the position the user is looking at right now.
+                const anchorRow = viewport?.querySelector<HTMLElement>(".vcl-row");
+                const anchorKey = anchorRow?.dataset.key;
+                const anchorTop = anchorRow?.getBoundingClientRect().top;
                 let offset = 0;
                 for (let i = 0; i < prependCount; i++) {
                     offset += getHeight(i);
@@ -913,6 +1014,40 @@
                 offset += prependCount * gapPx;
                 fromBottom += offset;
                 prependOffset = offset;
+                // Neutralise the prepend's shift in the SAME flush that
+                // renders it: the owner's anchored restore runs a task later,
+                // and the browser paints the shifted content in between — a
+                // one-frame flash of a different position at every load
+                // boundary, at any scroll speed. tick() resolves after this
+                // flush's DOM update but before the browser paints, so an
+                // anchor-exact write here is invisible; the owner's later
+                // restore then has nothing left to correct. At the genuine
+                // live bottom the view must FOLLOW new content instead — but
+                // the catch-up wall mid-history also sits at fromBottom 0,
+                // and only the owner can tell the two apart (caughtUp).
+                if (!(preFromBottom < 10 && (caughtUp?.() ?? true))) {
+                    tick().then(() => {
+                        if (!viewport || interrupt) return;
+                        const again =
+                            anchorKey !== undefined
+                                ? rowByKey(viewport, anchorKey)
+                                : undefined;
+                        const before = viewport.scrollTop;
+                        if (again && anchorTop !== undefined) {
+                            viewport.scrollTop +=
+                                again.getBoundingClientRect().top - anchorTop;
+                        } else {
+                            viewport.scrollTop = -fromBottom;
+                        }
+                        lastPrependPinTarget = viewport.scrollTop;
+                        vclDebug.log("prepend-pin", {
+                            anchored: !!again,
+                            from: Math.round(before),
+                            to: Math.round(viewport.scrollTop),
+                        });
+                        lastProgrammaticScrollTime = Date.now();
+                    });
+                }
             }
 
             vclDebug.log("items", {
@@ -982,6 +1117,7 @@
         behavior: "auto" | "instant" | "smooth" = "instant",
     ) {
         if (!viewport) return;
+        cancelGlide();
         // Re-freeze the estimate space BEFORE computing distance so getHeight,
         // computeWindow, and computeSpacers all use the same estimates.
         refreshEstimateSnapshot();
@@ -1360,6 +1496,14 @@
         // compensations are absorbed into the spacer instead of scrollTop.
         if (Date.now() - lastProgrammaticScrollTime > 100) {
             lastUserScrollTime = Date.now();
+            // velocity sample for synthetic momentum continuation
+            const nowP = performance.now();
+            const top = viewport.scrollTop;
+            if (nowP - sampleTime < 200 && nowP > sampleTime) {
+                sampledVelocity = (top - sampleTop) / (nowP - sampleTime);
+            }
+            sampleTime = nowP;
+            sampleTop = top;
         }
         if (spacerDebt !== 0) {
             clearTimeout(debtIdleTimer);
@@ -1397,7 +1541,19 @@
         lastProgrammaticScrollTime = Date.now();
     }
 
+    // The scrollTop the last prepend was pinned to by the same-flush anchor
+    // write. The owner's post-load restore must target THIS — its own anchor
+    // rect was captured before the load await, so restoring to it rewinds the
+    // user by however far they scrolled while the load was in flight (~700px
+    // per boundary on a cold cache; imperceptible on a warm one — which is
+    // why the boundary feel varied so wildly between sessions).
+    let lastPrependPinTarget: number | undefined;
+    export function lastPrependPin(): number | undefined {
+        return lastPrependPinTarget;
+    }
+
     export function scrollToBottom(behavior: "auto" | "instant" | "smooth" = "instant") {
+        cancelGlide();
         clearTimeout(scrollCorrectTimer);
         scrollCorrectTimer = undefined;
         pendingScrollFlatIdx = undefined;
@@ -1420,6 +1576,8 @@
         const onTouchStart = () => {
             isTouching = true;
             isMomentumScrolling = false;
+            // the finger takes over from any synthetic glide
+            cancelGlide();
             clearTimeout(momentumEndTimer);
             momentumEndTimer = undefined;
             onUserTouch?.();
@@ -1477,6 +1635,7 @@
                 el.removeEventListener("touchcancel", onTouchCancel);
             }
             el.removeEventListener("scrollend", onScrollEnd);
+            cancelGlide();
             clearTimeout(momentumEndTimer);
             clearTimeout(debtIdleTimer);
             ro.disconnect();

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -1056,6 +1056,22 @@
     // when items are prepended and all indices shift.
     function measureRow(node: HTMLElement, absIdx: number) {
         let currentIdx = absIdx;
+        // Rows whose content renders in two passes (media height styles are
+        // applied in onMount, after the first layout) briefly collapse on
+        // every remount, churning a correction pair per window re-entry. The
+        // settled height from the row's previous life is known — pin it as
+        // min-height across the mount so the transient never reaches layout,
+        // then release. Content that genuinely changed while unmounted
+        // corrects normally after the release.
+        const known = keyToHeight.get(items[absIdx]?.key ?? "");
+        if (known !== undefined && known > 0) {
+            node.style.minHeight = `${known}px`;
+            requestAnimationFrame(() =>
+                requestAnimationFrame(() => {
+                    node.style.minHeight = "";
+                }),
+            );
+        }
         function measure() {
             // Guard: items may have shrunk (chat switch, teardown) while
             // this ResizeObserver callback was pending.

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -852,7 +852,13 @@
                 });
                 return false;
             }
-            settleSpacerDebt(true);
+            // This call site is usually inside a render flush (measureRow
+            // during row creation), where settle's flushSync throws and falls
+            // back to a revert-and-retry that is non-atomic for one frame —
+            // observed as a one-frame glitch when the cap trips mid-glide.
+            // Deferring to a microtask keeps the settle atomic; the absorb
+            // below proceeds and the settle repays the new total.
+            queueMicrotask(() => settleSpacerDebt(true));
         }
         return bottomSpacerHeight - delta >= 0;
     }

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -337,7 +337,17 @@
         // assignment: the DOM spacer keeps its offset, so nothing shifts and
         // no scrollTop write is needed. Clamp so the DOM spacer stays >= 0.
         if (spacerDebt !== 0) {
-            if (spacerDebt > bh) spacerDebt = bh;
+            if (spacerDebt > bh) {
+                // Forgiving debt here leaves the DOM offset unmatched by the
+                // ledger — the repay that eventually fires moves scrollTop by
+                // less than the offset applied earlier.
+                vclDebug.log("!debt-clamped", {
+                    debt: Math.round(spacerDebt),
+                    bh: Math.round(bh),
+                    reason,
+                });
+                spacerDebt = bh;
+            }
             bh -= spacerDebt;
         }
         vclDebug.log("full", {
@@ -391,7 +401,14 @@
             }
             let [bh, th] = computeSpacers(s, e);
             if (spacerDebt !== 0) {
-                if (spacerDebt > bh) spacerDebt = bh;
+                if (spacerDebt > bh) {
+                    vclDebug.log("!debt-clamped", {
+                        debt: Math.round(spacerDebt),
+                        bh: Math.round(bh),
+                        reason: "incr-jumped",
+                    });
+                    spacerDebt = bh;
+                }
                 bh -= spacerDebt;
             }
             vclDebug.log("incr-jumped", { s, e, bh: Math.round(bh), th: Math.round(th) });
@@ -443,7 +460,26 @@
         topSpacerHeight = th;
 
         if (bottomSpacerHeight < 0) {
-            vclDebug.log("!negative-spacer", { bh: Math.round(bottomSpacerHeight), s, e });
+            // The clamp below silently adds |bh| px of content height with no
+            // matching scrollTop or debt adjustment — the visible shift. Full
+            // ledger context to pin down where the sign drift comes from:
+            // canon = what the spacer would be with outstanding debt repaid.
+            vclDebug.log("!negative-spacer", {
+                bh: Math.round(bottomSpacerHeight),
+                s,
+                e,
+                oldS: start,
+                oldE: end,
+                debt: Math.round(spacerDebt),
+                canon: Math.round(bottomSpacerHeight + spacerDebt),
+                fb: Math.round(fromBottom),
+                touch: isTouching,
+                mom: isMomentumScrolling,
+                pend: [...pendingBottomCorrections.entries()]
+                    .slice(0, 12)
+                    .map(([i, est]) => `${i}:${Math.round(est)}`)
+                    .join(" "),
+            });
         }
         bottomSpacerHeight = Math.max(0, bottomSpacerHeight);
         [bottomSpacerHeight, topSpacerHeight] = sanitizeSpacers(bottomSpacerHeight, topSpacerHeight);
@@ -454,6 +490,7 @@
             bh: Math.round(bottomSpacerHeight),
             th: Math.round(topSpacerHeight),
             pend: pendingBottomCorrections.size,
+            debt: Math.round(spacerDebt),
         });
 
         start = s;
@@ -577,7 +614,21 @@
         // it every entering item's estimate error shifts the content
         // mid-gesture (observed on iOS as per-message 'vibration' when
         // scrolling forward through unmeasured history).
-        if (!scrollingActive() || bottomSpacerHeight - delta < 0) {
+        if (!scrollingActive()) {
+            return false;
+        }
+        // Declines during an active gesture push the correction onto a write
+        // (or deferred-write) path — exactly the mid-gesture jolt hazard — so
+        // each decline reason is worth a trace line. A spacer too small to
+        // absorb is the normal state near the bottom of the list.
+        if (bottomSpacerHeight - delta < 0) {
+            vclDebug.log("!absorb-declined", {
+                why: "spacer-too-small",
+                bh: Math.round(bottomSpacerHeight),
+                delta: Math.round(delta),
+                debt: Math.round(spacerDebt),
+                fb: Math.round(fromBottom),
+            });
             return false;
         }
         // During touch/momentum a settle write would kill the native physics,
@@ -590,6 +641,11 @@
         // adjustment path — if we absorbed it we would immediately be forced
         // to repay it mid-scroll.
         if (Math.abs(delta) >= cap) {
+            vclDebug.log("!absorb-declined", {
+                why: "single-delta-cap",
+                delta: Math.round(delta),
+                cap,
+            });
             return false;
         }
         // On a long sustained scroll the debt never gets an idle moment to be
@@ -598,6 +654,12 @@
         // mid-gesture, where only the deferred path remains beyond the cap.
         if (Math.abs(spacerDebt + delta) >= cap) {
             if (isTouching || isMomentumScrolling) {
+                vclDebug.log("!absorb-declined", {
+                    why: "cap-mid-gesture",
+                    delta: Math.round(delta),
+                    debt: Math.round(spacerDebt),
+                    cap,
+                });
                 return false;
             }
             settleSpacerDebt(true);

--- a/frontend/app/src/components_shared/VirtualChatList.svelte
+++ b/frontend/app/src/components_shared/VirtualChatList.svelte
@@ -480,6 +480,17 @@
                     .map(([i, est]) => `${i}:${Math.round(est)}`)
                     .join(" "),
             });
+            // A negative DOM spacer near the bottom is outstanding debt with
+            // no spacer room left to live in (canonical → 0 as s → 0): the
+            // clamp below materialises the deficit as a content shift, so the
+            // matching ledger debt must be forgiven. Keeping it recorded makes
+            // the next carry/repay re-apply the offset against a DOM that no
+            // longer holds it — a second, opposite jolt.
+            if (spacerDebt > 0) {
+                const forgiven = Math.min(spacerDebt, -bottomSpacerHeight);
+                spacerDebt -= forgiven;
+                vclDebug.log("debt-forgiven", { forgiven: Math.round(forgiven) });
+            }
         }
         bottomSpacerHeight = Math.max(0, bottomSpacerHeight);
         [bottomSpacerHeight, topSpacerHeight] = sanitizeSpacers(bottomSpacerHeight, topSpacerHeight);

--- a/frontend/app/src/components_shared/virtualListUtils.ts
+++ b/frontend/app/src/components_shared/virtualListUtils.ts
@@ -14,11 +14,15 @@ export function buildPrefixSums(
     itemCount: number,
     heightMap: number[],
     averageHeight: number,
+    // optional frozen per-index estimates (per-class averages); falls back to
+    // averageHeight where absent
+    estimates?: number[],
 ): number[] {
     const prefix = new Array<number>(itemCount + 1);
     prefix[0] = 0;
     for (let i = 0; i < itemCount; i++) {
-        prefix[i + 1] = prefix[i] + getHeight(heightMap, averageHeight, i);
+        const h = heightMap[i];
+        prefix[i + 1] = prefix[i] + (h > 0 ? h : (estimates?.[i] ?? averageHeight));
     }
     return prefix;
 }

--- a/frontend/app/src/utils/media.ts
+++ b/frontend/app/src/utils/media.ts
@@ -2,6 +2,40 @@ import type { MessageContent, StoredMediaContent } from "openchat-client";
 
 let current: HTMLMediaElement | undefined;
 
+// Reserve a media element's box synchronously from its send-time dimensions.
+// This reproduces the old JS sizing (calculateMediaDimensions) in CSS:
+//   width  = min(available width, max(200, natural width))
+//   height = width x aspect ratio, capped at min(2/3 viewport, 400px);
+//            when the height cap binds, the width narrows to cap x ratio so
+//            the aspect ratio is always preserved (expressed here as the
+//            third min() term feeding the cap back into the width).
+// The available width comes from CSS shrink-to-fit: the message bubble is
+// capped at its --max-width, and max-width: 100% resolves against it.
+// Rendering the box correctly in the FIRST layout pass matters: the old
+// height style was computed in onMount from measured DOM widths, so every
+// (re)mount of a media row collapsed for a frame and then snapped back —
+// which the virtual list had to compensate for mid-scroll on every window
+// re-entry.
+export function reservedMediaStyle(
+    width: number | undefined,
+    height: number | undefined,
+): string | undefined {
+    if (!width || !height) return undefined;
+    const w = Math.round(width);
+    const ratio = width / height;
+    // The width must stay fully definite: a percentage inside width's min()
+    // is cyclic while the bubble shrink-to-fits and falls back to the
+    // placeholder thumbnail's intrinsic size. max-width: 100% is the
+    // standard non-cyclic way to hand the container cap to the image, and
+    // since the final width can only shrink from the cap-derived term, the
+    // height cap still holds through the aspect ratio.
+    return (
+        `aspect-ratio: ${width} / ${height}; ` +
+        `width: min(max(200px, ${w}px), calc(min(66.67dvh, 400px) * ${ratio.toFixed(4)})); ` +
+        `max-width: 100%; height: auto;`
+    );
+}
+
 export function isStoreMediaContent(content: MessageContent): content is StoredMediaContent {
     return ["file_content", "audio_content", "video_content", "image_content"].includes(
         content.kind,


### PR DESCRIPTION
Trace-driven follow-ups to #9066/#9067, all reproduced and verified against live data (device traces from iOS + a WebKit measurement rig driving the deployed/local builds).

## Boundary correctness (the "jump at the load boundary")

Four stacked causes, each visible in a device trace:

1. **Dead debt after the negative-spacer clamp** — the clamp materialised outstanding absorption debt as a content shift but kept it recorded, so the next carry/repay re-applied the offset against a DOM that no longer held it. The ledger now forgives exactly what the clamp materialises (device trace: `canon` marches to 0 precisely).
2. **One-frame flash** — the items flush and the scroll restore ran in different tasks and the browser painted between them. Prepends are now pinned anchor-exact in the same flush that renders them (rect captured pre-update, corrected scrollTop written post-update, pre-paint), with a `caughtUp` callback distinguishing the live bottom (follow) from the catch-up wall (preserve).
3. **Stale-anchor rewind** — the restore anchored to a rect captured before the load await, rewinding the user by the distance scrolled during the load: ~700px per boundary on a cold cache, ~0 warm. This was the source of the wild session-to-session variance in boundary feel. The restore now targets the same-flush pin.
4. **Estimate-space re-freeze at interrupt-end** — rows measured between the restore and the interrupt-end recompute moved the average; re-freezing re-estimated everything below the anchor and shifted the spacer under it. Interrupt-end recomputes now keep the estimate space the restore was computed against.

Note: the iOS/Safari restore must always run under the scroll interrupt even when scrollTop already sits on target — the overflow-hidden frame is what holds the position across WebKit's post-growth scroll anchoring (skipping it teleports the user into the new batch and re-triggers the load threshold).

## Fixed-height media (the "jiggle")

Media heights were computed in onMount from measured DOM widths, so every (re)mount of an image/video/giphy row rendered one layout collapsed and then snapped (~100px → 452px). The virtual list unmounts rows as they leave the window, so every re-entry replayed the transient — the direct source of mid-scroll jiggle and most correction pressure. Media boxes are now sized synchronously in CSS from the dimensions captured at send (aspect-ratio + a width term that reproduces the old min/max/height-cap coupling exactly). Verified box-for-box against the old sizing on a 21-image corridor: worst delta 1px. Row resizes after first layout: 12 per ride → 0. Deletes `recalculateMediaDimensions` and the per-message window resize listeners on both desktop and mobile. Re-entering rows are additionally pinned to their previously-measured height across the mount frames, which suppresses the same class of transient for any two-pass content.

## Estimate accuracy (debt-cap rails and gesture-end flushes)

One global average height was systematically wrong for every row class (39px date markers vs a media-inflated ~260px average; ~400px link-preview texts vs ~80px plain texts sharing one bucket). Unmeasured rows now estimate from per-content-kind averages with link-preview texts split out. Corridor measurements: per-row estimate bias −183px → −8px, peak absorption debt railed-at-cap → <600, gesture-end deferred flushes (one 1368px leap on a device trace) → 0.

## Island rendering

The event store can hold disjoint ranges (nav window + latest-messages island + strays). The flattened timeline bridged them with fiction estimates: scrolling forward from an old message crossed years in a screenful, hit a false bottom, then ground invisible backfill. The timeline now renders only the contiguous segment containing the anchor (contiguity from `eventIndexesLoadedStore`, so expired/disappeared events do not split), and forward loads visibly extend it until the gap closes.

## iOS synthetic momentum

The load-boundary interrupt kills the native fling. The fling velocity is now sampled from genuine scroll events and, when an interrupt ends, the remaining glide is continued programmatically with UIScrollView's deceleration curve, carrying across subsequent boundaries; cancelled by any touch or navigation. iOS-gated.

## Verification

- WebKit rig, cold-cache forward corridor, per-frame row-position tracking: boundary jolts (up to ~800px) → 0 at every crossing.
- Full historical scenario suite against the deployed build: forward wall ride (3 boundaries), backward fling + loadPrev, FAB go-to-latest, reply-click nav + resize, long mixed ride, pinned nav 6/6, sticky date 0 duplicate overlaps, routing 3/3.
- Manual iOS device testing of the slow-scroll boundary corridor (previously the reliable repro).

Known residual, tracked: an intermittent single jolt (~1 per long ride, always the same media-cluster zone) that pre-dates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)