### PR TITLE
fix: pasted URLs mangled inside markdown links

### DIFF
--- a/frontend/app/src/components_shared/RichTextEditor.svelte
+++ b/frontend/app/src/components_shared/RichTextEditor.svelte
@@ -200,6 +200,11 @@
                     inclusive() {
                         return false;
                     },
+                    // Never auto-linkify pasted URL text - it breaks hand-written
+                    // markdown link syntax when the url portion is pasted
+                    addPasteRules() {
+                        return [];
+                    },
                 }).configure({ openOnClick: false }),
                 UserMentionExtension,
                 GroupMentionExtension,

--- a/frontend/app/src/components_shared/markdownConversion.ts
+++ b/frontend/app/src/components_shared/markdownConversion.ts
@@ -21,7 +21,7 @@ export function nodeToMarkdown(node: any): string {
                     t = `<u>${t}</u>`;
                     break;
                 case "link":
-                    t = `[${t}](${mark.attrs?.href ?? ""})`;
+                    t = t === mark.attrs?.href ? t : `[${t}](${mark.attrs?.href ?? ""})`;
                     break;
             }
         }


### PR DESCRIPTION
## Problem

Typing a markdown link like `[hello](https://www.google.co.uk)` in the message composer works, but if the **URL portion is pasted** from the clipboard, the sent message URL gets mangled into nested, broken markdown:

```
[hello]([https://www.google.co.uk](https://www.google.co.uk))
```

## Cause

The composer is TipTap v3 with `@tiptap/extension-link`. That extension's `addPasteRules()` is registered **unconditionally** — it is *not* gated by the `autolink` / `linkOnPaste` options. It runs linkify over any pasted text and applies a `link` mark to detected URLs. Our serializer (`markdownConversion.ts`) then wraps any link-marked text as `[text](href)`, producing the nesting above. Typed URLs never receive the mark, which is why typing worked and pasting did not.

## Fix

- `RichTextEditor.svelte`: override `addPasteRules()` to return `[]` so pasted URL text stays plain. Paste-a-URL-over-a-selection, autolink-on-type, and pasted rich-HTML anchors are separate code paths and are left intact.
- `markdownConversion.ts`: emit a bare URL when link text equals the href, avoiding `[url](url)` for autolinked bare URLs.

## Security

No change to XSS posture. These edits only affect the composer that produces markdown source; the render pipeline (`Markdown.svelte` → `marked` → **DOMPurify** → `{@html}`) is untouched and independently treats all message content as untrusted. Both changes are strictly restrictive (remove an auto-link path; narrow an output format).

## Testing

`svelte-check` passes (0 errors). Manual:
1. Type `[hello](`, paste `https://www.google.co.uk`, type `)`, send → link "hello" → google.co.uk. ✅
2. Paste a bare URL alone, send → renders as a clickable link (marked gfm autolink). ✅
3. Select a typed word, paste a URL → word becomes a link. ✅
4. Copy a link from a webpage (rich HTML), paste → still pastes as a link. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)