### PR TITLE
fix: pasted mentions become literal markdown markup

### DIFF
--- a/frontend/app/src/components_shared/RichTextEditor.svelte
+++ b/frontend/app/src/components_shared/RichTextEditor.svelte
@@ -19,6 +19,7 @@
     import { CustomEmojiExtension } from "./customEmojiExtension";
     import { markdownToDoc, nodeToMarkdown } from "./markdownConversion";
     import { GroupMentionExtension, UserMentionExtension } from "./mentionExtension";
+    import { transformPastedHTML } from "./pasteTransform";
 
     const lowlight = createLowlight(common);
 
@@ -212,6 +213,7 @@
                 CodeBlockLowlight.configure({ lowlight, enableTabIndentation: true }),
             ],
             editorProps: {
+                transformPastedHTML,
                 handleKeyDown: (_view, event) => {
                     if (emojiSuggestion !== undefined) {
                         switch (event.key) {

--- a/frontend/app/src/components_shared/pasteTransform.spec.ts
+++ b/frontend/app/src/components_shared/pasteTransform.spec.ts
@@ -35,4 +35,19 @@ describe("transformPastedHTML", () => {
         const html = `<a href="https://eviloc.app?everyone">@everyone</a>`;
         expect(transformPastedHTML(html)).toBe(html);
     });
+
+    test("strips nested wrappers", () => {
+        const html = `<strong><u><a href="?everyone">@everyone</a></u></strong>`;
+        expect(transformPastedHTML(html)).toBe("@everyone");
+    });
+
+    test("strips wrappers containing stray whitespace", () => {
+        const html = `hi <strong> <a href="?everyone">@everyone</a></strong>`;
+        expect(transformPastedHTML(html)).toBe("hi @everyone");
+    });
+
+    test("skips profile-link missing user-id or text", () => {
+        const html = `hey <profile-link text="bob">@bob</profile-link>`;
+        expect(transformPastedHTML(html)).toBe(html);
+    });
 });

--- a/frontend/app/src/components_shared/pasteTransform.spec.ts
+++ b/frontend/app/src/components_shared/pasteTransform.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { transformPastedHTML } from "./pasteTransform";
+
+describe("transformPastedHTML", () => {
+    test("converts @everyone anchor to plain text and strips wrappers", () => {
+        const html = `hello there <strong><a href="https://oc.app/chats/group/2lcnt-ryaaa-aaaaf-aaula-cai?everyone">@everyone</a></strong> how are you?`;
+        expect(transformPastedHTML(html)).toBe("hello there @everyone how are you?");
+    });
+
+    test("converts underlined @everyone anchor", () => {
+        const html = `<u><a href="?everyone">@everyone</a></u>`;
+        expect(transformPastedHTML(html)).toBe("@everyone");
+    });
+
+    test("converts user group anchor to group_mention span", () => {
+        const html = `hi <strong><a href="https://oc.app/community/abc?usergroup=42">@devs</a></strong>`;
+        expect(transformPastedHTML(html)).toBe(
+            `hi <span data-type="group_mention" groupid="42" groupname="devs">@devs</span>`,
+        );
+    });
+
+    test("converts profile-link to user_mention span", () => {
+        const html = `hey <profile-link text="bob" user-id="abcde-fghij" suppress-links="false">@bob</profile-link>!`;
+        expect(transformPastedHTML(html)).toBe(
+            `hey <span data-type="user_mention" userid="abcde-fghij" username="bob">@bob</span>!`,
+        );
+    });
+
+    test("leaves ordinary links alone", () => {
+        const html = `see <a href="https://example.com?everyone">@everyone</a> and <a href="https://oc.app/blog">this post</a>`;
+        expect(transformPastedHTML(html)).toBe(html);
+    });
+
+    test("does not treat lookalike domains as oc.app", () => {
+        const html = `<a href="https://eviloc.app?everyone">@everyone</a>`;
+        expect(transformPastedHTML(html)).toBe(html);
+    });
+});

--- a/frontend/app/src/components_shared/pasteTransform.ts
+++ b/frontend/app/src/components_shared/pasteTransform.ts
@@ -1,0 +1,69 @@
+const INLINE_WRAPPERS = new Set(["SPAN", "STRONG", "B", "EM", "I", "U"]);
+
+// When text is copied from a rendered message, mentions arrive in the clipboard
+// HTML as <profile-link> elements or styled anchors (?everyone / ?usergroup=N).
+// Convert them back to mention nodes / plain text before tiptap parses the
+// paste, otherwise they end up being sent as literal markdown markup like
+// <u>[@everyone](https://oc.app/...?everyone)</u>.
+export function transformPastedHTML(html: string): string {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+
+    for (const el of [...doc.querySelectorAll("profile-link")]) {
+        const userId = el.getAttribute("user-id");
+        const username = el.getAttribute("text");
+        if (!userId || !username) continue;
+        const span = doc.createElement("span");
+        span.setAttribute("data-type", "user_mention");
+        span.setAttribute("userId", userId);
+        span.setAttribute("username", username);
+        span.textContent = `@${username}`;
+        replaceUnwrapped(el, span);
+    }
+
+    for (const a of [...doc.querySelectorAll("a")]) {
+        const text = a.textContent ?? "";
+        let url: URL;
+        try {
+            url = new URL(a.getAttribute("href") ?? "", window.location.href);
+        } catch {
+            continue;
+        }
+        if (
+            url.origin !== window.location.origin &&
+            url.hostname !== "oc.app" &&
+            !url.hostname.endsWith(".oc.app")
+        ) {
+            continue;
+        }
+        if (url.searchParams.has("everyone") && text === "@everyone") {
+            replaceUnwrapped(a, doc.createTextNode("@everyone"));
+        } else {
+            const groupId = url.searchParams.get("usergroup");
+            if (groupId && /^\d+$/.test(groupId) && text.startsWith("@")) {
+                const span = doc.createElement("span");
+                span.setAttribute("data-type", "group_mention");
+                span.setAttribute("groupId", groupId);
+                span.setAttribute("groupname", text.slice(1));
+                span.textContent = text;
+                replaceUnwrapped(a, span);
+            }
+        }
+    }
+
+    return doc.body.innerHTML;
+}
+
+// Replace `el` with `replacement`, also dropping any inline wrappers (bold,
+// underline, style spans) that contain nothing but `el`, so the mention
+// doesn't pick up formatting marks from the copied message's styling.
+function replaceUnwrapped(el: Element, replacement: Node) {
+    let target: Element = el;
+    while (
+        target.parentElement &&
+        INLINE_WRAPPERS.has(target.parentElement.tagName) &&
+        target.parentElement.textContent === el.textContent
+    ) {
+        target = target.parentElement;
+    }
+    target.replaceWith(replacement);
+}

--- a/frontend/app/src/components_shared/pasteTransform.ts
+++ b/frontend/app/src/components_shared/pasteTransform.ts
@@ -8,13 +8,17 @@ const INLINE_WRAPPERS = new Set(["SPAN", "STRONG", "B", "EM", "I", "U"]);
 export function transformPastedHTML(html: string): string {
     const doc = new DOMParser().parseFromString(html, "text/html");
 
+    // No origin gate here (unlike the anchors below): clipboard HTML carries no
+    // provenance and profile-link has no href to allowlist. Crafting one grants
+    // nothing beyond pasting the literal text @UserId(x), which was always
+    // possible - ids are validated against the user store when rendered.
     for (const el of [...doc.querySelectorAll("profile-link")]) {
         const userId = el.getAttribute("user-id");
         const username = el.getAttribute("text");
         if (!userId || !username) continue;
         const span = doc.createElement("span");
         span.setAttribute("data-type", "user_mention");
-        span.setAttribute("userId", userId);
+        span.setAttribute("userid", userId);
         span.setAttribute("username", username);
         span.textContent = `@${username}`;
         replaceUnwrapped(el, span);
@@ -42,7 +46,7 @@ export function transformPastedHTML(html: string): string {
             if (groupId && /^\d+$/.test(groupId) && text.startsWith("@")) {
                 const span = doc.createElement("span");
                 span.setAttribute("data-type", "group_mention");
-                span.setAttribute("groupId", groupId);
+                span.setAttribute("groupid", groupId);
                 span.setAttribute("groupname", text.slice(1));
                 span.textContent = text;
                 replaceUnwrapped(a, span);
@@ -57,11 +61,12 @@ export function transformPastedHTML(html: string): string {
 // underline, style spans) that contain nothing but `el`, so the mention
 // doesn't pick up formatting marks from the copied message's styling.
 function replaceUnwrapped(el: Element, replacement: Node) {
+    const text = el.textContent?.trim();
     let target: Element = el;
     while (
         target.parentElement &&
         INLINE_WRAPPERS.has(target.parentElement.tagName) &&
-        target.parentElement.textContent === el.textContent
+        target.parentElement.textContent?.trim() === text
     ) {
         target = target.parentElement;
     }


### PR DESCRIPTION
## Problem

Copy the text of a rendered message containing a mention, paste it into the message entry box, and the mention degrades into literal markup. For example:

> hello there @everyone how are you?

becomes

> hello there \<u\>[@everyone](https://oc.app/chats/group/2lcnt-ryaaa-aaaaf-aaula-cai?everyone)\</u\> how are you?

Rendered messages turn mentions into styled links (`@everyone` → `<strong><a href="?everyone">`, user groups similarly, user mentions → `<profile-link>` elements). The browser copies that HTML to the clipboard, tiptap parses it as link + underline marks, and `nodeToMarkdown` then faithfully emits those marks as literal markup on send.

## Fix

Add a `transformPastedHTML` hook to the shared `RichTextEditor` that rewrites the clipboard HTML before tiptap parses it:

- `<profile-link>` → `user_mention` node (keeps the userId, so it round-trips as a real mention)
- anchors with `?usergroup=N` → `group_mention` node
- anchors with `?everyone` and text `@everyone` → plain `@everyone` text
- strips formatting wrappers (`<strong>`, `<u>`, style spans) around them so no stray marks survive

Only anchors on the current origin, `oc.app`, or `*.oc.app` with matching mention text are rewritten; ordinary links and all other pasted content are untouched. Image paste is unaffected — it flows through `clipboardData.items`, which this hook never touches.

Covers desktop and mobile (both use the shared editor). Includes unit tests, one of which is the exact repro above, plus a lookalike-domain (`eviloc.app`) regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)