### PR TITLE
fix: user mentions degrade to literal text when editing

### DIFF
--- a/frontend/app/src/components/home/MessageEntry.svelte
+++ b/frontend/app/src/components/home/MessageEntry.svelte
@@ -33,6 +33,8 @@
         selectedCommunitySummaryStore,
         selectedCommunityUserGroupsStore,
         throttleDeadline,
+        userGroupMentionRegex,
+        userIdMentionRegex,
     } from "openchat-client";
     import { getContext, tick } from "svelte";
     import { _ } from "svelte-i18n";
@@ -240,7 +242,7 @@
     }
 
     function formatUserMentions(text: string): string {
-        return text.replace(/@UserId\(([\d\w-]+)\)/g, (match, p1) => {
+        return text.replace(userIdMentionRegex, (match, p1) => {
             const u = $allUsersStore.get(p1);
             if (u?.username !== undefined) {
                 const username = u.username;
@@ -251,7 +253,7 @@
     }
 
     function formatUserGroupMentions(text: string): string {
-        return text.replace(/@UserGroup\(([\d\w-]+)\)/g, (match, p1) => {
+        return text.replace(userGroupMentionRegex, (match, p1) => {
             const u = $selectedCommunityUserGroupsStore.get(Number(p1));
             if (u !== undefined) {
                 return `@${u.name}`;

--- a/frontend/app/src/components_mobile/home/MessageEntry.svelte
+++ b/frontend/app/src/components_mobile/home/MessageEntry.svelte
@@ -36,6 +36,8 @@
         selectedCommunitySummaryStore,
         selectedCommunityUserGroupsStore,
         throttleDeadline,
+        userGroupMentionRegex,
+        userIdMentionRegex,
         type CreatedUser,
     } from "openchat-client";
     import { getContext, onMount, tick } from "svelte";
@@ -416,7 +418,7 @@
     }
 
     function formatUserMentions(text: string): string {
-        return text.replace(/@UserId\(([\d\w-]+)\)/g, (match, p1) => {
+        return text.replace(userIdMentionRegex, (match, p1) => {
             const u = $allUsersStore.get(p1);
             if (u?.username !== undefined) {
                 const username = u.username;
@@ -427,7 +429,7 @@
     }
 
     function formatUserGroupMentions(text: string): string {
-        return text.replace(/@UserGroup\(([\d\w-]+)\)/g, (match, p1) => {
+        return text.replace(userGroupMentionRegex, (match, p1) => {
             const u = $selectedCommunityUserGroupsStore.get(Number(p1));
             if (u !== undefined) {
                 return `@${u.name}`;

--- a/frontend/app/src/components_shared/Markdown.svelte
+++ b/frontend/app/src/components_shared/Markdown.svelte
@@ -2,7 +2,12 @@
     import "highlight.js/styles/base16/helios.css";
     import { marked } from "marked";
     import type { OpenChat, ReadonlyMap, UserGroupSummary } from "openchat-client";
-    import { allUsersStore, userGroupSummariesStore } from "openchat-client";
+    import {
+        allUsersStore,
+        userGroupMentionRegex,
+        userGroupSummariesStore,
+        userIdMentionRegex,
+    } from "openchat-client";
     import { getContext } from "svelte";
     import { DOMPurifyDefault, DOMPurifyOneLine } from "../utils/domPurify";
     import { isSingleEmoji } from "../utils/emojis";
@@ -75,7 +80,7 @@
     }
 
     function replaceUserIds(text: string): string {
-        return text.replace(/@UserId\(([\d\w-]+)\)/g, (match, p1) => {
+        return text.replace(userIdMentionRegex, (match, p1) => {
             const u = $allUsersStore.get(p1);
             if (u !== undefined) {
                 return `<profile-link text="${escapeHtml(u.username)}" user-id="${
@@ -96,7 +101,7 @@
         text: string,
         userGroups: ReadonlyMap<number, UserGroupSummary>,
     ): string {
-        return text.replace(/@UserGroup\(([\d]+)\)/g, (match, p1) => {
+        return text.replace(userGroupMentionRegex, (match, p1) => {
             const u = userGroups.get(Number(p1));
             if (u !== undefined) {
                 return `**[@${escapeHtml(u.name)}](?usergroup=${u.id})**`;

--- a/frontend/app/src/components_shared/RichTextEditor.svelte
+++ b/frontend/app/src/components_shared/RichTextEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { rtlStore } from "@src/stores/rtl";
-    import { Editor, type Content } from "@tiptap/core";
+    import { Editor, type Content, type JSONContent } from "@tiptap/core";
     import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
     import Link from "@tiptap/extension-link";
     import { Placeholder } from "@tiptap/extensions";
@@ -9,6 +9,8 @@
     import "highlight.js/styles/base16/helios.css";
     import { common, createLowlight } from "lowlight";
     import {
+        allUsersStore,
+        userGroupSummariesStore,
         type Member,
         type OpenChat,
         type ReadonlyMap,
@@ -185,9 +187,27 @@
     }
 
     export function setContent(markdown: string): void {
-        editor?.commands.setContent(markdownToDoc(markdown));
+        editor?.commands.setContent(resolveMentionLabels(markdownToDoc(markdown)));
         editor?.commands.focus("end");
         empty = editor?.isEmpty ?? true;
+    }
+
+    // markdownToDoc has no access to the user/group stores, so mention nodes it
+    // creates carry placeholder labels - swap in the real names for display
+    function resolveMentionLabels(node: JSONContent): JSONContent {
+        if (node.type === "user_mention" && node.attrs) {
+            const username = $allUsersStore.get(node.attrs.userId)?.username;
+            if (username !== undefined) {
+                node.attrs.username = username;
+            }
+        } else if (node.type === "group_mention" && node.attrs) {
+            const name = $userGroupSummariesStore.get(Number(node.attrs.groupId))?.name;
+            if (name !== undefined) {
+                node.attrs.groupname = name;
+            }
+        }
+        node.content?.forEach(resolveMentionLabels);
+        return node;
     }
 
     onMount(() => {

--- a/frontend/app/src/components_shared/markdownConversion.spec.ts
+++ b/frontend/app/src/components_shared/markdownConversion.spec.ts
@@ -44,6 +44,21 @@ describe("markdown roundtrip", () => {
         expect(roundtrip("Hey @UserId(42) how are you")).toBe("Hey @UserId(42) how are you");
     });
 
+    it("mention with principal user id", () => {
+        expect(roundtrip("Hey @UserId(2lcnt-ryaaa-aaaaf-aaula-cai) how are you")).toBe(
+            "Hey @UserId(2lcnt-ryaaa-aaaaf-aaula-cai) how are you",
+        );
+        const doc = markdownToDoc("Hey @UserId(2lcnt-ryaaa-aaaaf-aaula-cai) how are you");
+        expect(doc.content[0].content[1].type).toBe("user_mention");
+        expect(doc.content[0].content[1].attrs.userId).toBe("2lcnt-ryaaa-aaaaf-aaula-cai");
+    });
+
+    it("group mention", () => {
+        const doc = markdownToDoc("Hey @UserGroup(42)");
+        expect(doc.content[0].content[1].type).toBe("group_mention");
+        expect(doc.content[0].content[1].attrs.groupId).toBe("42");
+    });
+
     it("mixed inline", () => {
         expect(roundtrip("Hello **world** and *everyone* at @UserId(1)")).toBe(
             "Hello **world** and *everyone* at @UserId(1)",

--- a/frontend/app/src/components_shared/markdownConversion.ts
+++ b/frontend/app/src/components_shared/markdownConversion.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { userGroupMentionRegex, userIdMentionRegex } from "openchat-shared";
+
+const anchoredUserMention = new RegExp(`^${userIdMentionRegex.source}`);
+const anchoredGroupMention = new RegExp(`^${userGroupMentionRegex.source}`);
+
 export function nodeToMarkdown(node: any): string {
     if (node.type === "text") {
         let t: string = node.text ?? "";
@@ -98,9 +103,9 @@ export function parseInline(text: string): any[] {
     }
 
     while (pos < text.length) {
-        // mention: @UserId(123)
+        // mention: @UserId(2lcnt-ryaaa-aaaaf-aaula-cai)
         if (text[pos] === "@") {
-            const m = /^@UserId\((\d+)\)/.exec(text.slice(pos));
+            const m = anchoredUserMention.exec(text.slice(pos));
             if (m) {
                 flush(pos);
                 nodes.push({
@@ -111,7 +116,7 @@ export function parseInline(text: string): any[] {
                 textStart = pos;
                 continue;
             }
-            const g = /^@UserGroup\((\d+)\)/.exec(text.slice(pos));
+            const g = anchoredGroupMention.exec(text.slice(pos));
             if (g) {
                 flush(pos);
                 nodes.push({

--- a/frontend/openchat-shared/src/domain/user/index.ts
+++ b/frontend/openchat-shared/src/domain/user/index.ts
@@ -1,2 +1,9 @@
 export * from "./user";
-export { extractUserIdsFromMentions, userStatus, userOrUserGroupName, userOrUserGroupId } from "./user.utils";
+export {
+    extractUserIdsFromMentions,
+    userGroupMentionRegex,
+    userIdMentionRegex,
+    userOrUserGroupId,
+    userOrUserGroupName,
+    userStatus,
+} from "./user.utils";

--- a/frontend/openchat-shared/src/domain/user/user.utils.ts
+++ b/frontend/openchat-shared/src/domain/user/user.utils.ts
@@ -8,10 +8,14 @@ export function userStatus(lastOnline: number | undefined, now: number): UserSta
     return secondsSinceOnline < ONLINE_THRESHOLD ? UserStatus.Online : UserStatus.Offline;
 }
 
-const mentionRegex = /@UserId\(([\d\w-]+)\)/g;
+// The single source of truth for mention markup. User ids are principals,
+// user group ids are numeric. Global flags: only use these with
+// replace/matchAll (which reset lastIndex), never exec/test.
+export const userIdMentionRegex = /@UserId\(([\d\w-]+)\)/g;
+export const userGroupMentionRegex = /@UserGroup\((\d+)\)/g;
 
 export function extractUserIdsFromMentions(text: string): string[] {
-    return [...text.matchAll(mentionRegex)].map((m) => m[1]);
+    return [...text.matchAll(userIdMentionRegex)].map((m) => m[1]);
 }
 
 export function userOrUserGroupName(u: UserOrUserGroup): string {


### PR DESCRIPTION
Closes #9076

## Problem

`markdownToDoc` (`parseInline`) matched user mentions with a digits-only regex:

```ts
/^@UserId\((\d+)\)/
```

but user ids are IC principals, so any path through `RichTextEditor.setContent` (editing a message, restoring a draft) failed to recognise them and showed the literal text `@UserId(2lcnt-ryaaa-...)` in the editor.

The root cause is duplication: the `@UserId(...)` / `@UserGroup(...)` patterns were hand-copied in five places (`markdownConversion.ts`, `Markdown.svelte`, both `MessageEntry.svelte` variants, `openchat-shared/user.utils.ts`) with three different charsets between them.

## Fix

- Export `userIdMentionRegex` and `userGroupMentionRegex` from `openchat-shared` as the single source of truth (user ids: `[\d\w-]+`, group ids: `\d+`) and derive every call site from them, including the anchored variants `parseInline` needs.
- Resolve mention labels against the user/group stores in `RichTextEditor.setContent`, so edited mentions display real usernames/group names instead of placeholder ids (previously group mentions showed `@UserGroup(5)` chips when editing).

Round-trip is unchanged: `nodeToMarkdown` still emits `@UserId(<principal>)` / `@UserGroup(<id>)`, and label resolution never touches the ids.

Includes round-trip and node-shape tests for principal user ids and numeric group ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)