### PR TITLE
fix: remove clientHeight/clientWidth bindables from Container

### DIFF
--- a/frontend/app/src/components_mobile/home/MessageEntry.svelte
+++ b/frontend/app/src/components_mobile/home/MessageEntry.svelte
@@ -133,7 +133,18 @@
     let editor = $state<RichTextEditor>();
     let editorEmpty = $state(true);
 
+    let messageEntryElement = $state<HTMLElement>();
     let messageEntryHeight = $state<number>(0);
+
+    $effect(() => {
+        if (messageEntryElement === undefined) return;
+        const el = messageEntryElement;
+        const observer = new ResizeObserver(() => {
+            messageEntryHeight = el.clientHeight;
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    });
     let activeStream: MediaStream | undefined = $state(undefined);
     let audioMimeType = client.audioRecordingMimeType();
     let previousEditingEvent: EventWrapper<Message> | undefined = $state();
@@ -680,7 +691,7 @@
                             </Row>
                         {/if}
                         <Container
-                            bind:clientHeight={messageEntryHeight}
+                            bind:ref={messageEntryElement}
                             gap="sm"
                             minHeight="3.5rem"
                             maxHeight="calc(var(--vh, 1vh) * 50)"

--- a/frontend/component-lib/src/components/Container.svelte
+++ b/frontend/component-lib/src/components/Container.svelte
@@ -40,8 +40,6 @@
         closeMenuOnScroll?: boolean;
         wrap?: boolean;
         ref?: HTMLElement;
-        clientHeight?: number;
-        clientWidth?: number;
         reverse?: boolean;
         data_id?: string; //todo find a better way to do this
         data_index?: string; // tod fine a better way to do this
@@ -132,8 +130,6 @@
         closeMenuOnScroll = false,
         wrap = false,
         ref = $bindable(),
-        clientHeight = $bindable(),
-        clientWidth = $bindable(),
         reverse = false,
         data_id,
         data_index,
@@ -141,8 +137,6 @@
         pan,
     }: Props = $props();
 
-    void clientHeight;
-    void clientWidth;
     void ref;
 
     // you might expect this to be done inside onMount but
@@ -192,8 +186,6 @@
     this={tag}
     data-id={data_id}
     data-index={data_index}
-    bind:clientHeight
-    bind:clientWidth
     role={onClick ? "button" : "none"}
     bind:this={ref}
     use:menuCloser={closeMenuOnScroll}


### PR DESCRIPTION
## Summary

`Container.svelte` unconditionally put `bind:clientHeight`/`bind:clientWidth` on its root element, so every instance paid for two `ResizeObserver` registrations plus two size-read effects on mount — regardless of whether the caller bound those props. Opening "New chat" mounts ~300 contact rows (each built from several Containers), adding up to a ~2s main-thread block on Android before the view rendered.

Closes #9078

## Changes

- **`Container.svelte`**: remove the `clientHeight`/`clientWidth` bindable props and the `bind:` directives on the root element.
- **`components_mobile/home/MessageEntry.svelte`**: the sole call site that bound `clientHeight` on a `Container` (feeding the `offset` of `MentionPicker`/`EmojiAutocompleter`) now uses `bind:ref` plus its own `ResizeObserver`, reading `el.clientHeight` to preserve the old bind semantics (includes padding). Observer is disconnected on teardown.

Audit notes: `clientWidth` had zero consumers; no usage existed via `Row`/`Column` (binding through their `{...props}` spread wouldn't propagate anyway); all other `bind:clientHeight`/`bind:clientWidth` in the app are on native elements and are unaffected.

## Verification

`svelte-check --threshold error`: 0 errors in both `app` (4628 files) and `component-lib` (372 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)