### PR TITLE
fix: drop empty text nodes when parsing markdown to doc

### DIFF
--- a/frontend/app/src/components_shared/markdownConversion.spec.ts
+++ b/frontend/app/src/components_shared/markdownConversion.spec.ts
@@ -155,3 +155,39 @@ describe("markdown roundtrip", () => {
         );
     });
 });
+
+// ProseMirror rejects empty text nodes ("Empty text nodes are not allowed"),
+// so zero-length delimiter matches must never produce them
+describe("no empty text nodes", () => {
+    type Node = { type: string; text?: string; content?: Node[] };
+    function hasEmptyText(node: Node): boolean {
+        if (node.type === "text" && !node.text) return true;
+        return (node.content ?? []).some(hasEmptyText);
+    }
+
+    it("triple backtick inline parses as code span", () => {
+        const doc = markdownToDoc("hello ```how are you``` test");
+        expect(hasEmptyText(doc)).toBe(false);
+        expect(doc.content[0].content).toEqual([
+            { type: "text", text: "hello " },
+            { type: "text", text: "how are you", marks: [{ type: "code" }] },
+            { type: "text", text: " test" },
+        ]);
+    });
+
+    it("empty link", () => {
+        expect(hasEmptyText(markdownToDoc("a [](http://x.com) b"))).toBe(false);
+    });
+
+    it("empty bold", () => {
+        expect(hasEmptyText(markdownToDoc("a **** b"))).toBe(false);
+    });
+
+    it("empty code block", () => {
+        const doc = markdownToDoc("```js\n\n```");
+        expect(hasEmptyText(doc)).toBe(false);
+        expect(doc.content[0].type).toBe("codeBlock");
+        // bare ``` fences with no language degrade to paragraphs but must not crash
+        expect(hasEmptyText(markdownToDoc("```\n\n```"))).toBe(false);
+    });
+});

--- a/frontend/app/src/components_shared/markdownConversion.spec.ts
+++ b/frontend/app/src/components_shared/markdownConversion.spec.ts
@@ -159,8 +159,8 @@ describe("markdown roundtrip", () => {
 // ProseMirror rejects empty text nodes ("Empty text nodes are not allowed"),
 // so zero-length delimiter matches must never produce them
 describe("no empty text nodes", () => {
-    type Node = { type: string; text?: string; content?: Node[] };
-    function hasEmptyText(node: Node): boolean {
+    type DocNode = { type: string; text?: string; content?: DocNode[] };
+    function hasEmptyText(node: DocNode): boolean {
         if (node.type === "text" && !node.text) return true;
         return (node.content ?? []).some(hasEmptyText);
     }
@@ -175,12 +175,29 @@ describe("no empty text nodes", () => {
         ]);
     });
 
+    it("unclosed backtick run stays literal", () => {
+        const doc = markdownToDoc("hello ``` test");
+        expect(hasEmptyText(doc)).toBe(false);
+        expect(doc.content[0].content).toEqual([{ type: "text", text: "hello ``` test" }]);
+    });
+
+    // empty spans are dropped entirely, delimiters included
     it("empty link", () => {
-        expect(hasEmptyText(markdownToDoc("a [](http://x.com) b"))).toBe(false);
+        const doc = markdownToDoc("a [](http://x.com) b");
+        expect(hasEmptyText(doc)).toBe(false);
+        expect(doc.content[0].content).toEqual([
+            { type: "text", text: "a " },
+            { type: "text", text: " b" },
+        ]);
     });
 
     it("empty bold", () => {
-        expect(hasEmptyText(markdownToDoc("a **** b"))).toBe(false);
+        const doc = markdownToDoc("a **** b");
+        expect(hasEmptyText(doc)).toBe(false);
+        expect(doc.content[0].content).toEqual([
+            { type: "text", text: "a " },
+            { type: "text", text: " b" },
+        ]);
     });
 
     it("empty code block", () => {

--- a/frontend/app/src/components_shared/markdownConversion.ts
+++ b/frontend/app/src/components_shared/markdownConversion.ts
@@ -102,6 +102,12 @@ export function parseInline(text: string): any[] {
         if (end > textStart) nodes.push({ type: "text", text: text.slice(textStart, end) });
     }
 
+    // ProseMirror rejects empty text nodes, so drop them (e.g. the zero-length
+    // matches produced by ``` or [](url))
+    function pushMarked(t: string, marks: any[]) {
+        if (t) nodes.push({ type: "text", text: t, marks });
+    }
+
     while (pos < text.length) {
         // mention: @UserId(2lcnt-ryaaa-aaaaf-aaula-cai)
         if (text[pos] === "@") {
@@ -133,11 +139,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("***", pos + 3);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 3, end),
-                    marks: [{ type: "bold" }, { type: "italic" }],
-                });
+                pushMarked(text.slice(pos + 3, end), [{ type: "bold" }, { type: "italic" }]);
                 pos = end + 3;
                 textStart = pos;
                 continue;
@@ -148,11 +150,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("**", pos + 2);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 2, end),
-                    marks: [{ type: "bold" }],
-                });
+                pushMarked(text.slice(pos + 2, end), [{ type: "bold" }]);
                 pos = end + 2;
                 textStart = pos;
                 continue;
@@ -163,11 +161,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("~~", pos + 2);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 2, end),
-                    marks: [{ type: "strike" }],
-                });
+                pushMarked(text.slice(pos + 2, end), [{ type: "strike" }]);
                 pos = end + 2;
                 textStart = pos;
                 continue;
@@ -178,11 +172,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("*", pos + 1);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 1, end),
-                    marks: [{ type: "italic" }],
-                });
+                pushMarked(text.slice(pos + 1, end), [{ type: "italic" }]);
                 pos = end + 1;
                 textStart = pos;
                 continue;
@@ -193,11 +183,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("`", pos + 1);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 1, end),
-                    marks: [{ type: "code" }],
-                });
+                pushMarked(text.slice(pos + 1, end), [{ type: "code" }]);
                 pos = end + 1;
                 textStart = pos;
                 continue;
@@ -208,11 +194,7 @@ export function parseInline(text: string): any[] {
             const end = text.indexOf("</u>", pos + 3);
             if (end !== -1) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: text.slice(pos + 3, end),
-                    marks: [{ type: "underline" }],
-                });
+                pushMarked(text.slice(pos + 3, end), [{ type: "underline" }]);
                 pos = end + 4;
                 textStart = pos;
                 continue;
@@ -234,11 +216,7 @@ export function parseInline(text: string): any[] {
             const m = /^\[([^\]]*)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)/.exec(text.slice(pos));
             if (m) {
                 flush(pos);
-                nodes.push({
-                    type: "text",
-                    text: m[1],
-                    marks: [{ type: "link", attrs: { href: m[2] } }],
-                });
+                pushMarked(m[1], [{ type: "link", attrs: { href: m[2] } }]);
                 pos += m[0].length;
                 textStart = pos;
                 continue;
@@ -260,7 +238,7 @@ export function blockToNode(block: string): any | null {
         return {
             type: "codeBlock",
             attrs: { language: codeMatch[1] || null },
-            content: [{ type: "text", text: codeMatch[2] }],
+            content: codeMatch[2] ? [{ type: "text", text: codeMatch[2] }] : [],
         };
     }
     // Heading: # text

--- a/frontend/app/src/components_shared/markdownConversion.ts
+++ b/frontend/app/src/components_shared/markdownConversion.ts
@@ -103,7 +103,7 @@ export function parseInline(text: string): any[] {
     }
 
     // ProseMirror rejects empty text nodes, so drop them (e.g. the zero-length
-    // matches produced by ``` or [](url))
+    // matches produced by **** or [](url))
     function pushMarked(t: string, marks: any[]) {
         if (t) nodes.push({ type: "text", text: t, marks });
     }
@@ -178,13 +178,17 @@ export function parseInline(text: string): any[] {
                 continue;
             }
         }
-        // inline code: `text`
+        // inline code: a run of N backticks closed by a matching run; an
+        // unclosed run stays literal
         if (text[pos] === "`") {
-            const end = text.indexOf("`", pos + 1);
+            let runEnd = pos;
+            while (text[runEnd] === "`") runEnd++;
+            const run = text.slice(pos, runEnd);
+            const end = text.indexOf(run, runEnd);
             if (end !== -1) {
                 flush(pos);
-                pushMarked(text.slice(pos + 1, end), [{ type: "code" }]);
-                pos = end + 1;
+                pushMarked(text.slice(runEnd, end), [{ type: "code" }]);
+                pos = end + run.length;
                 textStart = pos;
                 continue;
             }


### PR DESCRIPTION
## Problem

Editing a message containing a triple-backtick code span (e.g. `hello ```how are you``` test`) left the editor blank with console warnings:

```
[tiptap warn]: Invalid content. Passed value: {type: 'doc', content: Array(1)}
Error: RangeError: Empty text nodes are not allowed
```

`parseInline` paired the first backtick of a ``` run with the second, emitting a text node with an empty string and a `code` mark. ProseMirror rejects empty text nodes, so `setContent` failed. Same class of bug for `[](url)`, `****`, and empty fenced code blocks.

## Fix

- `parseInline`: route all marked-text emission through a `pushMarked` helper that drops zero-length matches. Triple-tick spans now parse as a code mark on the inner text (matching how marked renders them).
- `blockToNode`: an empty fenced code block emits `content: []` instead of an empty text node.

## Tests

New `no empty text nodes` describe block in `markdownConversion.spec.ts` covering the repro string plus the empty link/bold/code-block variants. 34/34 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)