### PR TITLE
fix: enforce Diamond membership server-side for P2P swaps

### DIFF
--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Enforce Diamond membership server-side when initiating a P2P swap
+
 ## [[2.0.1990-user](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1990-user)] - 2026-07-07
 
 ### Added

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -99,7 +99,11 @@ async fn send_message_v2_impl(mut args: Args) -> Response {
             ValidateNewMessageContentResult::SuccessP2PSwap(content) => {
                 let (escrow_canister_id, now, is_diamond) = read_state(|state| {
                     let now = state.env.now();
-                    (state.data.escrow_canister_id, now, state.data.membership(now).is_diamond_member())
+                    (
+                        state.data.escrow_canister_id,
+                        now,
+                        state.data.membership(now).is_diamond_member(),
+                    )
                 });
                 if !is_diamond {
                     return Error(OCErrorCode::NotDiamondMember.into());

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -97,7 +97,13 @@ async fn send_message_v2_impl(mut args: Args) -> Response {
             }
             ValidateNewMessageContentResult::SuccessPrize(_) => unreachable!(),
             ValidateNewMessageContentResult::SuccessP2PSwap(content) => {
-                let (escrow_canister_id, now) = read_state(|state| (state.data.escrow_canister_id, state.env.now()));
+                let (escrow_canister_id, now, is_diamond) = read_state(|state| {
+                    let now = state.env.now();
+                    (state.data.escrow_canister_id, now, state.data.membership(now).is_diamond_member())
+                });
+                if !is_diamond {
+                    return Error(OCErrorCode::NotDiamondMember.into());
+                }
                 let create_swap_args = escrow_canister::create_swap::Args {
                     location: P2PSwapLocation::from_message(Chat::Direct(args.recipient.into()), None, args.message_id),
                     token0: content.token0.clone(),

--- a/backend/canisters/user/impl/src/updates/send_message_with_transfer.rs
+++ b/backend/canisters/user/impl/src/updates/send_message_with_transfer.rs
@@ -306,6 +306,9 @@ fn prepare(
             }
         }
         MessageContentInitial::P2PSwap(p) => {
+            if !state.data.membership(now).is_diamond_member() {
+                return Err(OCErrorCode::NotDiamondMember.into());
+            }
             let chat_canister_id = chat.canister_id();
             let create_swap_args = escrow_canister::create_swap::Args {
                 location: P2PSwapLocation::from_message(chat, thread_root_message_index, message_id),

--- a/backend/integration_tests/src/message_activity_tests.rs
+++ b/backend/integration_tests/src/message_activity_tests.rs
@@ -10,8 +10,9 @@ use std::time::Duration;
 use test_case::test_case;
 use testing::rng::{random_from_u128, random_string};
 use types::{
-    Chat, ChatType, CryptoContent, CryptoTransaction, GroupReplyContext, MessageContentInitial, P2PSwapContentInitial,
-    PendingCryptoTransaction, PollConfig, PollContent, PollVotes, TextContent, TimestampMillis, TotalVotes,
+    Chat, ChatType, CryptoContent, CryptoTransaction, DiamondMembershipPlanDuration, GroupReplyContext, MessageContentInitial,
+    P2PSwapContentInitial, PendingCryptoTransaction, PollConfig, PollContent, PollVotes, TextContent, TimestampMillis,
+    TotalVotes,
 };
 use user_canister::MessageActivity;
 
@@ -338,6 +339,16 @@ fn accept_p2p_swap_and_check_activity_feed(chat_type: ChatType) {
     } = wrapper.env();
 
     let TestData { them, us, chat } = init_test_data(env, canister_ids, *controller, chat_type);
+
+    // Initiating a P2P swap requires Diamond membership
+    client::upgrade_user(
+        &us,
+        env,
+        canister_ids,
+        *controller,
+        DiamondMembershipPlanDuration::OneMonth,
+        true,
+    );
 
     client::ledger::happy_path::transfer(
         env,

--- a/backend/integration_tests/src/p2p_swap_tests.rs
+++ b/backend/integration_tests/src/p2p_swap_tests.rs
@@ -19,7 +19,7 @@ fn p2p_swap_in_direct_chat_succeeds() {
         ..
     } = wrapper.env();
 
-    let user1 = client::register_user(env, canister_ids);
+    let user1 = client::register_diamond_user(env, canister_ids, *controller);
     let user2 = client::register_user(env, canister_ids);
 
     client::ledger::happy_path::transfer(
@@ -241,7 +241,7 @@ fn cancel_p2p_swap_in_direct_chat_succeeds(delete_message: bool) {
         ..
     } = wrapper.env();
 
-    let user1 = client::register_user(env, canister_ids);
+    let user1 = client::register_diamond_user(env, canister_ids, *controller);
     let user2 = client::register_user(env, canister_ids);
 
     let original_chat_balance = 11_000_000_000;
@@ -486,7 +486,7 @@ fn deposit_refunded_if_swap_expires() {
         ..
     } = wrapper.env();
 
-    let user1 = client::register_user(env, canister_ids);
+    let user1 = client::register_diamond_user(env, canister_ids, *controller);
     let user2 = client::register_user(env, canister_ids);
 
     let original_chat_balance = 11_000_000_000;

--- a/backend/integration_tests/src/p2p_swap_tests.rs
+++ b/backend/integration_tests/src/p2p_swap_tests.rs
@@ -3,9 +3,9 @@ use crate::utils::{chat_token_info, icp_token_info, tick_many};
 use crate::{TestEnv, client};
 use candid::Principal;
 use constants::{CHAT_TRANSFER_FEE, DAY_IN_MS, MINUTE_IN_MS};
+use oc_error_codes::OCErrorCode;
 use std::ops::Deref;
 use std::time::Duration;
-use oc_error_codes::OCErrorCode;
 use test_case::test_case;
 use testing::rng::{random_from_u128, random_string};
 use types::{ChatEvent, MessageContent, MessageContentInitial, P2PSwapContentInitial, P2PSwapStatus};
@@ -700,6 +700,7 @@ fn p2p_swap_rejected_for_non_diamond_user() {
     // Group
     let group_id = client::user::happy_path::create_group(env, &diamond_user, &random_string(), true, true);
     client::group::happy_path::join_group(env, user.principal, group_id);
+    tick_many(env, 5);
 
     let group_response = client::user::send_message_with_transfer_to_group(
         env,
@@ -727,13 +728,15 @@ fn p2p_swap_rejected_for_non_diamond_user() {
     );
 
     // Channel
-    let community_id = client::user::happy_path::create_community(env, &diamond_user, &random_string(), true, vec![random_string()]);
+    let community_id =
+        client::user::happy_path::create_community(env, &diamond_user, &random_string(), true, vec![random_string()]);
     let channel_id = client::community::happy_path::summary(env, diamond_user.principal, community_id)
         .channels
         .first()
         .unwrap()
         .channel_id;
     client::community::happy_path::join_community(env, user.principal, community_id);
+    tick_many(env, 5);
 
     let channel_response = client::user::send_message_with_transfer_to_channel(
         env,

--- a/backend/integration_tests/src/p2p_swap_tests.rs
+++ b/backend/integration_tests/src/p2p_swap_tests.rs
@@ -5,6 +5,7 @@ use candid::Principal;
 use constants::{CHAT_TRANSFER_FEE, DAY_IN_MS, MINUTE_IN_MS};
 use std::ops::Deref;
 use std::time::Duration;
+use oc_error_codes::OCErrorCode;
 use test_case::test_case;
 use testing::rng::{random_from_u128, random_string};
 use types::{ChatEvent, MessageContent, MessageContentInitial, P2PSwapContentInitial, P2PSwapStatus};
@@ -646,6 +647,120 @@ fn p2p_swap_blocked_if_token_disabled(input_token: bool) {
     } else {
         panic!("Unexpected response: {send_message_response:?}");
     }
+}
+
+#[test]
+fn p2p_swap_rejected_for_non_diamond_user() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+        ..
+    } = wrapper.env();
+
+    let diamond_user = client::register_diamond_user(env, canister_ids, *controller);
+    let user = client::register_user(env, canister_ids);
+
+    // The Diamond check runs before any transfer, so the non-Diamond sender needs no funds
+    let swap_content = || {
+        MessageContentInitial::P2PSwap(P2PSwapContentInitial {
+            token0: icp_token_info(),
+            token0_amount: 1_000_000_000,
+            token1: chat_token_info(),
+            token1_amount: 10_000_000_000,
+            expires_in: DAY_IN_MS,
+            caption: None,
+        })
+    };
+
+    // Direct chat
+    let direct_response = client::user::send_message_v2(
+        env,
+        user.principal,
+        user.canister(),
+        &user_canister::send_message_v2::Args {
+            recipient: diamond_user.user_id,
+            thread_root_message_index: None,
+            message_id: random_from_u128(),
+            content: swap_content(),
+            replies_to: None,
+            forwarding: false,
+            block_level_markdown: false,
+            message_filter_failed: None,
+            pin: None,
+            og_previews: Vec::new(),
+        },
+    );
+    assert!(
+        matches!(&direct_response, user_canister::send_message_v2::Response::Error(e) if e.matches_code(OCErrorCode::NotDiamondMember)),
+        "{direct_response:?}"
+    );
+
+    // Group
+    let group_id = client::user::happy_path::create_group(env, &diamond_user, &random_string(), true, true);
+    client::group::happy_path::join_group(env, user.principal, group_id);
+
+    let group_response = client::user::send_message_with_transfer_to_group(
+        env,
+        user.principal,
+        user.canister(),
+        &user_canister::send_message_with_transfer_to_group::Args {
+            group_id,
+            thread_root_message_index: None,
+            message_id: random_from_u128(),
+            content: swap_content(),
+            sender_name: user.username(),
+            sender_display_name: None,
+            replies_to: None,
+            mentioned: Vec::new(),
+            block_level_markdown: false,
+            rules_accepted: None,
+            message_filter_failed: None,
+            pin: None,
+            og_previews: Vec::new(),
+        },
+    );
+    assert!(
+        matches!(&group_response, user_canister::send_message_with_transfer_to_group::Response::Error(e) if e.matches_code(OCErrorCode::NotDiamondMember)),
+        "{group_response:?}"
+    );
+
+    // Channel
+    let community_id = client::user::happy_path::create_community(env, &diamond_user, &random_string(), true, vec![random_string()]);
+    let channel_id = client::community::happy_path::summary(env, diamond_user.principal, community_id)
+        .channels
+        .first()
+        .unwrap()
+        .channel_id;
+    client::community::happy_path::join_community(env, user.principal, community_id);
+
+    let channel_response = client::user::send_message_with_transfer_to_channel(
+        env,
+        user.principal,
+        user.canister(),
+        &user_canister::send_message_with_transfer_to_channel::Args {
+            community_id,
+            channel_id,
+            thread_root_message_index: None,
+            message_id: random_from_u128(),
+            content: swap_content(),
+            sender_name: user.username(),
+            sender_display_name: None,
+            replies_to: None,
+            mentioned: Vec::new(),
+            block_level_markdown: false,
+            community_rules_accepted: None,
+            channel_rules_accepted: None,
+            message_filter_failed: None,
+            pin: None,
+            og_previews: Vec::new(),
+        },
+    );
+    assert!(
+        matches!(&channel_response, user_canister::send_message_with_transfer_to_channel::Response::Error(e) if e.matches_code(OCErrorCode::NotDiamondMember)),
+        "{channel_response:?}"
+    );
 }
 
 pub(crate) fn verify_swap_status<F: FnOnce(&P2PSwapStatus) -> bool>(event: ChatEvent, predicate: F) {


### PR DESCRIPTION
## Problem

P2P swap creation is a Diamond-only feature, but the restriction was enforced **only in the frontend** (`P2PSwapContentBuilder.svelte` redirects non-Diamond users to the upgrade flow). There was no server-side check, so a non-Diamond user could initiate a swap by calling the canister endpoints directly (scripts / `dfx` / agent), bypassing the gate.

Severity: feature-tier / revenue bypass. Escrow, transfer and swap-accept logic are unaffected — no funds at risk.

## Fix

All swap creation funnels through `set_up_p2p_swap` in the **user canister**, whose only callers are two choke points. Added a Diamond check at both, using the existing precedent from `create_group.rs` (`state.data.membership(now).is_diamond_member()` → `OCErrorCode::NotDiamondMember`):

- `send_message.rs` — direct-chat swaps (`SuccessP2PSwap` branch)
- `send_message_with_transfer.rs` `prepare()` — group + channel swaps (`P2PSwap` arm)

### Why groups/channels need no separate change

Group/community canisters never create a swap themselves:
- Their public `send_message_v2` rejects P2PSwap content with "Message type not supported".
- Swaps only arrive pre-formed via `c2c_send_message` from the sender's user canister, which has already done the escrow deposit **and** (now) the Diamond check.

So one check per user-canister choke point covers direct, group and channel.

## Tests

The three direct-chat swap integration tests sent from a non-Diamond `register_user` and would now (correctly) fail. Updated them to `register_diamond_user`, matching the existing group/channel swap tests (which already do this and assert identical balances; the Diamond fee is paid in ICP and doesn't touch the swap assertions).

No negative regression test added yet (repo convention: tests only when asked) — worth a follow-up asserting `Error(NotDiamondMember)` for direct/group/channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)