### PR TITLE
Move message translation behind a server-gated proxy

### DIFF
--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -131,7 +131,7 @@ jobs:
                   echo "OC_APP_TYPE=android" >> .env
                   echo "OC_WEBSITE_VERSION=${{ env.VERSION }}" >> .env
                   echo "OC_APP_KLIPY_APIKEY=${{ secrets.GH_KLIPY_API_KEY || 'dummy_klipy_key' }}" >> .env
-                  echo "OC_APP_TRANSLATE_API_KEY=${{ secrets.GH_TRANSLATE_API_KEY || 'dummy_translate_key' }}" >> .env
+                  echo "OC_TRANSLATE_PROXY_URL=${{ secrets.GH_TRANSLATE_PROXY_URL || '' }}" >> .env
                   echo "OC_ROLLBAR_ACCESS_TOKEN=${{ secrets.GH_ROLLBAR_ACCESS_TOKEN || 'dummy_rollbar_token' }}" >> .env
                   echo "OC_USERGEEK_APIKEY=${{ secrets.GH_USERGEEK_APIKEY || 'dummy_usergeek_key' }}" >> .env
                   echo "OC_METERED_APIKEY=${{ secrets.GH_METERED_APIKEY || 'dummy_metered_key' }}" >> .env

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -131,7 +131,7 @@ jobs:
                   echo "OC_APP_TYPE=android" >> .env
                   echo "OC_WEBSITE_VERSION=${{ env.VERSION }}" >> .env
                   echo "OC_APP_KLIPY_APIKEY=${{ secrets.GH_KLIPY_API_KEY || 'dummy_klipy_key' }}" >> .env
-                  echo "OC_TRANSLATE_PROXY_URL=${{ secrets.GH_TRANSLATE_PROXY_URL || '' }}" >> .env
+                  echo "OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws" >> .env
                   echo "OC_ROLLBAR_ACCESS_TOKEN=${{ secrets.GH_ROLLBAR_ACCESS_TOKEN || 'dummy_rollbar_token' }}" >> .env
                   echo "OC_USERGEEK_APIKEY=${{ secrets.GH_USERGEEK_APIKEY || 'dummy_usergeek_key' }}" >> .env
                   echo "OC_METERED_APIKEY=${{ secrets.GH_METERED_APIKEY || 'dummy_metered_key' }}" >> .env

--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Add `Translate` access token type for the translation proxy, issued to diamond members and platform moderators ([#9100](https://github.com/open-chat-labs/open-chat/pull/9100))
+
 ## [[2.0.1987](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1987-local_user_index)] - 2026-05-29
 
 ### Added

--- a/backend/canisters/local_user_index/api/src/queries/access_token_v2.rs
+++ b/backend/canisters/local_user_index/api/src/queries/access_token_v2.rs
@@ -10,6 +10,7 @@ pub enum Args {
     JoinVideoCall(JoinVideoCallArgs),
     MarkVideoCallAsEnded(MarkVideoCallAsEndedArgs),
     BotActionByCommand(BotActionByCommandArgs),
+    Translate,
 }
 
 #[ts_export(local_user_index, access_token_v2)]

--- a/backend/canisters/local_user_index/impl/src/queries/access_token_v2.rs
+++ b/backend/canisters/local_user_index/impl/src/queries/access_token_v2.rs
@@ -10,7 +10,13 @@ use serde::Serialize;
 use types::c2c_can_issue_access_token::{
     AccessTypeArgs, BotActionByCommandArgs, JoinVideoCallArgs, MarkVideoCallAsEndedArgs, StartVideoCallArgs,
 };
-use types::{AutonomousBotScope, BotActionByCommandClaims, BotCommand, Chat, JoinOrEndVideoCallClaims, StartVideoCallClaims};
+use types::{
+    AutonomousBotScope, BotActionByCommandClaims, BotCommand, Chat, JoinOrEndVideoCallClaims, Milliseconds,
+    StartVideoCallClaims, TranslateClaims,
+};
+
+const DEFAULT_TOKEN_VALIDITY: Milliseconds = 5 * 60 * 1000;
+const TRANSLATE_TOKEN_VALIDITY: Milliseconds = 30 * 60 * 1000;
 
 #[query(composite = true, msgpack = true)]
 #[trace]
@@ -18,6 +24,10 @@ async fn access_token_v2(args_wrapper: Args) -> Response {
     let Ok(args_wrapper) = ArgsInternal::from(args_wrapper) else {
         return InternalError("Failed to parse arguments".to_string());
     };
+
+    if let ArgsInternal::Translate = &args_wrapper {
+        return mutate_state(translate_token);
+    }
 
     let PrepareResult { scope, access_type_args } = match read_state(|state| prepare(&args_wrapper, state)) {
         Ok(r) => r,
@@ -48,7 +58,7 @@ async fn access_token_v2(args_wrapper: Args) -> Response {
                     meta: args.command.meta.clone(),
                 },
             };
-            return build_token(token_type_name, custom_claims, state);
+            return build_token(token_type_name, custom_claims, DEFAULT_TOKEN_VALIDITY, state);
         }
 
         match access_type_args {
@@ -59,21 +69,21 @@ async fn access_token_v2(args_wrapper: Args) -> Response {
                     call_type: args.call_type,
                     is_diamond: args.is_diamond,
                 };
-                build_token(token_type_name, custom_claims, state)
+                build_token(token_type_name, custom_claims, DEFAULT_TOKEN_VALIDITY, state)
             }
             AccessTypeArgs::JoinVideoCall(args) => {
                 let custom_claims = JoinOrEndVideoCallClaims {
                     user_id: args.initiator,
                     chat_id: chat.unwrap(),
                 };
-                build_token(token_type_name, custom_claims, state)
+                build_token(token_type_name, custom_claims, DEFAULT_TOKEN_VALIDITY, state)
             }
             AccessTypeArgs::MarkVideoCallAsEnded(args) => {
                 let custom_claims = JoinOrEndVideoCallClaims {
                     user_id: args.initiator,
                     chat_id: chat.unwrap(),
                 };
-                build_token(token_type_name, custom_claims, state)
+                build_token(token_type_name, custom_claims, DEFAULT_TOKEN_VALIDITY, state)
             }
             _ => unreachable!(),
         }
@@ -144,18 +154,45 @@ fn prepare(args_outer: &ArgsInternal, state: &RuntimeState) -> Result<PrepareRes
     Ok(result)
 }
 
-fn build_token<T: Serialize>(token_type_name: String, custom_claims: T, state: &mut RuntimeState) -> Response {
+fn translate_token(state: &mut RuntimeState) -> Response {
+    let Some(user) = state
+        .data
+        .global_users
+        .get_by_principal(&state.env.caller())
+        .filter(|u| !u.user_type.is_bot())
+    else {
+        return NotAuthorized;
+    };
+
+    let user_id = user.user_id;
+    let is_authorized = state.data.global_users.is_diamond_member(&user_id, state.env.now())
+        || state.data.global_users.platform_moderators().contains(&user_id);
+
+    if !is_authorized {
+        return NotAuthorized;
+    }
+
+    build_token(
+        "Translate".to_string(),
+        TranslateClaims { user_id },
+        TRANSLATE_TOKEN_VALIDITY,
+        state,
+    )
+}
+
+fn build_token<T: Serialize>(
+    token_type_name: String,
+    custom_claims: T,
+    validity: Milliseconds,
+    state: &mut RuntimeState,
+) -> Response {
     if !state.data.oc_key_pair.is_initialised() {
         return InternalError("OC Secret not set".to_string());
     };
 
     let mut rng = StdRng::from_seed(state.env.entropy());
 
-    let claims = Claims::new(
-        state.env.now() + 300_000, // Token valid for 5 mins from now
-        token_type_name,
-        custom_claims,
-    );
+    let claims = Claims::new(state.env.now() + validity, token_type_name, custom_claims);
 
     match jwt::sign_and_encode_token(state.data.oc_key_pair.secret_key_der(), claims, &mut rng) {
         Ok(token) => Success(token),
@@ -169,6 +206,7 @@ enum ArgsInternal {
     JoinVideoCall(access_token_v2::JoinVideoCallArgs),
     MarkVideoCallAsEnded(access_token_v2::MarkVideoCallAsEndedArgs),
     BotActionByCommand(access_token_v2::BotActionByCommandArgs),
+    Translate,
 }
 
 impl ArgsInternal {
@@ -178,6 +216,7 @@ impl ArgsInternal {
             Args::JoinVideoCall(args) => Ok(ArgsInternal::JoinVideoCall(args)),
             Args::MarkVideoCallAsEnded(args) => Ok(ArgsInternal::MarkVideoCallAsEnded(args)),
             Args::BotActionByCommand(args) => Ok(ArgsInternal::BotActionByCommand(args)),
+            Args::Translate => Ok(ArgsInternal::Translate),
         }
     }
 
@@ -187,6 +226,7 @@ impl ArgsInternal {
             Self::JoinVideoCall(_) => "JoinVideoCall",
             Self::MarkVideoCallAsEnded(_) => "MarkVideoCallAsEnded",
             Self::BotActionByCommand(_) => "BotActionByCommand",
+            Self::Translate => "Translate",
         }
     }
 
@@ -196,6 +236,7 @@ impl ArgsInternal {
             Self::JoinVideoCall(args) => Some(args.chat),
             Self::MarkVideoCallAsEnded(args) => Some(args.chat),
             Self::BotActionByCommand(args) => args.scope.chat(None),
+            Self::Translate => None,
         }
     }
 }

--- a/backend/libraries/types/src/claims.rs
+++ b/backend/libraries/types/src/claims.rs
@@ -16,6 +16,11 @@ pub struct StartVideoCallClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct TranslateClaims {
+    pub user_id: UserId,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct BotActionByCommandClaims {
     pub bot_api_gateway: CanisterId,
     pub bot: UserId,

--- a/frontend/app/build_android.sh
+++ b/frontend/app/build_android.sh
@@ -29,9 +29,8 @@ export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33
 export OC_VIDEO_BRIDGE_URL=https://d7ufu5rwdb6eb.cloudfront.net
 export OC_WALLET_CONNECT_PROJECT_ID=adf8b4a7c5514a8229981aabdee2e246
 
-# override klipy and translate api keys from local environment (app only)
+# override klipy api key from local environment (app only)
 export OC_KLIPY_APIKEY="$OC_APP_KLIPY_APIKEY"
-export OC_PUBLIC_TRANSLATE_API_KEY="$OC_APP_TRANSLATE_API_KEY"
 
 export OC_II_DERIVATION_ORIGIN=https://6hsbt-vqaaa-aaaaf-aaafq-cai.ic0.app
 # export OC_CUSTOM_DOMAINS=oc.app,webtest.oc.app

--- a/frontend/app/build_dev.sh
+++ b/frontend/app/build_dev.sh
@@ -31,9 +31,8 @@ export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5
 export OC_WEBSITE_VERSION=
 export OC_BASE_ORIGIN=http://localhost:5001
 
-# override klipy and translate api keys from local environment (app only)
+# override klipy api key from local environment (app only)
 export OC_KLIPY_APIKEY="$OC_APP_KLIPY_APIKEY"
-export OC_PUBLIC_TRANSLATE_API_KEY="$OC_APP_TRANSLATE_API_KEY"
 
 # Run dev app
 npx vite --strictPort --port $OC_DEV_PORT

--- a/frontend/app/build_dev.sh
+++ b/frontend/app/build_dev.sh
@@ -24,6 +24,7 @@ export OC_INTERNET_IDENTITY_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:808
 export OC_NFID_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080
 export OC_NODE_ENV=$NODE_ENV
 export OC_PREVIEW_PROXY_URL=${OC_PREVIEW_PROXY_URL:-https://dy7sqxe9if6te.cloudfront.net}
+export OC_TRANSLATE_PROXY_URL=${OC_TRANSLATE_PROXY_URL:-https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws}
 # For local development preview proxy, set OC_PREVIEW_PROXY_URL=http://localhost:5070
 export OC_VAPID_PUBLIC_KEY=BOzPIB0gN10bFIjMs10jrxzWNlZrVnZmrpK2SLEDd3uAQi0YHQ_n8zx_2zGDLpE3VHvIjels4BFIqiFWmvvAGz4
 export OC_VIDEO_BRIDGE_URL=http://localhost:5050

--- a/frontend/app/build_docker.sh
+++ b/frontend/app/build_docker.sh
@@ -22,6 +22,7 @@ export OC_INTERNET_IDENTITY_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:808
 export OC_NFID_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080
 export OC_NODE_ENV=$NODE_ENV
 export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws
 export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=
 export OC_VIDEO_BRIDGE_URL=http://localhost:5050
 export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5

--- a/frontend/app/build_mobile.sh
+++ b/frontend/app/build_mobile.sh
@@ -32,6 +32,7 @@ export OC_INTERNET_IDENTITY_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:808
 export OC_NFID_URL=http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080
 export OC_NODE_ENV=$NODE_ENV
 export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws
 export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=
 export OC_VIDEO_BRIDGE_URL=http://$(ipconfig getifaddr en0):5050
 export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5

--- a/frontend/app/build_mobile.sh
+++ b/frontend/app/build_mobile.sh
@@ -38,9 +38,8 @@ export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5
 export OC_WEBSITE_VERSION=
 export OC_BASE_ORIGIN=http://localhost:5001
 
-# override klipy and translate api keys from local environment (app only)
+# override klipy api key from local environment (app only)
 export OC_KLIPY_APIKEY="$OC_APP_KLIPY_APIKEY"
-export OC_PUBLIC_TRANSLATE_API_KEY="$OC_APP_TRANSLATE_API_KEY"
 
 # Run dev app
 npx vite --strictPort --port $OC_DEV_PORT

--- a/frontend/app/build_prod.sh
+++ b/frontend/app/build_prod.sh
@@ -13,6 +13,7 @@ export OC_BLOB_URL_PATTERN=https://{canisterId}.raw.icp0.io/{blobType}
 export OC_CANISTER_URL_PATH=https://{canisterId}.raw.icp0.io
 export OC_WALLET_CONNECT_PROJECT_ID=adf8b4a7c5514a8229981aabdee2e246
 export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws
 export OC_BITCOIN_MAINNET_ENABLED=true
 export OC_ACCOUNT_LINKING_CODES_ENABLED=true
 export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=

--- a/frontend/app/build_prod_test.sh
+++ b/frontend/app/build_prod_test.sh
@@ -13,6 +13,7 @@ export OC_BLOB_URL_PATTERN=https://{canisterId}.raw.icp0.io/{blobType}
 export OC_CANISTER_URL_PATH=https://{canisterId}.raw.icp0.io
 export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5
 export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws
 export OC_BITCOIN_MAINNET_ENABLED=false
 export OC_ACCOUNT_LINKING_CODES_ENABLED=true
 export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=

--- a/frontend/app/build_testnet.sh
+++ b/frontend/app/build_testnet.sh
@@ -16,6 +16,7 @@ export OC_CANISTER_URL_PATH=https://{canisterId}.raw.icp0.io
 export OC_VIDEO_BRIDGE_URL=https://d37cwaycp9g5li.cloudfront.net
 export OC_WALLET_CONNECT_PROJECT_ID=b9aafebed2abfaf8341afd9428c947d5
 export OC_PREVIEW_PROXY_URL=https://dy7sqxe9if6te.cloudfront.net
+export OC_TRANSLATE_PROXY_URL=https://5rabdwftr36yvlgf5xmr34swb40nxsgs.lambda-url.eu-west-2.on.aws
 export OC_BITCOIN_MAINNET_ENABLED=false
 export OC_ACCOUNT_LINKING_CODES_ENABLED=true
 export OC_VAPID_PUBLIC_KEY=BD8RU5tDBbFTDFybDoWhFzlL5+mYptojI6qqqqiit68KSt17+vt33jcqLTHKhAXdSzu6pXntfT9e4LccBv+iV3A=

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -91,6 +91,7 @@
             nfidUrl: import.meta.env.OC_NFID_URL!,
             userGeekApiKey: import.meta.env.OC_USERGEEK_APIKEY!,
             videoBridgeUrl: import.meta.env.OC_VIDEO_BRIDGE_URL!,
+            translateProxyUrl: import.meta.env.OC_TRANSLATE_PROXY_URL!,
             meteredApiKey: import.meta.env.OC_METERED_APIKEY!,
             blobUrlPattern: import.meta.env.OC_BLOB_URL_PATTERN!,
             canisterUrlPath: import.meta.env.OC_CANISTER_URL_PATH!,

--- a/frontend/app/src/components/home/ChatMessageMenu.svelte
+++ b/frontend/app/src/components/home/ChatMessageMenu.svelte
@@ -287,22 +287,12 @@
     }
 
     function getTranslation(text: string, messageId: bigint) {
-        const params = new URLSearchParams();
-        params.append("q", text);
-        params.append("target", translationCodes[$locale || "en"] || "en");
-        params.append("format", "text");
-        params.append("key", import.meta.env.OC_PUBLIC_TRANSLATE_API_KEY!);
-        fetch(`https://translation.googleapis.com/language/translate/v2?${params}`, {
-            method: "POST",
-        })
-            .then((resp) => resp.json())
-            .then(({ data: { translations } }) => {
-                if (Array.isArray(translations) && translations.length > 0) {
-                    client.translate(messageId, translations[0].translatedText);
+        client
+            .translateMessage(messageId, text, translationCodes[$locale || "en"] || "en")
+            .then((success) => {
+                if (!success) {
+                    toastStore.showFailureToast(i18nKey("unableToTranslate"));
                 }
-            })
-            .catch((_err) => {
-                toastStore.showFailureToast(i18nKey("unableToTranslate"));
             });
     }
 

--- a/frontend/app/src/components/home/admin/ReviewTranslationCorrections.svelte
+++ b/frontend/app/src/components/home/admin/ReviewTranslationCorrections.svelte
@@ -144,25 +144,13 @@
         if (verifications[key]) {
             return Promise.resolve(verifications[key]);
         }
-        const params = new URLSearchParams();
-        params.append("q", correction.value);
-        params.append("target", "en");
-        params.append("format", "text");
-        params.append("key", import.meta.env.OC_PUBLIC_TRANSLATE_API_KEY!);
-        return fetch(`https://translation.googleapis.com/language/translate/v2?${params}`, {
-            method: "POST",
-        })
-            .then((resp) => resp.json())
-            .then(({ data: { translations } }) => {
-                if (Array.isArray(translations) && translations.length > 0) {
-                    verifications[key] = translations[0].translatedText;
-                    return translations[0].translatedText;
-                }
-            })
-            .catch((err) => {
-                console.error("Couldn't get english translation: ", err);
-                return "Unable to get english translation at the moment";
-            });
+        return client.translateText(correction.value, "en").then((english) => {
+            if (english !== undefined) {
+                verifications[key] = english;
+                return english;
+            }
+            return "Unable to get english translation at the moment";
+        });
     }
 </script>
 

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -83,6 +83,7 @@
             nfidUrl: import.meta.env.OC_NFID_URL!,
             userGeekApiKey: import.meta.env.OC_USERGEEK_APIKEY!,
             videoBridgeUrl: import.meta.env.OC_VIDEO_BRIDGE_URL!,
+            translateProxyUrl: import.meta.env.OC_TRANSLATE_PROXY_URL!,
             meteredApiKey: import.meta.env.OC_METERED_APIKEY!,
             blobUrlPattern: import.meta.env.OC_BLOB_URL_PATTERN!,
             canisterUrlPath: import.meta.env.OC_CANISTER_URL_PATH!,

--- a/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessageOptions.svelte
@@ -384,22 +384,12 @@
     }
 
     function getTranslation(text: string, messageId: bigint) {
-        const params = new URLSearchParams();
-        params.append("q", text);
-        params.append("target", translationCodes[$locale || "en"] || "en");
-        params.append("format", "text");
-        params.append("key", import.meta.env.OC_PUBLIC_TRANSLATE_API_KEY!);
-        fetch(`https://translation.googleapis.com/language/translate/v2?${params}`, {
-            method: "POST",
-        })
-            .then((resp) => resp.json())
-            .then(({ data: { translations } }) => {
-                if (Array.isArray(translations) && translations.length > 0) {
-                    client.translate(messageId, translations[0].translatedText);
+        client
+            .translateMessage(messageId, text, translationCodes[$locale || "en"] || "en")
+            .then((success) => {
+                if (!success) {
+                    toastStore.showFailureToast(i18nKey("unableToTranslate"));
                 }
-            })
-            .catch((_err) => {
-                toastStore.showFailureToast(i18nKey("unableToTranslate"));
             });
     }
 

--- a/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
+++ b/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
@@ -103,6 +103,7 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
             const { requestId, response } = await this.agent.call(canisterIdPrincipal, {
                 methodName: methodName + "_msgpack",
                 arg: payload,
+                effectiveCanisterId: canisterIdPrincipal,
                 callSync: onRequestAccepted === undefined,
             });
 

--- a/frontend/openchat-agent/src/services/common/chatMappersV2.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappersV2.ts
@@ -535,6 +535,14 @@ export function event(value: TChatEvent): ChatEvent {
         };
     }
 
+    if ("HistoryDeleted" in value) {
+        return {
+            kind: "history_deleted",
+            before: value.HistoryDeleted.before,
+            deletedBy: principalBytesToString(value.HistoryDeleted.deleted_by),
+        };
+    }
+
     throw new UnsupportedValueError("Unexpected ApiEventWrapper type received", value);
 }
 

--- a/frontend/openchat-agent/src/services/localUserIndex/mappers.ts
+++ b/frontend/openchat-agent/src/services/localUserIndex/mappers.ts
@@ -100,6 +100,9 @@ export function apiAccessTokenType(domain: AccessTokenType): LocalUserIndexAcces
         case "mark_video_call_ended":
             return { MarkVideoCallAsEnded: { chat: apiChatIdentifier(domain.chatId) } };
 
+        case "translate":
+            return "Translate";
+
         case "bot_action_by_command":
             return {
                 BotActionByCommand: {

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -2709,7 +2709,7 @@ export class OpenChatAgent extends EventTarget {
                 });
             });
         } else {
-            return this.userClient.getPublicProfile();
+            return this.userClient.getPublicProfile().map<PublicProfile | undefined>((p) => p);
         }
     }
 

--- a/frontend/openchat-agent/src/services/registry/mappers.ts
+++ b/frontend/openchat-agent/src/services/registry/mappers.ts
@@ -40,7 +40,9 @@ export function updatesResponse(
                 ) ?? [],
             tokensUninstalled: value.Success.tokens_uninstalled?.map(principalBytesToString) ?? [],
             nervousSystemSummary: value.Success.nervous_system_details.map(nervousSystemSummary),
-            swapProviders: mapOptional(value.Success.swap_providers, (r) => r.map(swapProvider)),
+            swapProviders: mapOptional(value.Success.swap_providers, (r) =>
+                r.flatMap((e) => swapProvider(e) ?? []),
+            ),
             messageFiltersAdded: value.Success.message_filters_added,
             messageFiltersRemoved: value.Success.message_filters_removed,
             currentAirdropChannel: optionUpdateV2(value.Success.airdrop_config, (cfg) => {
@@ -129,8 +131,9 @@ function nervousSystemSummary(value: RegistryNervousSystemSummary): NervousSyste
     };
 }
 
-function swapProvider(value: TExchangeId): DexId {
+// Exchanges which exist in the backend enum but have no swap support in this client map to undefined
+function swapProvider(value: TExchangeId): DexId | undefined {
     if (value === "ICPSwap") return "icpswap";
     if (value === "Taco") return "taco";
-    throw new UnsupportedValueError("Unexpected ApiSwapProvider type received", value);
+    return undefined;
 }

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -8052,6 +8052,7 @@ export const LocalUserIndexAccessTokenV2Args = Type.Union([
     Type.Object({
         BotActionByCommand: BotActionByCommandArgs,
     }),
+    Type.Literal("Translate"),
 ]);
 
 export type LocalUserIndexBotSendMessageArgs = Static<typeof LocalUserIndexBotSendMessageArgs>;

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -227,6 +227,11 @@ export const GroupRegisterWebhookArgs = Type.Object({
     avatar: Type.Optional(Type.String()),
 });
 
+export type GroupDeleteHistoryArgs = Static<typeof GroupDeleteHistoryArgs>;
+export const GroupDeleteHistoryArgs = Type.Object({
+    before: Type.BigInt(),
+});
+
 export type GroupSelectedUpdatesArgs = Static<typeof GroupSelectedUpdatesArgs>;
 export const GroupSelectedUpdatesArgs = Type.Object({
     updates_since: Type.BigInt(),
@@ -517,7 +522,12 @@ export const OgPreviewImage = Type.Object({
 });
 
 export type ExchangeId = Static<typeof ExchangeId>;
-export const ExchangeId = Type.Union([Type.Literal("ICPSwap"), Type.Literal("Taco")]);
+export const ExchangeId = Type.Union([
+    Type.Literal("ICPSwap"),
+    Type.Literal("Taco"),
+    Type.Literal("Sonic"),
+    Type.Literal("KongSwap"),
+]);
 
 export type ProposalDecisionStatus = Static<typeof ProposalDecisionStatus>;
 export const ProposalDecisionStatus = Type.Union([
@@ -913,6 +923,7 @@ export const ChatEventType = Type.Union([
     Type.Literal("Frozen"),
     Type.Literal("Unfrozen"),
     Type.Literal("DisappearingMessagesUpdated"),
+    Type.Literal("HistoryDeleted"),
     Type.Literal("MessagePinned"),
     Type.Literal("MessageUnpinned"),
     Type.Literal("MembersJoined"),
@@ -2923,6 +2934,12 @@ export const CommunityDeleteMessagesArgs = Type.Object({
     new_achievement: Type.Boolean(),
 });
 
+export type CommunityDeleteChannelHistoryArgs = Static<typeof CommunityDeleteChannelHistoryArgs>;
+export const CommunityDeleteChannelHistoryArgs = Type.Object({
+    channel_id: ChannelId,
+    before: Type.BigInt(),
+});
+
 export type CommunityRemoveMemberFromChannelArgs = Static<
     typeof CommunityRemoveMemberFromChannelArgs
 >;
@@ -4261,6 +4278,12 @@ export const UserSwapTokensExchangeSwapArgs = Type.Object({
     zero_for_one: Type.Boolean(),
 });
 
+export type UserSwapTokensTacoArgs = Static<typeof UserSwapTokensTacoArgs>;
+export const UserSwapTokensTacoArgs = Type.Object({
+    swap_canister_id: TSPrincipal,
+    treasury_canister_id: TSPrincipal,
+});
+
 export type UserSwapTokensResponse = Static<typeof UserSwapTokensResponse>;
 export const UserSwapTokensResponse = Type.Union([
     Type.Object({
@@ -5557,6 +5580,12 @@ export const MembersResponse = Type.Union([
     }),
 ]);
 
+export type HistoryDeleted = Static<typeof HistoryDeleted>;
+export const HistoryDeleted = Type.Object({
+    before: Type.BigInt(),
+    deleted_by: UserId,
+});
+
 export type RoleChanged = Static<typeof RoleChanged>;
 export const RoleChanged = Type.Object({
     user_ids: Type.Array(UserId),
@@ -6669,12 +6698,6 @@ export const UserSetProfileBackgroundArgs = Type.Object({
     profile_background: Type.Optional(Document),
 });
 
-export type UserSwapTokensTacoArgs = Static<typeof UserSwapTokensTacoArgs>;
-export const UserSwapTokensTacoArgs = Type.Object({
-    swap_canister_id: TSPrincipal,
-    treasury_canister_id: TSPrincipal,
-});
-
 export type UserSwapTokensExchangeArgs = Static<typeof UserSwapTokensExchangeArgs>;
 export const UserSwapTokensExchangeArgs = Type.Union([
     Type.Object({
@@ -6682,6 +6705,12 @@ export const UserSwapTokensExchangeArgs = Type.Union([
     }),
     Type.Object({
         Taco: UserSwapTokensTacoArgs,
+    }),
+    Type.Object({
+        Sonic: UserSwapTokensExchangeSwapArgs,
+    }),
+    Type.Object({
+        KongSwap: UserSwapTokensExchangeSwapArgs,
     }),
 ]);
 
@@ -8853,6 +8882,9 @@ export const ChatEvent = Type.Union([
     }),
     Type.Object({
         BotUpdated: BotUpdated,
+    }),
+    Type.Object({
+        HistoryDeleted: HistoryDeleted,
     }),
     Type.Literal("FailedToDeserialize"),
 ]);

--- a/frontend/openchat-agent/tsconfig.json
+++ b/frontend/openchat-agent/tsconfig.json
@@ -3,5 +3,5 @@
     "compilerOptions": {
         "outDir": "lib"
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "../global.d.ts"]
 }

--- a/frontend/openchat-client/src/config.ts
+++ b/frontend/openchat-client/src/config.ts
@@ -17,6 +17,7 @@ export type OpenChatConfig = {
     nfidUrl: string;
     userGeekApiKey: string;
     videoBridgeUrl: string;
+    translateProxyUrl: string;
     meteredApiKey: string;
     enableMultiCrypto?: boolean;
     blobUrlPattern: string;

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -7901,6 +7901,35 @@ export class OpenChat {
         });
     }
 
+    #translationToken: { token: string; expiresAt: number } | undefined;
+
+    async getTranslationToken(forceRefresh: boolean = false): Promise<string | undefined> {
+        const margin = 60 * 1000;
+        if (
+            !forceRefresh &&
+            this.#translationToken !== undefined &&
+            this.#translationToken.expiresAt - margin > Date.now()
+        ) {
+            return this.#translationToken.token;
+        }
+
+        const localUserIndex = await this.#worker.send({
+            kind: "getLocalUserIndexForUser",
+            userId: currentUserIdStore.value,
+        });
+        const token = await this.#worker.send({
+            kind: "getAccessToken",
+            accessTokenType: { kind: "translate" },
+            localUserIndex,
+        });
+        if (token === undefined) {
+            this.#translationToken = undefined;
+            return undefined;
+        }
+        this.#translationToken = { token, expiresAt: jwtExpiryMs(token) ?? 0 };
+        return token;
+    }
+
     #startBtcBalanceUpdateJob() {
         bitcoinAddress.subscribe((addr) => {
             if (addr !== undefined) {
@@ -10562,3 +10591,20 @@ export class OpenChat {
 type UserIndexMetrics = {
     oc_public_key: string;
 };
+
+function jwtExpiryMs(token: string): number | undefined {
+    const parts = token.split(".");
+    if (parts.length < 2) return undefined;
+    try {
+        const payload = JSON.parse(
+            new TextDecoder().decode(
+                Uint8Array.from(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+                    c.charCodeAt(0),
+                ),
+            ),
+        );
+        return typeof payload.exp === "number" ? payload.exp * 1000 : undefined;
+    } catch {
+        return undefined;
+    }
+}

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -7930,6 +7930,51 @@ export class OpenChat {
         return token;
     }
 
+    async translateText(text: string, targetLocale: string): Promise<string | undefined> {
+        const token = await this.getTranslationToken();
+        if (token === undefined) return undefined;
+
+        let resp = await this.#translateRequest(token, text, targetLocale);
+        if (resp?.status === 401) {
+            const freshToken = await this.getTranslationToken(true);
+            if (freshToken === undefined) return undefined;
+            resp = await this.#translateRequest(freshToken, text, targetLocale);
+        }
+        if (resp === undefined || !resp.ok) return undefined;
+
+        const { translations } = await resp.json();
+        return Array.isArray(translations) ? translations[0] : undefined;
+    }
+
+    #translateRequest(
+        token: string,
+        text: string,
+        targetLocale: string,
+    ): Promise<Response | undefined> {
+        return fetch(`${this.config.translateProxyUrl}/translate`, {
+            method: "POST",
+            headers: {
+                "x-auth-jwt": token,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ texts: [text], target: targetLocale }),
+        }).catch((err) => {
+            console.warn("Translation request failed: ", err);
+            return undefined;
+        });
+    }
+
+    async translateMessage(
+        messageId: bigint,
+        text: string,
+        targetLocale: string,
+    ): Promise<boolean> {
+        const translation = await this.translateText(text, targetLocale);
+        if (translation === undefined) return false;
+        this.translate(messageId, translation);
+        return true;
+    }
+
     #startBtcBalanceUpdateJob() {
         bitcoinAddress.subscribe((addr) => {
             if (addr !== undefined) {

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -918,7 +918,14 @@ export type ChatEvent =
     | ExternalUrlUpdated
     | BotAdded
     | BotRemoved
-    | BotUpdated;
+    | BotUpdated
+    | HistoryDeleted;
+
+export type HistoryDeleted = {
+    kind: "history_deleted";
+    before: bigint;
+    deletedBy: string;
+};
 
 export type BotAdded = {
     kind: "bot_added";
@@ -2532,7 +2539,8 @@ export type ChatEventType =
     | "UsersUnblocked"
     | "BotAdded"
     | "BotRemoved"
-    | "BotUpdated";
+    | "BotUpdated"
+    | "HistoryDeleted";
 
 export function emptyEventsResponse<T extends ChatEvent>(): EventsSuccessResult<T> {
     return {

--- a/frontend/openchat-shared/src/domain/permission.ts
+++ b/frontend/openchat-shared/src/domain/permission.ts
@@ -219,7 +219,16 @@ export function defaultOptionalMessagePermissions(): OptionalMessagePermissions 
 
 export type PermissionsByRole = Record<ChatPermissionRole, Set<string>>;
 
-export type AccessTokenType = JoinVideoCall | StartVideoCall | MarkVideoCallEnded | BotActionByCommand;
+export type AccessTokenType =
+    | JoinVideoCall
+    | StartVideoCall
+    | MarkVideoCallEnded
+    | BotActionByCommand
+    | Translate;
+
+export type Translate = {
+    kind: "translate";
+};
 
 export type JoinVideoCall = {
     kind: "join_video_call";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,11 @@
         "build:docker": "cd app && sh ./build_docker.sh",
         "android:release": "cd app && bash ./build_android.sh",
         "typecheck": "svelte-check --tsconfig ./app/tsconfig.json --threshold error",
+        "typecheck:agent": "tsc --noEmit -p openchat-agent/tsconfig.json",
+        "typebox": "ts2typebox --input ../tsBindings/types.d.ts --output ./openchat-agent/src/typebox.ts",
         "lint": "eslint . --fix",
         "test": "vitest --run",
-        "build:ci": "npm run typecheck && npm run lint && npm run test && npm run build:prod",
+        "build:ci": "npm run typecheck && npm run typecheck:agent && npm run lint && npm run test && npm run build:prod",
         "changelog": "auto-changelog --tag-pattern '-website' --file-pattern '^frontend'",
         "tauri": "tauri",
         "mobile": "cargo tauri android dev --no-watch"

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -28,7 +28,7 @@ interface ImportMetaEnv {
     readonly OC_OTA_UPDATES: "none" | "major" | "minor" | "patch";
     readonly OC_PREVIEW_PROXY_URL: string;
     readonly OC_PROPOSALS_BOT_CANISTER: string;
-    readonly OC_PUBLIC_TRANSLATE_API_KEY: string;
+    readonly OC_TRANSLATE_PROXY_URL: string;
     readonly OC_REGISTRY_CANISTER: string;
     readonly OC_ROLLBAR_ACCESS_TOKEN: string;
     readonly OC_SERVICE_WORKER_PATH: string;

--- a/scripts/generate-typebox-types.sh
+++ b/scripts/generate-typebox-types.sh
@@ -29,11 +29,11 @@ done
 
 cargo run -p ts_exporter
 
-cd frontend/openchat-agent
+cd frontend
 
 npm run typebox
 
-awk '{sub(/import { Type, Static }/,"import { Type, type Static }")}1' ./src/typebox.ts > ./tmp.ts
-mv tmp.ts ./src/typebox.ts
-awk '{sub(/"BigIntZero"/,"BigInt(0)")}1' ./src/typebox.ts > ./tmp.ts
-mv tmp.ts ./src/typebox.ts
+awk '{sub(/import { Type, Static }/,"import { Type, type Static }")}1' ./openchat-agent/src/typebox.ts > ./tmp.ts
+mv tmp.ts ./openchat-agent/src/typebox.ts
+awk '{sub(/"BigIntZero"/,"BigInt(0)")}1' ./openchat-agent/src/typebox.ts > ./tmp.ts
+mv tmp.ts ./openchat-agent/src/typebox.ts


### PR DESCRIPTION
## Why

Message translation for diamond users was performed entirely client-side: the Google Translate API key was baked into the client bundle (fully public in every shipped build), and the diamond gate was a client-side UI check that could be bypassed.

Translation now goes through a small authenticated proxy ([translation_proxy](https://github.com/open-chat-labs/translation_proxy), already deployed): the key never ships to clients, and access is enforced server-side via an OpenChat-issued JWT.

## What

**`fix: repair typebox generation after frontend consolidation`**
- Restores the `typebox` npm script lost in the frontend consolidation and fixes the paths in `generate-typebox-types.sh`; `typebox.ts` is regenerated from the current backend APIs again.
- Handles the API drift the stale file was hiding: `HistoryDeleted` chat event (new domain event + mapper arm; all dispatch sites have safe fallbacks) and `Sonic`/`KongSwap` exchange ids (filtered at the registry mapper — the client only supports swaps via ICPSwap/TACO).
- Fixes the pre-existing type errors in openchat-agent and adds `typecheck:agent` to `build:ci` — nothing was typechecking agent sources post-consolidation, so drift failed silently.

**`feat: diamond-gated translate access token`**
- New `Translate` token type on `local_user_index` `access_token_v2`, issued to diamond members and platform moderators (the latter for the translation-corrections review flow). No c2c needed — the LUI checks diamond status locally. 30-minute TTL (existing token types stay at 5).
- Client: `getTranslationToken()` fetches via the existing `getAccessToken` worker path, caches, refetches within a minute of expiry or on demand.

**`feat: route message translation via authenticated proxy`**
- `translateText`/`translateMessage` on `OpenChat`: POST `{texts, target}` to the proxy with an `x-auth-jwt` header, retry once with a fresh token on 401. Results feed the existing `translationsStore` flow — display/untranslate behaviour unchanged.
- All three Google call sites (desktop menu, mobile options, admin corrections review) now use the client methods.
- Google API key removed from the bundle, build scripts, and android release workflow. Proxy endpoint comes from `OC_TRANSLATE_PROXY_URL` (`GH_TRANSLATE_PROXY_URL` secret is already set).

## Testing

- Full e2e against a local replica: UI → LUI token issuance → deployed proxy → Google → cached → rendered. Cache hits confirmed on repeat translation.
- Proxy JWT verification has unit tests mirroring the OC signing scheme (valid/expired/wrong-type/tampered/wrong-key).
- svelte-check, `typecheck:agent`, and all 377 frontend tests pass; backend `cargo check` clean.

## Post-merge

- Old Google API keys (still baked into previously shipped bundles) to be revoked after the native-app adoption window; the stale `GH_TRANSLATE_API_KEY` secret can be deleted then too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)