### PR TITLE
Drop pooled canisters the LocalUserIndex doesn't control

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Classify public group and community messages via the OpenAI Moderation API, batching requests across all local canisters ([#9091](https://github.com/open-chat-labs/open-chat/pull/9091))
 - Pass in `expected_claim_type` when verifying JWT claims ([#9102](https://github.com/open-chat-labs/open-chat/pull/9102))
 
+### Fixed
+
+- Drop pooled canisters the LocalUserIndex doesn't control instead of re-pooling them forever
+
 ## [[2.0.1987](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1987-local_user_index)] - 2026-05-29
 
 ### Added

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_create_community.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_create_community.rs
@@ -9,9 +9,10 @@ use local_user_index_canister::ChildCanisterType;
 use local_user_index_canister::c2c_create_community::{Response::*, *};
 use oc_error_codes::OCErrorCode;
 use rand::{Rng, RngCore};
+use tracing::error;
 use types::{
-    BuildVersion, CanisterId, CanisterWasm, ChannelId, CommunityCreatedEventPayload, CommunityId, Cycles, OCResult, UserId,
-    UserType,
+    BuildVersion, C2CError, CanisterId, CanisterWasm, ChannelId, CommunityCreatedEventPayload, CommunityId, Cycles, OCResult,
+    UserId, UserType,
 };
 use utils::canister;
 
@@ -67,7 +68,7 @@ async fn c2c_create_community(args: Args) -> Response {
             })
         }
         Err((canister_id, error)) => {
-            mutate_state(|state| rollback(canister_id, state));
+            mutate_state(|state| rollback(canister_id, &error, state));
             Error(error.into())
         }
     }
@@ -162,9 +163,17 @@ fn commit(
     crate::jobs::topup_canister_pool::start_job_if_required(state, None);
 }
 
-fn rollback(canister_id: Option<CanisterId>, state: &mut RuntimeState) {
+fn rollback(canister_id: Option<CanisterId>, error: &C2CError, state: &mut RuntimeState) {
     if let Some(canister_id) = canister_id {
-        state.data.canister_pool.push(canister_id);
+        // If this canister is not controlled by the LocalUserIndex then installs into it can
+        // never succeed, so drop it from the pool and let the topup job replace it, else
+        // creations would keep pulling the same unusable canisters out of the pool
+        if canister::is_invalid_controller_error(error.reject_code(), error.message()) {
+            error!(%canister_id, "Dropping canister from pool - LocalUserIndex is not a controller");
+            crate::jobs::topup_canister_pool::start_job_if_required(state, None);
+        } else {
+            state.data.canister_pool.push(canister_id);
+        }
     }
 }
 

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_create_group.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_create_group.rs
@@ -9,7 +9,10 @@ use local_user_index_canister::ChildCanisterType;
 use local_user_index_canister::c2c_create_group::{Response::*, *};
 use oc_error_codes::OCErrorCode;
 use rand::Rng;
-use types::{BuildVersion, CanisterId, CanisterWasm, ChatId, Cycles, GroupCreatedEventPayload, OCResult, UserId, UserType};
+use tracing::error;
+use types::{
+    BuildVersion, C2CError, CanisterId, CanisterWasm, ChatId, Cycles, GroupCreatedEventPayload, OCResult, UserId, UserType,
+};
 use utils::canister;
 
 #[update(guard = "caller_is_group_index", msgpack = true)]
@@ -61,7 +64,7 @@ async fn c2c_create_group(args: Args) -> Response {
             })
         }
         Err((canister_id, error)) => {
-            mutate_state(|state| rollback(canister_id, state));
+            mutate_state(|state| rollback(canister_id, &error, state));
             Error(error.into())
         }
     }
@@ -153,9 +156,17 @@ fn commit(
     crate::jobs::topup_canister_pool::start_job_if_required(state, None);
 }
 
-fn rollback(canister_id: Option<CanisterId>, state: &mut RuntimeState) {
+fn rollback(canister_id: Option<CanisterId>, error: &C2CError, state: &mut RuntimeState) {
     if let Some(canister_id) = canister_id {
-        state.data.canister_pool.push(canister_id);
+        // If this canister is not controlled by the LocalUserIndex then installs into it can
+        // never succeed, so drop it from the pool and let the topup job replace it, else
+        // creations would keep pulling the same unusable canisters out of the pool
+        if canister::is_invalid_controller_error(error.reject_code(), error.message()) {
+            error!(%canister_id, "Dropping canister from pool - LocalUserIndex is not a controller");
+            crate::jobs::topup_canister_pool::start_job_if_required(state, None);
+        } else {
+            state.data.canister_pool.push(canister_id);
+        }
     }
 }
 

--- a/backend/canisters/local_user_index/impl/src/updates/register_user.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/register_user.rs
@@ -9,6 +9,7 @@ use ledger_utils::default_ledger_account;
 use local_user_index_canister::ChildCanisterType;
 use local_user_index_canister::register_user::{Response::*, *};
 use rand::Rng;
+use tracing::error;
 use types::{BuildVersion, CanisterId, CanisterWasm, Cycles, MessageContentInitial, TextContent, UserId, UserType};
 use user_canister::ReferredUserRegistered;
 use user_canister::init::Args as InitUserCanisterArgs;
@@ -69,7 +70,16 @@ async fn register_user(args: Args) -> Response {
             mutate_state(|state| {
                 state.data.local_users.mark_registration_failed(&caller);
                 if let Some(id) = canister_id {
-                    state.data.canister_pool.push(id);
+                    // If this canister is not controlled by the LocalUserIndex then installs into
+                    // it can never succeed, so drop it from the pool and let the topup job replace
+                    // it, else registrations would keep pulling the same unusable canisters out of
+                    // the pool
+                    if canister::is_invalid_controller_error(error.reject_code(), error.message()) {
+                        error!(canister_id = %id, "Dropping canister from pool - LocalUserIndex is not a controller");
+                        crate::jobs::topup_canister_pool::start_job_if_required(state, None);
+                    } else {
+                        state.data.canister_pool.push(id);
+                    }
                 }
             });
             Error(error.into())

--- a/backend/libraries/utils/src/canister/mod.rs
+++ b/backend/libraries/utils/src/canister/mod.rs
@@ -38,8 +38,7 @@ pub fn is_out_of_cycles_error(reject_code: RejectCode, message: &str) -> bool {
 // The reject message for this case doesn't always include the `IC0512` code, so also match on
 // the message text
 pub fn is_invalid_controller_error(reject_code: RejectCode, message: &str) -> bool {
-    matches!(reject_code, RejectCode::CanisterError)
-        && (message.contains("IC0512") || message.contains("can control it"))
+    matches!(reject_code, RejectCode::CanisterError) && (message.contains("IC0512") || message.contains("can control it"))
 }
 
 // Returns `Some(delay)` if the call should be retried, else `None`.

--- a/backend/libraries/utils/src/canister/mod.rs
+++ b/backend/libraries/utils/src/canister/mod.rs
@@ -35,6 +35,13 @@ pub fn is_out_of_cycles_error(reject_code: RejectCode, message: &str) -> bool {
     matches!(reject_code, RejectCode::SysTransient) && message.contains("out of cycles")
 }
 
+// The reject message for this case doesn't always include the `IC0512` code, so also match on
+// the message text
+pub fn is_invalid_controller_error(reject_code: RejectCode, message: &str) -> bool {
+    matches!(reject_code, RejectCode::CanisterError)
+        && (message.contains("IC0512") || message.contains("can control it"))
+}
+
 // Returns `Some(delay)` if the call should be retried, else `None`.
 pub fn delay_if_should_retry_failed_c2c_call(reject_code: RejectCode, message: &str) -> Option<Milliseconds> {
     match reject_code {


### PR DESCRIPTION
## Problem

Community creation on prod-test fails every time. The LUI's canister pool contains empty canisters whose only controller is the retired local_group_index (leftovers from the LGI→LUI merge — the #7871/#7889 controller-migration job missed them). Installing into them rejects with an invalid-controller error, and the creation `rollback` pushes the canister straight back into the pool, so:

- every create pops the next poisoned entry, fails, and re-queues it
- the pool never shrinks below target, so the topup job never adds healthy canisters
- the system can never self-heal

Same pattern in community creation, group creation, and user registration.

## Fix

On install failure, classify the error: an invalid-controller rejection (`IC0512` or the reject message text — ic-cdk often omits the error code) drops the canister from the pool and starts the topup job, which replaces it with a fresh canister the LUI controls. All other failures re-pool as before.

Self-heals in production: each failed creation flushes one poisoned entry until the pool is clean.

## Notes

- Observed live on prod-test (`w3ojd-cyaaa-aaaaf-bsc4a-cai`, `w4ppx-paaaa-aaaaf-bsc4q-cai`, controller `sbhuw-gyaaa-aaaaf-bfynq-cai` = old LGI). Prod LUI `nq4qv` error logs show the same class historically (`user_upgrades_failed` buckets from version 0.0.0).
- Does not reclaim the dropped canisters or their cycles — they were never controllable by the LUI. The live-canister variants (`pa5wn`, `5626j` status-poll errors) need separate controller surgery via the old LGI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)