### PR TITLE
Fix reported_messages query so moderators can view reports again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ frontend/app/src/stores/timeline.ts
 /Makefile
 claude.md
 GEMINI.md
+plans/

--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2000](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2000-local_user_index)] - 2026-07-22
+
 ### Added
 
 - Forward `GroupModerationFlagsChanged` events from group_index to groups ([#9089](https://github.com/open-chat-labs/open-chat/pull/9089))
@@ -19,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Drop pooled canisters the LocalUserIndex doesn't control instead of re-pooling them forever
+- Drop pooled canisters the LocalUserIndex doesn't control instead of re-pooling them forever ([#9113](https://github.com/open-chat-labs/open-chat/pull/9113))
 
 ## [[2.0.1987](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1987-local_user_index)] - 2026-05-29
 

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Bump `date_updated` on suspension so clients receive the suspended flag ([#9092](https://github.com/open-chat-labs/open-chat/pull/9092))
+- Expose `reported_messages` query over msgpack so the website can call it again ([#9116](https://github.com/open-chat-labs/open-chat/pull/9116))
 
 ### Removed
 

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Expose `reported_messages` query over msgpack so the website can call it again ([#9116](https://github.com/open-chat-labs/open-chat/pull/9116))
+
+## [[2.0.1993](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1993-user_index)] - 2026-07-21
+
 ### Changed
 
 - Add `c2c_csam_detected` endpoint - applies the CSAM auto-sanction and posts a moderation alert ([#9093](https://github.com/open-chat-labs/open-chat/pull/9093))
@@ -17,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Bump `date_updated` on suspension so clients receive the suspended flag ([#9092](https://github.com/open-chat-labs/open-chat/pull/9092))
-- Expose `reported_messages` query over msgpack so the website can call it again ([#9116](https://github.com/open-chat-labs/open-chat/pull/9116))
 
 ### Removed
 

--- a/backend/canisters/user_index/impl/src/queries/reported_messages.rs
+++ b/backend/canisters/user_index/impl/src/queries/reported_messages.rs
@@ -3,7 +3,7 @@ use crate::{RuntimeState, read_state};
 use ic_cdk::query;
 use user_index_canister::reported_messages::{Response::*, *};
 
-#[query(guard = "caller_is_platform_moderator")]
+#[query(guard = "caller_is_platform_moderator", candid = true, msgpack = true)]
 fn reported_messages(args: Args) -> Response {
     read_state(|state| reported_messages_impl(args, state))
 }

--- a/backend/canisters/user_index/impl/src/queries/reported_messages.rs
+++ b/backend/canisters/user_index/impl/src/queries/reported_messages.rs
@@ -1,6 +1,6 @@
 use crate::guards::caller_is_platform_moderator;
 use crate::{RuntimeState, read_state};
-use ic_cdk::query;
+use canister_api_macros::query;
 use user_index_canister::reported_messages::{Response::*, *};
 
 #[query(guard = "caller_is_platform_moderator", candid = true, msgpack = true)]

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -387,7 +387,7 @@
     }
 
     function reportedMessages(userId?: string): void {
-        console.log(client.reportedMessages(userId));
+        client.reportedMessages(userId).then((json) => console.log(JSON.parse(json)));
     }
 
     function unsuspendUser(userId: string): void {


### PR DESCRIPTION
The msgpack client migration left the `user_index` `reported_messages` query candid-only, while the website's `UserIndexClient` now calls `reported_messages_msgpack` — so the platform-moderator console tool (`platformModerator.reportedMessages()`) fails with method-not-found against prod.

- Add `candid = true, msgpack = true` to the `reported_messages` query export
- Frontend console tool: await the result and `console.log` the parsed array instead of the pending `Promise`

🤖 Generated with [Claude Code](https://claude.com/claude-code)