### PR TITLE
Add evidence vault to storage canisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10442,6 +10442,7 @@ dependencies = [
  "oc_error_codes",
  "serde",
  "serde_bytes",
+ "storage_bucket_canister",
  "ts-rs",
  "ts_export",
  "types",

--- a/backend/canisters/storage_bucket/CHANGELOG.md
+++ b/backend/canisters/storage_bucket/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Evidence vault: quarantine blobs by hash so they are never publicly served and survive every deletion path, with capture metadata, retention clock, legal holds, LE-requested destruction, a hash-chained append-only access log, and a `vault_file_chunk` endpoint restricted to designated reviewers ([#9118](https://github.com/open-chat-labs/open-chat/pull/9118))
+
 ## [[2.0.1857](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1857-storage_bucket)] - 2025-08-05
 
 ### Fixed

--- a/backend/canisters/storage_bucket/api/can.did
+++ b/backend/canisters/storage_bucket/api/can.did
@@ -82,8 +82,26 @@ type FileInfoSuccessResult = record {
     file_hash : Hash;
 };
 
+type VaultFileChunkArgs = record {
+    file_id : FileId;
+    chunk_index : nat32;
+};
+
+type VaultFileChunkResponse = variant {
+    Success : record {
+        bytes : blob;
+        chunk_index : nat32;
+        chunk_count : nat32;
+        total_size : nat64;
+        mime_type : text;
+    };
+    NotAuthorized;
+    NotFound;
+};
+
 service : {
     upload_chunk_v2 : (UploadChunkArgs) -> (UploadChunkResponse);
+    vault_file_chunk : (VaultFileChunkArgs) -> (VaultFileChunkResponse);
     delete_file : (DeleteFileArgs) -> (DeleteFileResponse);
     delete_files : (DeleteFilesArgs) -> (DeleteFilesResponse);
     forward_file : (ForwardFileArgs) -> (ForwardFileResponse);

--- a/backend/canisters/storage_bucket/api/can.did
+++ b/backend/canisters/storage_bucket/api/can.did
@@ -97,6 +97,7 @@ type VaultFileChunkResponse = variant {
     };
     NotAuthorized;
     NotFound;
+    SessionRequired;
 };
 
 service : {

--- a/backend/canisters/storage_bucket/api/src/main.rs
+++ b/backend/canisters/storage_bucket/api/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
     generate_candid_method!(storage_bucket, delete_files, update);
     generate_candid_method!(storage_bucket, forward_file, update);
     generate_candid_method!(storage_bucket, upload_chunk_v2, update);
+    generate_candid_method!(storage_bucket, vault_file_chunk, update);
 
     let directory = env::current_dir().unwrap().join("tsBindings/storageBucket");
     if directory.exists() {
@@ -21,6 +22,7 @@ fn main() {
     generate_ts_method!(storage_bucket, delete_files);
     generate_ts_method!(storage_bucket, forward_file);
     generate_ts_method!(storage_bucket, upload_chunk_v2);
+    generate_ts_method!(storage_bucket, vault_file_chunk);
 
     candid::export_service!();
     std::print!("{}", __export_service());

--- a/backend/canisters/storage_bucket/api/src/updates/c2c_vault_sync.rs
+++ b/backend/canisters/storage_bucket/api/src/updates/c2c_vault_sync.rs
@@ -1,0 +1,58 @@
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+use types::{Chat, FileId, MessageId, MessageIndex, TimestampMillis, UserId};
+
+#[derive(CandidType, Serialize, Deserialize, Debug, Default)]
+pub struct Args {
+    pub ops: Vec<VaultOp>,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub enum VaultOp {
+    Quarantine(QuarantineOp),
+    Unquarantine(FileId),
+    ApplyVerdict(ApplyVerdictOp),
+    SetLegalHold(SetLegalHoldOp),
+    Destroy(DestroyOp),
+    SetReviewers(Vec<Principal>),
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct QuarantineOp {
+    pub file_id: FileId,
+    pub metadata: VaultCaptureMetadata,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct VaultCaptureMetadata {
+    pub report_index: u64,
+    pub chat: Chat,
+    pub message_index: MessageIndex,
+    pub message_id: MessageId,
+    pub sender: UserId,
+    pub detection_timestamp: TimestampMillis,
+    pub classifier_categories: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ApplyVerdictOp {
+    pub file_id: FileId,
+    pub retention_until: TimestampMillis,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct SetLegalHoldOp {
+    pub file_id: FileId,
+    pub legal_hold: bool,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct DestroyOp {
+    pub file_id: FileId,
+    pub le_request_ref: String,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub enum Response {
+    Success,
+}

--- a/backend/canisters/storage_bucket/api/src/updates/c2c_vault_sync.rs
+++ b/backend/canisters/storage_bucket/api/src/updates/c2c_vault_sync.rs
@@ -54,5 +54,12 @@ pub struct DestroyOp {
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub enum Response {
-    Success,
+    Success(SuccessResult),
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct SuccessResult {
+    // Evidence-capture failures (eg. file deleted before the op arrived) — callers must not
+    // treat these as quarantined
+    pub quarantine_failures: Vec<FileId>,
 }

--- a/backend/canisters/storage_bucket/api/src/updates/mod.rs
+++ b/backend/canisters/storage_bucket/api/src/updates/mod.rs
@@ -1,5 +1,7 @@
 pub mod c2c_sync_index;
+pub mod c2c_vault_sync;
 pub mod delete_file;
 pub mod delete_files;
 pub mod forward_file;
 pub mod upload_chunk_v2;
+pub mod vault_file_chunk;

--- a/backend/canisters/storage_bucket/api/src/updates/vault_file_chunk.rs
+++ b/backend/canisters/storage_bucket/api/src/updates/vault_file_chunk.rs
@@ -16,6 +16,9 @@ pub enum Response {
     Success(SuccessResult),
     NotAuthorized,
     NotFound,
+    // Chunks after the first are served only in order within a session opened (and logged) by
+    // fetching chunk 0
+    SessionRequired,
 }
 
 #[ts_export(storage_bucket, vault_file_chunk)]

--- a/backend/canisters/storage_bucket/api/src/updates/vault_file_chunk.rs
+++ b/backend/canisters/storage_bucket/api/src/updates/vault_file_chunk.rs
@@ -1,0 +1,30 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+use ts_export::ts_export;
+use types::FileId;
+
+#[ts_export(storage_bucket, vault_file_chunk)]
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct Args {
+    pub file_id: FileId,
+    pub chunk_index: u32,
+}
+
+#[ts_export(storage_bucket, vault_file_chunk)]
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub enum Response {
+    Success(SuccessResult),
+    NotAuthorized,
+    NotFound,
+}
+
+#[ts_export(storage_bucket, vault_file_chunk)]
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct SuccessResult {
+    #[serde(with = "serde_bytes")]
+    pub bytes: Vec<u8>,
+    pub chunk_index: u32,
+    pub chunk_count: u32,
+    pub total_size: u64,
+    pub mime_type: String,
+}

--- a/backend/canisters/storage_bucket/c2c_client/src/lib.rs
+++ b/backend/canisters/storage_bucket/c2c_client/src/lib.rs
@@ -6,6 +6,7 @@ generate_candid_c2c_call!(file_status);
 
 // Updates
 generate_candid_c2c_call!(c2c_sync_index);
+generate_candid_c2c_call!(c2c_vault_sync);
 generate_candid_c2c_call!(delete_file);
 generate_candid_c2c_call!(delete_files);
 generate_candid_c2c_call!(upload_chunk_v2);

--- a/backend/canisters/storage_bucket/impl/src/jobs/mod.rs
+++ b/backend/canisters/storage_bucket/impl/src/jobs/mod.rs
@@ -3,9 +3,11 @@ use crate::RuntimeState;
 pub mod check_cycles_balance;
 pub mod remove_expired_files;
 pub mod remove_old_pending_files;
+pub mod vault_retention;
 
 pub(crate) fn start(state: &RuntimeState) {
     check_cycles_balance::start_job();
     remove_expired_files::start_job_if_required(state);
     remove_old_pending_files::start_job();
+    vault_retention::start_job_if_required(state);
 }

--- a/backend/canisters/storage_bucket/impl/src/jobs/vault_retention.rs
+++ b/backend/canisters/storage_bucket/impl/src/jobs/vault_retention.rs
@@ -1,0 +1,42 @@
+use crate::{RuntimeState, mutate_state};
+use ic_cdk_timers::TimerId;
+use std::cell::Cell;
+use std::time::Duration;
+use tracing::info;
+use types::TimestampMillis;
+
+thread_local! {
+    static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
+    static NEXT_EXPIRY: Cell<Option<TimestampMillis>> = Cell::default();
+}
+
+// Deletes vaulted blobs whose retention period has passed (and which are not under legal hold).
+// The vault's access log records each deletion and survives it.
+pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
+    let next_expiry = state.data.vault.next_retention_expiry();
+
+    // If the next expiry has changed, reset the timer with the new expiry
+    if NEXT_EXPIRY.replace(next_expiry) != next_expiry {
+        if let Some(timer_id) = TIMER_ID.take() {
+            ic_cdk_timers::clear_timer(timer_id);
+        }
+        if let Some(expiry) = next_expiry {
+            let delay = Duration::from_millis(expiry.saturating_sub(state.env.now()));
+            let timer_id = ic_cdk_timers::set_timer(delay, run);
+            TIMER_ID.set(Some(timer_id));
+            return true;
+        }
+    }
+    false
+}
+
+fn run() {
+    mutate_state(|state| {
+        let now = state.env.now();
+        for hash in state.data.vault.remove_expired(now) {
+            state.data.files.vault_unpin(&hash);
+            info!("Vault: blob removed at retention expiry");
+        }
+        start_job_if_required(state);
+    });
+}

--- a/backend/canisters/storage_bucket/impl/src/lib.rs
+++ b/backend/canisters/storage_bucket/impl/src/lib.rs
@@ -71,6 +71,7 @@ impl RuntimeState {
             vault_legal_holds: vault_metrics.legal_holds,
             vault_reviewers: vault_metrics.reviewers,
             vault_log_length: vault_metrics.log_length,
+            vault_quarantine_failures: vault_metrics.quarantine_failures,
             stable_memory_sizes: memory::memory_sizes(),
         }
     }
@@ -139,6 +140,7 @@ pub struct Metrics {
     pub vault_legal_holds: u64,
     pub vault_reviewers: u64,
     pub vault_log_length: u64,
+    pub vault_quarantine_failures: u64,
     pub stable_memory_sizes: BTreeMap<u8, u64>,
 }
 

--- a/backend/canisters/storage_bucket/impl/src/lib.rs
+++ b/backend/canisters/storage_bucket/impl/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::model::files::{Files, RemoveFileResult};
 use crate::model::index_event_batch::{EventToSync, IndexEventBatch};
 use crate::model::users::Users;
+use crate::model::vault::Vault;
 use candid::{CandidType, Principal};
 use canister_state_macros::canister_state;
 use serde::{Deserialize, Serialize};
@@ -49,6 +50,7 @@ impl RuntimeState {
 
     pub fn metrics(&self) -> Metrics {
         let file_metrics = self.data.files.metrics();
+        let vault_metrics = self.data.vault.metrics();
 
         Metrics {
             now: self.env.now(),
@@ -65,6 +67,10 @@ impl RuntimeState {
             total_file_bytes: file_metrics.total_file_bytes,
             index_sync_queue_length: self.data.index_event_sync_queue.len() as u32,
             expiration_queue_length: file_metrics.expiration_queue_len,
+            vault_quarantined: vault_metrics.quarantined,
+            vault_legal_holds: vault_metrics.legal_holds,
+            vault_reviewers: vault_metrics.reviewers,
+            vault_log_length: vault_metrics.log_length,
             stable_memory_sizes: memory::memory_sizes(),
         }
     }
@@ -75,6 +81,8 @@ struct Data {
     storage_index_canister_id: CanisterId,
     users: Users,
     files: Files,
+    #[serde(default)]
+    vault: Vault,
     index_event_sync_queue: BatchedTimerJobQueue<IndexEventBatch>,
     created: TimestampMillis,
     rng_seed: [u8; 32],
@@ -87,6 +95,7 @@ impl Data {
             storage_index_canister_id,
             users: Users::default(),
             files: Files::default(),
+            vault: Vault::default(),
             index_event_sync_queue: BatchedTimerJobQueue::new(storage_index_canister_id, false),
             created: now,
             rng_seed: [0; 32],
@@ -126,6 +135,10 @@ pub struct Metrics {
     pub total_file_bytes: u64,
     pub index_sync_queue_length: u32,
     pub expiration_queue_length: u64,
+    pub vault_quarantined: u64,
+    pub vault_legal_holds: u64,
+    pub vault_reviewers: u64,
+    pub vault_log_length: u64,
     pub stable_memory_sizes: BTreeMap<u8, u64>,
 }
 

--- a/backend/canisters/storage_bucket/impl/src/model/files.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/files.rs
@@ -371,13 +371,14 @@ impl Files {
     }
 
     // Takes a vault pin on the hash of the given file, incrementing the reference count so the
-    // blob survives every existing deletion path. Returns the hash, or None if the file is gone.
-    pub fn vault_pin(&mut self, file_id: &FileId) -> Option<Hash> {
-        let hash = self.get(file_id)?.hash;
-        if self.vault_pins.insert(hash) {
-            self.reference_counts.incr(hash);
+    // blob survives every existing deletion path. Returns the hash and mime type, or None if
+    // the file is gone.
+    pub fn vault_pin(&mut self, file_id: &FileId) -> Option<(Hash, String)> {
+        let file = self.get(file_id)?;
+        if self.vault_pins.insert(file.hash) {
+            self.reference_counts.incr(file.hash);
         }
-        Some(hash)
+        Some((file.hash, file.mime_type))
     }
 
     // Releases a vault pin, removing the blob if the pin held the last reference

--- a/backend/canisters/storage_bucket/impl/src/model/files.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/files.rs
@@ -28,6 +28,10 @@ pub struct Files {
     expiration_queue: BTreeSet<(TimestampMillis, FileId)>,
     #[serde(alias = "bytes_used")]
     total_file_bytes: u64,
+    // Hashes pinned by the evidence vault. A pin holds one reference so that no deletion path
+    // can remove the blob while it is quarantined (see model::vault).
+    #[serde(default)]
+    vault_pins: BTreeSet<Hash>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -366,6 +370,27 @@ impl Files {
         }
     }
 
+    // Takes a vault pin on the hash of the given file, incrementing the reference count so the
+    // blob survives every existing deletion path. Returns the hash, or None if the file is gone.
+    pub fn vault_pin(&mut self, file_id: &FileId) -> Option<Hash> {
+        let hash = self.get(file_id)?.hash;
+        if self.vault_pins.insert(hash) {
+            self.reference_counts.incr(hash);
+        }
+        Some(hash)
+    }
+
+    // Releases a vault pin, removing the blob if the pin held the last reference
+    pub fn vault_unpin(&mut self, hash: &Hash) {
+        if self.vault_pins.remove(hash) && self.reference_counts.decr(*hash) == 0 {
+            self.remove_blob(hash);
+        }
+    }
+
+    pub fn is_vault_pinned(&self, hash: &Hash) -> bool {
+        self.vault_pins.contains(hash)
+    }
+
     fn remove_blob(&mut self, hash: &Hash) {
         if let Some(size) = self.blobs.data_size(hash) {
             self.blobs.remove(hash);
@@ -403,6 +428,10 @@ impl Files {
                 files_per_accessor.entry(*accessor).or_default().push(file_id);
             }
             *reference_counts.entry(file.hash).or_default() += 1;
+        }
+
+        for hash in self.vault_pins.iter() {
+            *reference_counts.entry(*hash).or_default() += 1;
         }
 
         assert_eq!(files_per_accessor, self.accessors_map.get_all());

--- a/backend/canisters/storage_bucket/impl/src/model/mod.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/mod.rs
@@ -6,3 +6,4 @@ pub mod reference_counts;
 pub mod stable_blob_storage;
 pub mod users;
 pub mod users_map;
+pub mod vault;

--- a/backend/canisters/storage_bucket/impl/src/model/vault.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/vault.rs
@@ -1,0 +1,194 @@
+use candid::Principal;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
+use storage_bucket_canister::c2c_vault_sync::VaultCaptureMetadata;
+use types::{FileId, Hash, TimestampMillis};
+use utils::hasher::hash_bytes;
+
+// Evidence vault: metadata, retention state and the append-only access log for quarantined
+// blobs. The blob bytes themselves stay in `Files`, kept alive by a vault pin on the hash so
+// that no existing deletion path can remove them (see Files::vault_pin).
+#[derive(Serialize, Deserialize, Default)]
+pub struct Vault {
+    records: BTreeMap<Hash, VaultRecord>,
+    file_id_to_hash: BTreeMap<FileId, Hash>,
+    reviewers: HashSet<Principal>,
+    log: Vec<VaultLogEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VaultRecord {
+    pub hash: Hash,
+    pub original_file_id: FileId,
+    pub metadata: VaultCaptureMetadata,
+    pub quarantined_at: TimestampMillis,
+    pub retention_until: Option<TimestampMillis>,
+    pub legal_hold: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VaultLogEntry {
+    pub index: u64,
+    pub timestamp: TimestampMillis,
+    // Hash of the previous entry, making the log a tamper-evident chain
+    pub prev_hash: Hash,
+    pub event: VaultLogEvent,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum VaultLogEvent {
+    Quarantined(FileId),
+    Unquarantined(FileId),
+    VerdictApplied(FileId, TimestampMillis),
+    LegalHoldSet(FileId),
+    LegalHoldCleared(FileId),
+    Destroyed(FileId, String),
+    RetentionExpired(FileId),
+    Viewed(FileId, Principal, u32),
+}
+
+pub enum VaultOpOutcome {
+    Applied,
+    // The blob is no longer referenced by the vault and its pin should be released
+    ReleasePin(Hash),
+    NotFound,
+}
+
+impl Vault {
+    pub fn set_reviewers(&mut self, reviewers: Vec<Principal>) {
+        self.reviewers = reviewers.into_iter().collect();
+    }
+
+    pub fn is_reviewer(&self, principal: &Principal) -> bool {
+        self.reviewers.contains(principal)
+    }
+
+    pub fn hash_for_file(&self, file_id: &FileId) -> Option<Hash> {
+        self.file_id_to_hash.get(file_id).copied()
+    }
+
+    // Returns false if the hash is already quarantined (the pin is already held)
+    pub fn quarantine(&mut self, file_id: FileId, hash: Hash, metadata: VaultCaptureMetadata, now: TimestampMillis) -> bool {
+        self.file_id_to_hash.insert(file_id, hash);
+        self.append_log(VaultLogEvent::Quarantined(file_id), now);
+
+        match self.records.entry(hash) {
+            std::collections::btree_map::Entry::Occupied(_) => false,
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(VaultRecord {
+                    hash,
+                    original_file_id: file_id,
+                    metadata,
+                    quarantined_at: now,
+                    retention_until: None,
+                    legal_hold: false,
+                });
+                true
+            }
+        }
+    }
+
+    pub fn unquarantine(&mut self, file_id: FileId, now: TimestampMillis) -> VaultOpOutcome {
+        let Some(hash) = self.file_id_to_hash.remove(&file_id) else {
+            return VaultOpOutcome::NotFound;
+        };
+        self.records.remove(&hash);
+        self.append_log(VaultLogEvent::Unquarantined(file_id), now);
+        VaultOpOutcome::ReleasePin(hash)
+    }
+
+    pub fn apply_verdict(&mut self, file_id: FileId, retention_until: TimestampMillis, now: TimestampMillis) -> VaultOpOutcome {
+        let Some(record) = self.file_id_to_hash.get(&file_id).and_then(|h| self.records.get_mut(h)) else {
+            return VaultOpOutcome::NotFound;
+        };
+        record.retention_until = Some(retention_until);
+        self.append_log(VaultLogEvent::VerdictApplied(file_id, retention_until), now);
+        VaultOpOutcome::Applied
+    }
+
+    pub fn set_legal_hold(&mut self, file_id: FileId, legal_hold: bool, now: TimestampMillis) -> VaultOpOutcome {
+        let Some(record) = self.file_id_to_hash.get(&file_id).and_then(|h| self.records.get_mut(h)) else {
+            return VaultOpOutcome::NotFound;
+        };
+        record.legal_hold = legal_hold;
+        let event = if legal_hold {
+            VaultLogEvent::LegalHoldSet(file_id)
+        } else {
+            VaultLogEvent::LegalHoldCleared(file_id)
+        };
+        self.append_log(event, now);
+        VaultOpOutcome::Applied
+    }
+
+    // Permanent destruction on law enforcement request, overriding the retention clock.
+    // The log entry (including the request reference) survives the record.
+    pub fn destroy(&mut self, file_id: FileId, le_request_ref: String, now: TimestampMillis) -> VaultOpOutcome {
+        let Some(hash) = self.file_id_to_hash.remove(&file_id) else {
+            return VaultOpOutcome::NotFound;
+        };
+        self.records.remove(&hash);
+        self.append_log(VaultLogEvent::Destroyed(file_id, le_request_ref), now);
+        VaultOpOutcome::ReleasePin(hash)
+    }
+
+    pub fn log_view(&mut self, file_id: FileId, reviewer: Principal, chunk_index: u32, now: TimestampMillis) {
+        self.append_log(VaultLogEvent::Viewed(file_id, reviewer, chunk_index), now);
+    }
+
+    pub fn next_retention_expiry(&self) -> Option<TimestampMillis> {
+        self.records
+            .values()
+            .filter(|r| !r.legal_hold)
+            .filter_map(|r| r.retention_until)
+            .min()
+    }
+
+    // Removes expired records, returning the hashes whose pins should be released
+    pub fn remove_expired(&mut self, now: TimestampMillis) -> Vec<Hash> {
+        let expired: Vec<(FileId, Hash)> = self
+            .records
+            .values()
+            .filter(|r| !r.legal_hold && r.retention_until.is_some_and(|ts| ts <= now))
+            .map(|r| (r.original_file_id, r.hash))
+            .collect();
+
+        for (file_id, hash) in expired.iter() {
+            self.records.remove(hash);
+            self.file_id_to_hash.retain(|_, h| h != hash);
+            self.append_log(VaultLogEvent::RetentionExpired(*file_id), now);
+        }
+
+        expired.into_iter().map(|(_, hash)| hash).collect()
+    }
+
+    pub fn metrics(&self) -> VaultMetrics {
+        VaultMetrics {
+            quarantined: self.records.len() as u64,
+            legal_holds: self.records.values().filter(|r| r.legal_hold).count() as u64,
+            reviewers: self.reviewers.len() as u64,
+            log_length: self.log.len() as u64,
+        }
+    }
+
+    fn append_log(&mut self, event: VaultLogEvent, now: TimestampMillis) {
+        let prev_hash = self.log.last().map(Self::entry_hash).unwrap_or_default();
+        self.log.push(VaultLogEntry {
+            index: self.log.len() as u64,
+            timestamp: now,
+            prev_hash,
+            event,
+        });
+    }
+
+    fn entry_hash(entry: &VaultLogEntry) -> Hash {
+        hash_bytes(msgpack::serialize_then_unwrap(entry))
+    }
+}
+
+#[derive(Debug)]
+pub struct VaultMetrics {
+    pub quarantined: u64,
+    pub legal_holds: u64,
+    pub reviewers: u64,
+    pub log_length: u64,
+}

--- a/backend/canisters/storage_bucket/impl/src/model/vault.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/vault.rs
@@ -14,12 +14,17 @@ pub struct Vault {
     file_id_to_hash: BTreeMap<FileId, Hash>,
     reviewers: HashSet<Principal>,
     log: Vec<VaultLogEntry>,
+    #[serde(default)]
+    quarantine_failures: u64,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct VaultRecord {
     pub hash: Hash,
     pub original_file_id: FileId,
+    // Captured at quarantine time since the file record may be deleted while the blob is vaulted
+    #[serde(default)]
+    pub mime_type: String,
     pub metadata: VaultCaptureMetadata,
     pub quarantined_at: TimestampMillis,
     pub retention_until: Option<TimestampMillis>,
@@ -37,7 +42,10 @@ pub struct VaultLogEntry {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum VaultLogEvent {
-    Quarantined(FileId),
+    // FileId plus the report_index which triggered the quarantine, so that when multiple
+    // reports reference the same blob each report's linkage is preserved in the log even
+    // though the vault keeps a single record per hash
+    Quarantined(FileId, u64),
     Unquarantined(FileId),
     VerdictApplied(FileId, TimestampMillis),
     LegalHoldSet(FileId),
@@ -51,6 +59,8 @@ pub enum VaultOpOutcome {
     Applied,
     // The blob is no longer referenced by the vault and its pin should be released
     ReleasePin(Hash),
+    // The operation was refused because the record is under legal hold
+    Blocked,
     NotFound,
 }
 
@@ -63,36 +73,48 @@ impl Vault {
         self.reviewers.contains(principal)
     }
 
-    pub fn hash_for_file(&self, file_id: &FileId) -> Option<Hash> {
-        self.file_id_to_hash.get(file_id).copied()
+    pub fn record_for_file(&self, file_id: &FileId) -> Option<&VaultRecord> {
+        self.file_id_to_hash.get(file_id).and_then(|h| self.records.get(h))
     }
 
-    // Returns false if the hash is already quarantined (the pin is already held)
-    pub fn quarantine(&mut self, file_id: FileId, hash: Hash, metadata: VaultCaptureMetadata, now: TimestampMillis) -> bool {
+    pub fn quarantine(
+        &mut self,
+        file_id: FileId,
+        hash: Hash,
+        mime_type: String,
+        metadata: VaultCaptureMetadata,
+        now: TimestampMillis,
+    ) {
         self.file_id_to_hash.insert(file_id, hash);
-        self.append_log(VaultLogEvent::Quarantined(file_id), now);
+        self.append_log(VaultLogEvent::Quarantined(file_id, metadata.report_index), now);
 
-        match self.records.entry(hash) {
-            std::collections::btree_map::Entry::Occupied(_) => false,
-            std::collections::btree_map::Entry::Vacant(e) => {
-                e.insert(VaultRecord {
-                    hash,
-                    original_file_id: file_id,
-                    metadata,
-                    quarantined_at: now,
-                    retention_until: None,
-                    legal_hold: false,
-                });
-                true
-            }
-        }
+        // If the hash is already quarantined (another file referencing the same blob), the
+        // original record is kept; the log entry above preserves this report's linkage
+        self.records.entry(hash).or_insert(VaultRecord {
+            hash,
+            original_file_id: file_id,
+            mime_type,
+            metadata,
+            quarantined_at: now,
+            retention_until: None,
+            legal_hold: false,
+        });
+    }
+
+    pub fn record_quarantine_failure(&mut self) {
+        self.quarantine_failures += 1;
     }
 
     pub fn unquarantine(&mut self, file_id: FileId, now: TimestampMillis) -> VaultOpOutcome {
-        let Some(hash) = self.file_id_to_hash.remove(&file_id) else {
+        let Some(hash) = self.file_id_to_hash.get(&file_id).copied() else {
             return VaultOpOutcome::NotFound;
         };
-        self.records.remove(&hash);
+        if self.records.get(&hash).is_some_and(|r| r.legal_hold) {
+            // A legal hold blocks release; it must be explicitly cleared first (LE-requested
+            // destruction is the only operation which overrides a hold)
+            return VaultOpOutcome::Blocked;
+        }
+        self.remove_all_references(&hash);
         self.append_log(VaultLogEvent::Unquarantined(file_id), now);
         VaultOpOutcome::ReleasePin(hash)
     }
@@ -120,13 +142,13 @@ impl Vault {
         VaultOpOutcome::Applied
     }
 
-    // Permanent destruction on law enforcement request, overriding the retention clock.
-    // The log entry (including the request reference) survives the record.
+    // Permanent destruction on law enforcement request, overriding the retention clock and any
+    // legal hold. The log entry (including the request reference) survives the record.
     pub fn destroy(&mut self, file_id: FileId, le_request_ref: String, now: TimestampMillis) -> VaultOpOutcome {
-        let Some(hash) = self.file_id_to_hash.remove(&file_id) else {
+        let Some(hash) = self.file_id_to_hash.get(&file_id).copied() else {
             return VaultOpOutcome::NotFound;
         };
-        self.records.remove(&hash);
+        self.remove_all_references(&hash);
         self.append_log(VaultLogEvent::Destroyed(file_id, le_request_ref), now);
         VaultOpOutcome::ReleasePin(hash)
     }
@@ -153,8 +175,7 @@ impl Vault {
             .collect();
 
         for (file_id, hash) in expired.iter() {
-            self.records.remove(hash);
-            self.file_id_to_hash.retain(|_, h| h != hash);
+            self.remove_all_references(hash);
             self.append_log(VaultLogEvent::RetentionExpired(*file_id), now);
         }
 
@@ -167,7 +188,15 @@ impl Vault {
             legal_holds: self.records.values().filter(|r| r.legal_hold).count() as u64,
             reviewers: self.reviewers.len() as u64,
             log_length: self.log.len() as u64,
+            quarantine_failures: self.quarantine_failures,
         }
+    }
+
+    // Removes the record and every file_id alias mapping to the hash, so that quarantine state
+    // is released for all sibling files referencing the same blob at once
+    fn remove_all_references(&mut self, hash: &Hash) {
+        self.records.remove(hash);
+        self.file_id_to_hash.retain(|_, h| h != hash);
     }
 
     fn append_log(&mut self, event: VaultLogEvent, now: TimestampMillis) {
@@ -191,4 +220,5 @@ pub struct VaultMetrics {
     pub legal_holds: u64,
     pub reviewers: u64,
     pub log_length: u64,
+    pub quarantine_failures: u64,
 }

--- a/backend/canisters/storage_bucket/impl/src/model/vault.rs
+++ b/backend/canisters/storage_bucket/impl/src/model/vault.rs
@@ -16,6 +16,11 @@ pub struct Vault {
     log: Vec<VaultLogEntry>,
     #[serde(default)]
     quarantine_failures: u64,
+    // Ephemeral read sessions: (reviewer, file_id) -> next expected chunk. Not serialized:
+    // an upgrade resets sessions and reviewers restart from chunk 0 (an extra logged act,
+    // never an unlogged one).
+    #[serde(skip)]
+    sessions: BTreeMap<(Principal, FileId), u32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -52,7 +57,7 @@ pub enum VaultLogEvent {
     LegalHoldCleared(FileId),
     Destroyed(FileId, String),
     RetentionExpired(FileId),
-    Viewed(FileId, Principal, u32),
+    Viewed(FileId, Principal),
 }
 
 pub enum VaultOpOutcome {
@@ -114,8 +119,9 @@ impl Vault {
             // destruction is the only operation which overrides a hold)
             return VaultOpOutcome::Blocked;
         }
-        self.remove_all_references(&hash);
-        self.append_log(VaultLogEvent::Unquarantined(file_id), now);
+        for alias in self.remove_all_references(&hash) {
+            self.append_log(VaultLogEvent::Unquarantined(alias), now);
+        }
         VaultOpOutcome::ReleasePin(hash)
     }
 
@@ -148,13 +154,43 @@ impl Vault {
         let Some(hash) = self.file_id_to_hash.get(&file_id).copied() else {
             return VaultOpOutcome::NotFound;
         };
-        self.remove_all_references(&hash);
-        self.append_log(VaultLogEvent::Destroyed(file_id, le_request_ref), now);
+        for alias in self.remove_all_references(&hash) {
+            self.append_log(VaultLogEvent::Destroyed(alias, le_request_ref.clone()), now);
+        }
         VaultOpOutcome::ReleasePin(hash)
     }
 
-    pub fn log_view(&mut self, file_id: FileId, reviewer: Principal, chunk_index: u32, now: TimestampMillis) {
-        self.append_log(VaultLogEvent::Viewed(file_id, reviewer, chunk_index), now);
+    // Authorizes serving a chunk to a reviewer. Chunk 0 always succeeds: it is the deliberate
+    // review act, is logged, and (re)opens a sequential read session. Later chunks are served
+    // only as the session's next expected chunk, so no bytes can ever be fetched outside a
+    // logged session, while the log stays 1:1 with review acts.
+    pub fn authorize_view(
+        &mut self,
+        file_id: FileId,
+        reviewer: Principal,
+        chunk_index: u32,
+        chunk_count: u32,
+        now: TimestampMillis,
+    ) -> bool {
+        let key = (reviewer, file_id);
+        if chunk_index == 0 {
+            self.append_log(VaultLogEvent::Viewed(file_id, reviewer), now);
+            if chunk_count > 1 {
+                self.sessions.insert(key, 1);
+            } else {
+                self.sessions.remove(&key);
+            }
+            true
+        } else if self.sessions.get(&key) == Some(&chunk_index) {
+            if chunk_index + 1 < chunk_count {
+                self.sessions.insert(key, chunk_index + 1);
+            } else {
+                self.sessions.remove(&key);
+            }
+            true
+        } else {
+            false
+        }
     }
 
     pub fn next_retention_expiry(&self) -> Option<TimestampMillis> {
@@ -174,9 +210,10 @@ impl Vault {
             .map(|r| (r.original_file_id, r.hash))
             .collect();
 
-        for (file_id, hash) in expired.iter() {
-            self.remove_all_references(hash);
-            self.append_log(VaultLogEvent::RetentionExpired(*file_id), now);
+        for (_, hash) in expired.iter() {
+            for alias in self.remove_all_references(hash) {
+                self.append_log(VaultLogEvent::RetentionExpired(alias), now);
+            }
         }
 
         expired.into_iter().map(|(_, hash)| hash).collect()
@@ -194,9 +231,17 @@ impl Vault {
 
     // Removes the record and every file_id alias mapping to the hash, so that quarantine state
     // is released for all sibling files referencing the same blob at once
-    fn remove_all_references(&mut self, hash: &Hash) {
+    fn remove_all_references(&mut self, hash: &Hash) -> Vec<FileId> {
         self.records.remove(hash);
+        let aliases: Vec<FileId> = self
+            .file_id_to_hash
+            .iter()
+            .filter(|(_, h)| *h == hash)
+            .map(|(id, _)| *id)
+            .collect();
         self.file_id_to_hash.retain(|_, h| h != hash);
+        self.sessions.retain(|(_, file_id), _| !aliases.contains(file_id));
+        aliases
     }
 
     fn append_log(&mut self, event: VaultLogEvent, now: TimestampMillis) {

--- a/backend/canisters/storage_bucket/impl/src/queries/http_request.rs
+++ b/backend/canisters/storage_bucket/impl/src/queries/http_request.rs
@@ -49,6 +49,9 @@ fn http_request_streaming_callback(token: Token) -> StreamingCallbackHttpRespons
 
 fn start_streaming_file(file_id: FileId, request_headers: &[(String, String)], state: &RuntimeState) -> HttpResponse {
     if let Some(file) = state.data.files.get(&file_id)
+        // Quarantined blobs are never served publicly. The check is hash-based, so any file
+        // referencing a quarantined blob (including re-uploads of the same content) is covered.
+        && !state.data.files.is_vault_pinned(&file.hash)
         && let Some(file_bytes) = state.data.files.blob_bytes(&file.hash)
     {
         let file_bytes_len = file_bytes.len();
@@ -140,7 +143,11 @@ fn continue_streaming_file(token: Token, state: &RuntimeState) -> StreamingCallb
         let chunk_index = token.index.0.to_u32().unwrap();
         let files = &state.data.files;
 
-        if let Some(bytes) = files.get(&file_id).and_then(|f| files.blob_bytes(&f.hash)) {
+        if let Some(bytes) = files
+            .get(&file_id)
+            .filter(|f| !files.is_vault_pinned(&f.hash))
+            .and_then(|f| files.blob_bytes(&f.hash))
+        {
             let (chunk_bytes, stream_next_chunk) = chunk_bytes(bytes, chunk_index);
 
             let token = if stream_next_chunk { Some(build_token(file_id, chunk_index + 1)) } else { None };

--- a/backend/canisters/storage_bucket/impl/src/updates/c2c_vault_sync.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/c2c_vault_sync.rs
@@ -1,0 +1,56 @@
+use crate::guards::caller_is_storage_index_canister;
+use crate::model::vault::VaultOpOutcome;
+use crate::{RuntimeState, mutate_state};
+use canister_tracing_macros::trace;
+use ic_cdk::update;
+use storage_bucket_canister::c2c_vault_sync::{Response::*, *};
+use tracing::info;
+
+#[update(guard = "caller_is_storage_index_canister")]
+#[trace]
+fn c2c_vault_sync(args: Args) -> Response {
+    mutate_state(|state| c2c_vault_sync_impl(args, state))
+}
+
+fn c2c_vault_sync_impl(args: Args, state: &mut RuntimeState) -> Response {
+    let now = state.env.now();
+
+    for op in args.ops {
+        match op {
+            VaultOp::Quarantine(q) => {
+                if let Some(hash) = state.data.files.vault_pin(&q.file_id) {
+                    state.data.vault.quarantine(q.file_id, hash, q.metadata, now);
+                    info!(file_id = %q.file_id, "Vault: quarantined");
+                } else {
+                    info!(file_id = %q.file_id, "Vault: quarantine failed, file not found");
+                }
+            }
+            VaultOp::Unquarantine(file_id) => {
+                if let VaultOpOutcome::ReleasePin(hash) = state.data.vault.unquarantine(file_id, now) {
+                    state.data.files.vault_unpin(&hash);
+                    info!(%file_id, "Vault: unquarantined");
+                }
+            }
+            VaultOp::ApplyVerdict(v) => {
+                state.data.vault.apply_verdict(v.file_id, v.retention_until, now);
+            }
+            VaultOp::SetLegalHold(l) => {
+                state.data.vault.set_legal_hold(l.file_id, l.legal_hold, now);
+            }
+            VaultOp::Destroy(d) => {
+                let file_id = d.file_id;
+                if let VaultOpOutcome::ReleasePin(hash) = state.data.vault.destroy(d.file_id, d.le_request_ref, now) {
+                    state.data.files.vault_unpin(&hash);
+                    info!(%file_id, "Vault: destroyed on law enforcement request");
+                }
+            }
+            VaultOp::SetReviewers(reviewers) => {
+                state.data.vault.set_reviewers(reviewers);
+            }
+        }
+    }
+
+    crate::jobs::vault_retention::start_job_if_required(state);
+
+    Success
+}

--- a/backend/canisters/storage_bucket/impl/src/updates/c2c_vault_sync.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/c2c_vault_sync.rs
@@ -4,7 +4,7 @@ use crate::{RuntimeState, mutate_state};
 use canister_tracing_macros::trace;
 use ic_cdk::update;
 use storage_bucket_canister::c2c_vault_sync::{Response::*, *};
-use tracing::info;
+use tracing::{error, info};
 
 #[update(guard = "caller_is_storage_index_canister")]
 #[trace]
@@ -14,23 +14,32 @@ fn c2c_vault_sync(args: Args) -> Response {
 
 fn c2c_vault_sync_impl(args: Args, state: &mut RuntimeState) -> Response {
     let now = state.env.now();
+    let mut quarantine_failures = Vec::new();
 
     for op in args.ops {
         match op {
             VaultOp::Quarantine(q) => {
-                if let Some(hash) = state.data.files.vault_pin(&q.file_id) {
-                    state.data.vault.quarantine(q.file_id, hash, q.metadata, now);
+                if let Some((hash, mime_type)) = state.data.files.vault_pin(&q.file_id) {
+                    state.data.vault.quarantine(q.file_id, hash, mime_type, q.metadata, now);
                     info!(file_id = %q.file_id, "Vault: quarantined");
                 } else {
-                    info!(file_id = %q.file_id, "Vault: quarantine failed, file not found");
+                    // Evidence capture failed (eg. the file was deleted before the op arrived).
+                    // Loud by design: silent loss is the worst failure mode for an evidence vault.
+                    error!(file_id = %q.file_id, "Vault: quarantine failed, file not found");
+                    state.data.vault.record_quarantine_failure();
+                    quarantine_failures.push(q.file_id);
                 }
             }
-            VaultOp::Unquarantine(file_id) => {
-                if let VaultOpOutcome::ReleasePin(hash) = state.data.vault.unquarantine(file_id, now) {
+            VaultOp::Unquarantine(file_id) => match state.data.vault.unquarantine(file_id, now) {
+                VaultOpOutcome::ReleasePin(hash) => {
                     state.data.files.vault_unpin(&hash);
                     info!(%file_id, "Vault: unquarantined");
                 }
-            }
+                VaultOpOutcome::Blocked => {
+                    error!(%file_id, "Vault: unquarantine refused, record is under legal hold");
+                }
+                _ => (),
+            },
             VaultOp::ApplyVerdict(v) => {
                 state.data.vault.apply_verdict(v.file_id, v.retention_until, now);
             }
@@ -52,5 +61,5 @@ fn c2c_vault_sync_impl(args: Args, state: &mut RuntimeState) -> Response {
 
     crate::jobs::vault_retention::start_job_if_required(state);
 
-    Success
+    Success(SuccessResult { quarantine_failures })
 }

--- a/backend/canisters/storage_bucket/impl/src/updates/mod.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/mod.rs
@@ -1,6 +1,8 @@
 mod c2c_sync_index;
+mod c2c_vault_sync;
 mod delete_file;
 mod delete_files;
 mod forward_file;
 mod upload_chunk;
+mod vault_file_chunk;
 mod wallet_receive;

--- a/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
@@ -6,8 +6,12 @@ use storage_bucket_canister::vault_file_chunk::{Response::*, *};
 const VAULT_CHUNK_SIZE_BYTES: u32 = 1 << 20; // 1MB
 
 // Streams a quarantined blob to an allowlisted vault reviewer. Deliberately an update call (not
-// a query) so that every fetch writes an entry to the vault's tamper-evident access log — each
-// log entry corresponds 1:1 to an explicit, deliberate review act.
+// a query) so that fetching cannot happen without writing to the vault's tamper-evident access
+// log. Only the first chunk of a fetch is logged: chunk 0 corresponds 1:1 with the reviewer's
+// explicit "Review" action, and subsequent chunks are its mechanical continuation (this also
+// bounds log growth to deliberate review acts).
+// Perf note: blob_bytes copies the full blob per chunk call (matching the existing http_request
+// pattern); a ranged read from stable storage is the eventual fix if vault media grows large.
 #[update]
 #[trace]
 fn vault_file_chunk(args: Args) -> Response {
@@ -20,7 +24,12 @@ fn vault_file_chunk_impl(args: Args, state: &mut RuntimeState) -> Response {
         return NotAuthorized;
     }
 
-    let Some(hash) = state.data.vault.hash_for_file(&args.file_id) else {
+    let Some((hash, mime_type)) = state
+        .data
+        .vault
+        .record_for_file(&args.file_id)
+        .map(|r| (r.hash, r.mime_type.clone()))
+    else {
         return NotFound;
     };
     let Some(bytes) = state.data.files.blob_bytes(&hash) else {
@@ -36,10 +45,10 @@ fn vault_file_chunk_impl(args: Args, state: &mut RuntimeState) -> Response {
     let start = (args.chunk_index as usize) * (VAULT_CHUNK_SIZE_BYTES as usize);
     let end = std::cmp::min(start + VAULT_CHUNK_SIZE_BYTES as usize, bytes.len());
 
-    let mime_type = state.data.files.get(&args.file_id).map(|f| f.mime_type).unwrap_or_default();
-
-    let now = state.env.now();
-    state.data.vault.log_view(args.file_id, caller, args.chunk_index, now);
+    if args.chunk_index == 0 {
+        let now = state.env.now();
+        state.data.vault.log_view(args.file_id, caller, args.chunk_index, now);
+    }
 
     Success(SuccessResult {
         bytes: bytes[start..end].to_vec(),

--- a/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
@@ -6,10 +6,10 @@ use storage_bucket_canister::vault_file_chunk::{Response::*, *};
 const VAULT_CHUNK_SIZE_BYTES: u32 = 1 << 20; // 1MB
 
 // Streams a quarantined blob to an allowlisted vault reviewer. Deliberately an update call (not
-// a query) so that fetching cannot happen without writing to the vault's tamper-evident access
-// log. Only the first chunk of a fetch is logged: chunk 0 corresponds 1:1 with the reviewer's
-// explicit "Review" action, and subsequent chunks are its mechanical continuation (this also
-// bounds log growth to deliberate review acts).
+// a query) so that fetching cannot happen outside a logged session: chunk 0 is the deliberate
+// "Review" act — it is logged and opens a sequential read session — and later chunks are served
+// only in session order, so no bytes are ever fetched unlogged while log growth stays bounded
+// to review acts.
 // Perf note: blob_bytes copies the full blob per chunk call (matching the existing http_request
 // pattern); a ranged read from stable storage is the eventual fix if vault media grows large.
 #[update]
@@ -42,13 +42,17 @@ fn vault_file_chunk_impl(args: Args, state: &mut RuntimeState) -> Response {
         return NotFound;
     }
 
+    let now = state.env.now();
+    if !state
+        .data
+        .vault
+        .authorize_view(args.file_id, caller, args.chunk_index, chunk_count, now)
+    {
+        return SessionRequired;
+    }
+
     let start = (args.chunk_index as usize) * (VAULT_CHUNK_SIZE_BYTES as usize);
     let end = std::cmp::min(start + VAULT_CHUNK_SIZE_BYTES as usize, bytes.len());
-
-    if args.chunk_index == 0 {
-        let now = state.env.now();
-        state.data.vault.log_view(args.file_id, caller, args.chunk_index, now);
-    }
 
     Success(SuccessResult {
         bytes: bytes[start..end].to_vec(),

--- a/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
+++ b/backend/canisters/storage_bucket/impl/src/updates/vault_file_chunk.rs
@@ -1,0 +1,51 @@
+use crate::{RuntimeState, calc_chunk_count, mutate_state};
+use canister_tracing_macros::trace;
+use ic_cdk::update;
+use storage_bucket_canister::vault_file_chunk::{Response::*, *};
+
+const VAULT_CHUNK_SIZE_BYTES: u32 = 1 << 20; // 1MB
+
+// Streams a quarantined blob to an allowlisted vault reviewer. Deliberately an update call (not
+// a query) so that every fetch writes an entry to the vault's tamper-evident access log — each
+// log entry corresponds 1:1 to an explicit, deliberate review act.
+#[update]
+#[trace]
+fn vault_file_chunk(args: Args) -> Response {
+    mutate_state(|state| vault_file_chunk_impl(args, state))
+}
+
+fn vault_file_chunk_impl(args: Args, state: &mut RuntimeState) -> Response {
+    let caller = state.env.caller();
+    if !state.data.vault.is_reviewer(&caller) {
+        return NotAuthorized;
+    }
+
+    let Some(hash) = state.data.vault.hash_for_file(&args.file_id) else {
+        return NotFound;
+    };
+    let Some(bytes) = state.data.files.blob_bytes(&hash) else {
+        return NotFound;
+    };
+
+    let total_size = bytes.len() as u64;
+    let chunk_count = calc_chunk_count(VAULT_CHUNK_SIZE_BYTES, total_size);
+    if args.chunk_index >= chunk_count {
+        return NotFound;
+    }
+
+    let start = (args.chunk_index as usize) * (VAULT_CHUNK_SIZE_BYTES as usize);
+    let end = std::cmp::min(start + VAULT_CHUNK_SIZE_BYTES as usize, bytes.len());
+
+    let mime_type = state.data.files.get(&args.file_id).map(|f| f.mime_type).unwrap_or_default();
+
+    let now = state.env.now();
+    state.data.vault.log_view(args.file_id, caller, args.chunk_index, now);
+
+    Success(SuccessResult {
+        bytes: bytes[start..end].to_vec(),
+        chunk_index: args.chunk_index,
+        chunk_count,
+        total_size,
+        mime_type,
+    })
+}

--- a/backend/canisters/storage_index/CHANGELOG.md
+++ b/backend/canisters/storage_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Vault control plane: `c2c_vault_ops` routes evidence-vault operations to the owning buckets and syncs the vault-reviewer allowlist ([#9118](https://github.com/open-chat-labs/open-chat/pull/9118))
+
 ### Changed
 
 - Switch some endpoints over to using common response types ([#8450](https://github.com/open-chat-labs/open-chat/pull/8450))

--- a/backend/canisters/storage_index/api/Cargo.toml
+++ b/backend/canisters/storage_index/api/Cargo.toml
@@ -12,6 +12,7 @@ human_readable = { path = "../../../libraries/human_readable" }
 oc_error_codes = { path = "../../../libraries/error_codes" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+storage_bucket_canister = { path = "../../storage_bucket/api" }
 ts_export = { path = "../../../libraries/ts_export" }
 ts-rs = { workspace = true }
 types = { path = "../../../libraries/types" }

--- a/backend/canisters/storage_index/api/src/updates/c2c_vault_ops.rs
+++ b/backend/canisters/storage_index/api/src/updates/c2c_vault_ops.rs
@@ -1,0 +1,48 @@
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+use storage_bucket_canister::c2c_vault_sync::VaultCaptureMetadata;
+use types::{BlobReference, TimestampMillis};
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub struct Args {
+    pub ops: Vec<VaultOp>,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub enum VaultOp {
+    Quarantine(QuarantineOp),
+    Unquarantine(BlobReference),
+    ApplyVerdict(ApplyVerdictOp),
+    SetLegalHold(SetLegalHoldOp),
+    Destroy(DestroyOp),
+    SetReviewers(Vec<Principal>),
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct QuarantineOp {
+    pub blob_reference: BlobReference,
+    pub metadata: VaultCaptureMetadata,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct ApplyVerdictOp {
+    pub blob_reference: BlobReference,
+    pub retention_until: TimestampMillis,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct SetLegalHoldOp {
+    pub blob_reference: BlobReference,
+    pub legal_hold: bool,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct DestroyOp {
+    pub blob_reference: BlobReference,
+    pub le_request_ref: String,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+pub enum Response {
+    Success,
+}

--- a/backend/canisters/storage_index/api/src/updates/mod.rs
+++ b/backend/canisters/storage_index/api/src/updates/mod.rs
@@ -3,6 +3,7 @@ pub mod add_or_update_users;
 pub mod c2c_notify_low_balance;
 pub mod c2c_sync_bucket;
 pub mod c2c_update_user_principal;
+pub mod c2c_vault_ops;
 pub mod remove_accessors;
 pub mod remove_users;
 pub mod set_bucket_full;

--- a/backend/canisters/storage_index/impl/src/lib.rs
+++ b/backend/canisters/storage_index/impl/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::model::bucket_event_batch::{BucketEventBatch, EventToSync};
 use crate::model::buckets::{BucketRecord, Buckets};
 use crate::model::files::Files;
+use crate::model::vault_event_batch::VaultEventBatch;
 use candid::{CandidType, Principal};
 use canister_state_macros::canister_state;
 use constants::ICP_LEDGER_CANISTER_ID;
@@ -110,6 +111,10 @@ struct Data {
     pub files: Files,
     pub buckets: Buckets,
     pub bucket_event_sync_queue: GroupedTimerJobQueue<BucketEventBatch>,
+    #[serde(default = "default_vault_event_sync_queue")]
+    pub vault_event_sync_queue: GroupedTimerJobQueue<VaultEventBatch>,
+    #[serde(default)]
+    pub vault_reviewers: HashSet<Principal>,
     pub canisters_requiring_upgrade: CanistersRequiringUpgrade,
     pub total_cycles_spent_on_canisters: Cycles,
     pub cycles_dispenser_config: CyclesDispenserConfig,
@@ -119,6 +124,10 @@ struct Data {
     pub cycles_minting_canister_id: CanisterId,
     pub rng_seed: [u8; 32],
     pub test_mode: bool,
+}
+
+fn default_vault_event_sync_queue() -> GroupedTimerJobQueue<VaultEventBatch> {
+    GroupedTimerJobQueue::new(5, false)
 }
 
 fn icp_ledger_canister_id() -> CanisterId {
@@ -147,6 +156,8 @@ impl Data {
             files: Files::default(),
             buckets: Buckets::default(),
             bucket_event_sync_queue: GroupedTimerJobQueue::new(5, false),
+            vault_event_sync_queue: default_vault_event_sync_queue(),
+            vault_reviewers: HashSet::new(),
             canisters_requiring_upgrade: CanistersRequiringUpgrade::default(),
             total_cycles_spent_on_canisters: 0,
             cycles_dispenser_config,
@@ -224,6 +235,12 @@ impl Data {
             bucket.canister_id,
             self.users.keys().map(|p| EventToSync::UserAdded(*p)).collect(),
         );
+        if !self.vault_reviewers.is_empty() {
+            self.vault_event_sync_queue.push(
+                bucket.canister_id,
+                storage_bucket_canister::c2c_vault_sync::VaultOp::SetReviewers(self.vault_reviewers.iter().copied().collect()),
+            );
+        }
         self.buckets.add_bucket(bucket);
     }
 }

--- a/backend/canisters/storage_index/impl/src/model/mod.rs
+++ b/backend/canisters/storage_index/impl/src/model/mod.rs
@@ -1,3 +1,4 @@
 pub mod bucket_event_batch;
 pub mod buckets;
 pub mod files;
+pub mod vault_event_batch;

--- a/backend/canisters/storage_index/impl/src/model/vault_event_batch.rs
+++ b/backend/canisters/storage_index/impl/src/model/vault_event_batch.rs
@@ -12,6 +12,9 @@ impl TimerJobItem for VaultEventBatch {
         let response = storage_bucket_canister_c2c_client::c2c_vault_sync(self.key, &args).await;
 
         match response {
+            // TODO(user_index wiring PR): propagate response.quarantine_failures back to
+            // user_index so the report records reflect evidence-capture failure instead of
+            // silently treating the blob as vaulted
             Ok(_) => Ok(()),
             Err(error) => {
                 let delay_if_should_retry = delay_if_should_retry_failed_c2c_call(error.reject_code(), error.message());

--- a/backend/canisters/storage_index/impl/src/model/vault_event_batch.rs
+++ b/backend/canisters/storage_index/impl/src/model/vault_event_batch.rs
@@ -1,0 +1,22 @@
+use storage_bucket_canister::c2c_vault_sync::VaultOp;
+use timer_job_queues::{TimerJobItem, grouped_timer_job_batch};
+use types::{CanisterId, Milliseconds};
+use utils::canister::delay_if_should_retry_failed_c2c_call;
+
+grouped_timer_job_batch!(VaultEventBatch, CanisterId, VaultOp, 200);
+
+impl TimerJobItem for VaultEventBatch {
+    async fn process(&self) -> Result<(), Option<Milliseconds>> {
+        let args = storage_bucket_canister::c2c_vault_sync::Args { ops: self.items.clone() };
+
+        let response = storage_bucket_canister_c2c_client::c2c_vault_sync(self.key, &args).await;
+
+        match response {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                let delay_if_should_retry = delay_if_should_retry_failed_c2c_call(error.reject_code(), error.message());
+                Err(delay_if_should_retry)
+            }
+        }
+    }
+}

--- a/backend/canisters/storage_index/impl/src/updates/c2c_vault_ops.rs
+++ b/backend/canisters/storage_index/impl/src/updates/c2c_vault_ops.rs
@@ -84,5 +84,10 @@ fn push_for_blob(state: &mut RuntimeState, blob_reference: &BlobReference, op: b
 }
 
 fn push(state: &mut RuntimeState, bucket: types::CanisterId, op: bucket_vault::VaultOp) {
+    // Defense in depth: never c2c-call a canister we don't recognise as one of our buckets
+    if state.data.buckets.get(&bucket).is_none() {
+        tracing::error!(%bucket, "Vault op dropped: unknown bucket canister");
+        return;
+    }
     state.data.vault_event_sync_queue.push(bucket, op);
 }

--- a/backend/canisters/storage_index/impl/src/updates/c2c_vault_ops.rs
+++ b/backend/canisters/storage_index/impl/src/updates/c2c_vault_ops.rs
@@ -1,0 +1,88 @@
+use crate::guards::caller_is_user_controller;
+use crate::{RuntimeState, mutate_state};
+use canister_tracing_macros::trace;
+use ic_cdk::update;
+use storage_bucket_canister::c2c_vault_sync as bucket_vault;
+use storage_index_canister::c2c_vault_ops::{Response::*, *};
+use types::BlobReference;
+
+// Vault control plane: routes evidence-vault operations to the bucket holding each blob, and
+// broadcasts the reviewer allowlist to every bucket. Callable only by a user controller
+// (i.e. the user_index, which mediates all authorization).
+#[update(guard = "caller_is_user_controller")]
+#[trace]
+fn c2c_vault_ops(args: Args) -> Response {
+    mutate_state(|state| c2c_vault_ops_impl(args, state))
+}
+
+fn c2c_vault_ops_impl(args: Args, state: &mut RuntimeState) -> Response {
+    for op in args.ops {
+        match op {
+            VaultOp::Quarantine(q) => {
+                let bucket = q.blob_reference.canister_id;
+                push(
+                    state,
+                    bucket,
+                    bucket_vault::VaultOp::Quarantine(bucket_vault::QuarantineOp {
+                        file_id: q.blob_reference.blob_id,
+                        metadata: q.metadata,
+                    }),
+                );
+            }
+            VaultOp::Unquarantine(blob_reference) => {
+                push_for_blob(
+                    state,
+                    &blob_reference,
+                    bucket_vault::VaultOp::Unquarantine(blob_reference.blob_id),
+                );
+            }
+            VaultOp::ApplyVerdict(v) => {
+                push_for_blob(
+                    state,
+                    &v.blob_reference,
+                    bucket_vault::VaultOp::ApplyVerdict(bucket_vault::ApplyVerdictOp {
+                        file_id: v.blob_reference.blob_id,
+                        retention_until: v.retention_until,
+                    }),
+                );
+            }
+            VaultOp::SetLegalHold(l) => {
+                push_for_blob(
+                    state,
+                    &l.blob_reference,
+                    bucket_vault::VaultOp::SetLegalHold(bucket_vault::SetLegalHoldOp {
+                        file_id: l.blob_reference.blob_id,
+                        legal_hold: l.legal_hold,
+                    }),
+                );
+            }
+            VaultOp::Destroy(d) => {
+                push_for_blob(
+                    state,
+                    &d.blob_reference,
+                    bucket_vault::VaultOp::Destroy(bucket_vault::DestroyOp {
+                        file_id: d.blob_reference.blob_id,
+                        le_request_ref: d.le_request_ref,
+                    }),
+                );
+            }
+            VaultOp::SetReviewers(reviewers) => {
+                state.data.vault_reviewers = reviewers.iter().copied().collect();
+                let buckets: Vec<_> = state.data.buckets.iter().map(|b| b.canister_id).collect();
+                for bucket in buckets {
+                    push(state, bucket, bucket_vault::VaultOp::SetReviewers(reviewers.clone()));
+                }
+            }
+        }
+    }
+
+    Success
+}
+
+fn push_for_blob(state: &mut RuntimeState, blob_reference: &BlobReference, op: bucket_vault::VaultOp) {
+    push(state, blob_reference.canister_id, op);
+}
+
+fn push(state: &mut RuntimeState, bucket: types::CanisterId, op: bucket_vault::VaultOp) {
+    state.data.vault_event_sync_queue.push(bucket, op);
+}

--- a/backend/canisters/storage_index/impl/src/updates/mod.rs
+++ b/backend/canisters/storage_index/impl/src/updates/mod.rs
@@ -3,6 +3,7 @@ pub mod add_or_update_users;
 pub mod c2c_notify_low_balance;
 pub mod c2c_sync_bucket;
 pub mod c2c_update_user_principal;
+pub mod c2c_vault_ops;
 pub mod remove_accessor;
 pub mod remove_users;
 pub mod set_bucket_full;


### PR DESCRIPTION
Storage-side foundation for the moderation human-in-the-loop redesign. **Inert until called** — no caller exists yet (user_index integration follows in a subsequent PR), and no behaviour changes for any existing flow.

### storage_bucket
- **Quarantine via reference-count pin**: the vault holds one reference on the blob hash, so no existing deletion path (`remove_file`, accessor removal, expiry, `files_to_remove`) can ever free a vaulted blob — zero changes to those paths.
- **Public serving blocked by hash**: `http_request` (and the streaming continuation) return 404 for any file whose blob is quarantined — automatically covering re-uploads and forwards of the same content.
- **Vault records**: capture metadata (report index, chat/message/sender, detection timestamp, classifier categories, mime type), retention clock (timer job deletes at expiry unless a legal hold is set), legal holds (which also block unquarantine — LE-requested destruction is the only override), and destruction with the request reference logged. Releasing a hash (unquarantine/destroy/expiry) releases and logs every file_id alias of that hash at once.
- **Hash-chained append-only access log**: every state transition and every review act is an entry carrying the previous entry's hash; the log survives blob deletion. No mutation API exists. Quarantine failures (e.g. file deleted before the op arrived) are error-logged, counted in metrics, and returned per-op to the caller.
- **`vault_file_chunk`**: an update call (deliberately not a query) restricted to the reviewer allowlist. Chunk 0 is the deliberate review act — logged, and it opens a sequential read session; later chunks are served only in session order (`SessionRequired` otherwise). **No bytes can be fetched outside a logged session**, and log growth stays bounded to review acts rather than per-chunk noise.

### storage_index
- **`c2c_vault_ops`** (user-controller guarded, i.e. callable by user_index): routes quarantine/unquarantine/verdict/legal-hold/destroy ops to the bucket owning each blob via a dedicated grouped sync queue (unknown bucket ids are dropped with an error), and broadcasts the vault-reviewer allowlist to all buckets, seeding newly created ones.

Candid validated both directions; clippy clean; existing proptests pass with the reference-count invariant extended to cover vault pins.

Part of the moderation redesign; integration tests for the full vault lifecycle land with the user_index wiring PR, which also picks up the TODO to propagate per-op quarantine failures back to report records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)