### PR TITLE
Stop retrying c2c calls to deleted canisters, and recognise errors by code not message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8493,6 +8493,7 @@ dependencies = [
  "msgpack",
  "nns_governance_canister",
  "nns_governance_canister_c2c_client",
+ "oc_error_codes",
  "proposals_bot_canister",
  "rand 0.8.5",
  "registry_canister",

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Only abandon a group import due to a contract violation if the reject code matches too ([#9124](https://github.com/open-chat-labs/open-chat/pull/9124))
 - Prevent members from demoting others more senior than themselves ([#9115](https://github.com/open-chat-labs/open-chat/pull/9115))
 - Lock against a user having two gate payments in progress concurrently ([#9080](https://github.com/open-chat-labs/open-chat/pull/9080))
 

--- a/backend/canisters/community/impl/src/jobs/import_groups.rs
+++ b/backend/canisters/community/impl/src/jobs/import_groups.rs
@@ -12,13 +12,15 @@ use chat_events::ChatEvents;
 use constants::OPENCHAT_BOT_USER_ID;
 use group_canister::c2c_export_group::{Args, Response};
 use group_chat_core::{GroupChatCore, GroupMembers};
+use ic_cdk::call::RejectCode;
 use ic_cdk_timers::TimerId;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::time::Duration;
 use tracing::{info, trace};
 use types::{
-    Caller, ChannelId, ChannelLatestMessageIndex, Chat, ChatId, CommunityUsersBlocked, Empty, MultiUserChat, UserId, UserType,
+    C2CError, Caller, ChannelId, ChannelLatestMessageIndex, Chat, ChatId, CommunityUsersBlocked, Empty, MultiUserChat, UserId,
+    UserType,
 };
 
 const PAGE_SIZE: u32 = 19 * 102 * 1024; // Roughly 1.9MB (1.9 * 1024 * 1024)
@@ -95,7 +97,7 @@ async fn import_group(group: GroupToImport) {
                 }
                 Err(error) => {
                     mutate_state(|state| {
-                        if error.message().contains("violated contract") {
+                        if is_unrecoverable(&error) {
                             state.data.groups_being_imported.take(&group_id);
                         } else {
                             state
@@ -406,6 +408,18 @@ pub(crate) fn mark_import_complete(group_id: ChatId, channel_id: ChannelId) {
     });
 
     info!(%group_id, "'mark_import_complete' completed");
+}
+
+// Whether retrying the import could ever succeed. A batch which is too large for the group to
+// reply with fails as a contract violation - the page size is fixed, so it would fail identically
+// every time and the import has to be abandoned rather than retried forever.
+//
+// Unfortunately this can only be recognised from the reject message: a contract violation reaches
+// us as a plain `CanisterError`, and the IC does not expose its fine grained error codes to
+// canisters, so the reject code alone cannot distinguish it from a transient trap. The reject code
+// is still checked so that unrelated failures can't match on the text alone.
+fn is_unrecoverable(error: &C2CError) -> bool {
+    matches!(error.reject_code(), RejectCode::CanisterError) && error.message().contains("violated contract")
 }
 
 fn trigger_upgrade_to_finalize_import(group_id: ChatId) {

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `og_previews` field to messages for handling OpenGraph previews ([#9002](https://github.com/open-chat-labs/open-chat/pull/9002))
 
+### Fixed
+
+- Detect an already pushed proposal via `MessageIdAlreadyExists` rather than the error message ([#9124](https://github.com/open-chat-labs/open-chat/pull/9124))
+
 ## [[2.0.1957](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1957-proposals_bot)] - 2026-01-16
 
 ### Added

--- a/backend/canisters/proposals_bot/impl/Cargo.toml
+++ b/backend/canisters/proposals_bot/impl/Cargo.toml
@@ -38,6 +38,7 @@ ledger_utils = { path = "../../../libraries/ledger_utils" }
 msgpack = { path = "../../../libraries/msgpack" }
 nns_governance_canister = { path = "../../../external_canisters/nns_governance/api" }
 nns_governance_canister_c2c_client = { path = "../../../external_canisters/nns_governance/c2c_client" }
+oc_error_codes = { path = "../../../libraries/error_codes" }
 proposals_bot_canister = { path = "../api" }
 rand = { workspace = true }
 registry_canister = { path = "../../registry/api" }

--- a/backend/canisters/proposals_bot/impl/src/jobs/push_proposals.rs
+++ b/backend/canisters/proposals_bot/impl/src/jobs/push_proposals.rs
@@ -3,6 +3,7 @@ use crate::{RuntimeState, generate_message_id, mutate_state, read_state};
 use chat_events::{MessageContentInternal, ProposalContentInternal};
 use ic_cdk::call::RejectCode;
 use ic_cdk_timers::TimerId;
+use oc_error_codes::OCErrorCode;
 use sns_governance_canister::types::{ProposalId, get_proposal_response};
 use std::cell::Cell;
 use std::collections::BTreeMap;
@@ -189,7 +190,14 @@ fn extract_channel_result(
 ) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
     match response {
         Ok(community_canister::c2c_send_message::Response::Success(result)) => Ok((message_id, Some(result.message_index))),
-        other => extract_result_inner(message_id, other, canister_id),
+        // The messageId is derived from the proposal, so if it is already in use then this
+        // proposal has already been pushed
+        Ok(community_canister::c2c_send_message::Response::Error(error))
+            if error.matches_code(OCErrorCode::MessageIdAlreadyExists) =>
+        {
+            Ok((message_id, None))
+        }
+        other => extract_result_inner(other, canister_id),
     }
 }
 
@@ -200,20 +208,22 @@ fn extract_group_result(
 ) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
     match response {
         Ok(group_canister::c2c_send_message::Response::Success(result)) => Ok((message_id, Some(result.message_index))),
-        other => extract_result_inner(message_id, other, canister_id),
+        // The messageId is derived from the proposal, so if it is already in use then this
+        // proposal has already been pushed
+        Ok(group_canister::c2c_send_message::Response::Error(error))
+            if error.matches_code(OCErrorCode::MessageIdAlreadyExists) =>
+        {
+            Ok((message_id, None))
+        }
+        other => extract_result_inner(other, canister_id),
     }
 }
 
 fn extract_result_inner<T: Debug>(
-    message_id: MessageId,
     response: Result<T, C2CError>,
     canister_id: CanisterId,
 ) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
     match response {
-        // If the messageId has already been used, treat that as success
-        Err(error) if error.reject_code() == RejectCode::CanisterError && error.message().contains("MessageId") => {
-            Ok((message_id, None))
-        }
         Err(error) => Err(error),
         _ => {
             error!(?response, %canister_id, "Failed to push proposal");

--- a/backend/canisters/proposals_bot/impl/src/jobs/push_proposals.rs
+++ b/backend/canisters/proposals_bot/impl/src/jobs/push_proposals.rs
@@ -3,11 +3,10 @@ use crate::{RuntimeState, generate_message_id, mutate_state, read_state};
 use chat_events::{MessageContentInternal, ProposalContentInternal};
 use ic_cdk::call::RejectCode;
 use ic_cdk_timers::TimerId;
-use oc_error_codes::OCErrorCode;
+use oc_error_codes::{OCError, OCErrorCode};
 use sns_governance_canister::types::{ProposalId, get_proposal_response};
 use std::cell::Cell;
 use std::collections::BTreeMap;
-use std::fmt::Debug;
 use std::time::Duration;
 use tracing::{error, trace};
 use types::{C2CError, CanisterId, ChannelId, ChatId, CommunityId, MessageId, MessageIndex, MultiUserChat, Proposal};
@@ -188,16 +187,14 @@ fn extract_channel_result(
     response: Result<community_canister::c2c_send_message::Response, C2CError>,
     canister_id: CanisterId,
 ) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
-    match response {
-        Ok(community_canister::c2c_send_message::Response::Success(result)) => Ok((message_id, Some(result.message_index))),
-        // The messageId is derived from the proposal, so if it is already in use then this
-        // proposal has already been pushed
-        Ok(community_canister::c2c_send_message::Response::Error(error))
+    match response? {
+        community_canister::c2c_send_message::Response::Success(result) => Ok((message_id, Some(result.message_index))),
+        community_canister::c2c_send_message::Response::Error(error)
             if error.matches_code(OCErrorCode::MessageIdAlreadyExists) =>
         {
             Ok((message_id, None))
         }
-        other => extract_result_inner(other, canister_id),
+        community_canister::c2c_send_message::Response::Error(error) => Err(handle_error(error, canister_id)),
     }
 }
 
@@ -206,33 +203,21 @@ fn extract_group_result(
     response: Result<group_canister::c2c_send_message::Response, C2CError>,
     canister_id: CanisterId,
 ) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
-    match response {
-        Ok(group_canister::c2c_send_message::Response::Success(result)) => Ok((message_id, Some(result.message_index))),
-        // The messageId is derived from the proposal, so if it is already in use then this
-        // proposal has already been pushed
-        Ok(group_canister::c2c_send_message::Response::Error(error))
-            if error.matches_code(OCErrorCode::MessageIdAlreadyExists) =>
-        {
+    match response? {
+        group_canister::c2c_send_message::Response::Success(result) => Ok((message_id, Some(result.message_index))),
+        group_canister::c2c_send_message::Response::Error(error) if error.matches_code(OCErrorCode::MessageIdAlreadyExists) => {
             Ok((message_id, None))
         }
-        other => extract_result_inner(other, canister_id),
+        group_canister::c2c_send_message::Response::Error(error) => Err(handle_error(error, canister_id)),
     }
 }
 
-fn extract_result_inner<T: Debug>(
-    response: Result<T, C2CError>,
-    canister_id: CanisterId,
-) -> Result<(MessageId, Option<MessageIndex>), C2CError> {
-    match response {
-        Err(error) => Err(error),
-        _ => {
-            error!(?response, %canister_id, "Failed to push proposal");
-            Err(C2CError::new(
-                canister_id,
-                "c2c_send_message",
-                RejectCode::CanisterError,
-                "Unexpected response type".to_string(),
-            ))
-        }
-    }
+fn handle_error(error: OCError, canister_id: CanisterId) -> C2CError {
+    error!(?error, %canister_id, "Failed to push proposal");
+    C2CError::new(
+        canister_id,
+        "c2c_send_message",
+        RejectCode::CanisterError,
+        "Unexpected response type".to_string(),
+    )
 }

--- a/backend/libraries/utils/src/cycles/mod.rs
+++ b/backend/libraries/utils/src/cycles/mod.rs
@@ -1,5 +1,3 @@
-use ic_cdk::call::RejectCode;
-
 mod accept_cycles;
 mod can_spend_cycles;
 mod check_cycles_balance;
@@ -9,7 +7,3 @@ pub use self::cycles_dispenser_client::init_cycles_dispenser_client;
 pub use accept_cycles::accept_cycles;
 pub use can_spend_cycles::can_spend_cycles;
 pub use check_cycles_balance::{MIN_CYCLES_BALANCE, check_cycles_balance, send_low_balance_notification};
-
-pub fn is_out_of_cycles_error(code: RejectCode, message: &str) -> bool {
-    code == RejectCode::SysTransient && message.starts_with("IC0207:")
-}

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -38,6 +38,7 @@
         identityStateStore,
         inititaliseLogger,
         notFoundStore,
+        requiresLogout,
         routeForChatIdentifier,
         routeForScope,
         routeStore,
@@ -626,11 +627,7 @@
         }
 
         logger?.error("Unhandled error: ", ev);
-        if (
-            ev instanceof PromiseRejectionEvent &&
-            (ev.reason?.name === "SessionExpiryError" ||
-                ev.reason?.name === "InvalidDelegationError")
-        ) {
+        if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             client.logout();
             ev.preventDefault();
         }

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -32,6 +32,7 @@
         fontSize,
         identityStateStore,
         inititaliseLogger,
+        requiresLogout,
         routeForChatIdentifier,
         routeForScope,
         subscribe,
@@ -311,11 +312,7 @@
         }
 
         logger?.error("Unhandled error: ", ev);
-        if (
-            ev instanceof PromiseRejectionEvent &&
-            (ev.reason?.name === "SessionExpiryError" ||
-                ev.reason?.name === "InvalidDelegationError")
-        ) {
+        if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             if (client.isNativeApp()) clearChatShortcuts();
             client.logout();
             ev.preventDefault();

--- a/frontend/openchat-agent/src/services/canisterAgent/base.ts
+++ b/frontend/openchat-agent/src/services/canisterAgent/base.ts
@@ -2,6 +2,7 @@ import { HttpAgent, type Identity } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import {
     AuthError,
+    CanisterUnavailableError,
     DestinationInvalidError,
     ResponseTooLargeError,
     SessionExpiryError,
@@ -45,6 +46,7 @@ export abstract class CanisterAgent {
                     !(responseErr instanceof ResponseTooLargeError) &&
                     !(responseErr instanceof SessionExpiryError) &&
                     !(responseErr instanceof DestinationInvalidError) &&
+                    !(responseErr instanceof CanisterUnavailableError) &&
                     !(responseErr instanceof AuthError) &&
                     !(responseErr instanceof TypeboxValidationError) &&
                     retries < MAX_RETRIES

--- a/frontend/openchat-agent/src/services/error.spec.ts
+++ b/frontend/openchat-agent/src/services/error.spec.ts
@@ -1,0 +1,55 @@
+import {
+    RejectError,
+    ReplicaRejectCode,
+    UncertifiedRejectErrorCode,
+    type Identity,
+} from "@icp-sdk/core/agent";
+import { DestinationInvalidError, HttpError } from "@shared";
+import { toCanisterResponseError } from "./error";
+
+// Only `getPrincipal` and `getDelegation` are ever touched for the errors under test
+const identity = {} as Identity;
+
+function reject(rejectCode: ReplicaRejectCode, message: string, errorCode?: string): Error {
+    return RejectError.fromCode(
+        new UncertifiedRejectErrorCode(
+            new Uint8Array([1]),
+            rejectCode,
+            message,
+            errorCode,
+            undefined,
+        ),
+    );
+}
+
+describe("toCanisterResponseError", () => {
+    // A query to a deleted group/community canister is rejected with `DestinationInvalid`. It must
+    // be mapped to `DestinationInvalidError` so that the retry loop is short-circuited - retrying
+    // can never succeed, and 7 retries with exponential backoff blocks the chat from loading.
+    test("a rejection from a canister which doesn't exist is not retryable", () => {
+        const error = toCanisterResponseError(
+            reject(
+                ReplicaRejectCode.DestinationInvalid,
+                "Canister 4vbct-tqaaa-aaaar-bljfa-cai not found",
+                "IC0301",
+            ),
+            identity,
+        );
+
+        expect(error).toBeInstanceOf(DestinationInvalidError);
+    });
+
+    test("other rejections remain retryable", () => {
+        for (const rejectCode of [
+            ReplicaRejectCode.SysFatal,
+            ReplicaRejectCode.SysTransient,
+            ReplicaRejectCode.CanisterReject,
+            ReplicaRejectCode.CanisterError,
+        ]) {
+            const error = toCanisterResponseError(reject(rejectCode, "rejected"), identity);
+
+            expect(error).toBeInstanceOf(HttpError);
+            expect(error).not.toBeInstanceOf(DestinationInvalidError);
+        }
+    });
+});

--- a/frontend/openchat-agent/src/services/error.spec.ts
+++ b/frontend/openchat-agent/src/services/error.spec.ts
@@ -7,7 +7,12 @@ import {
     UncertifiedRejectErrorCode,
     type Identity,
 } from "@icp-sdk/core/agent";
-import { DestinationInvalidError, HttpError, InvalidDelegationError } from "@shared";
+import {
+    CanisterUnavailableError,
+    DestinationInvalidError,
+    HttpError,
+    InvalidDelegationError,
+} from "@shared";
 import { toCanisterResponseError } from "./error";
 
 // An expired session is the default - only the delegation tests need a live one
@@ -48,6 +53,44 @@ describe("toCanisterResponseError", () => {
 
             expect(error).toBeInstanceOf(HttpError);
             expect(error).not.toBeInstanceOf(DestinationInvalidError);
+        }
+    });
+
+    // A frozen or uninstalled canister can't serve the call and won't recover during this request,
+    // but its reject code is shared with failures which are worth retrying - so without keying on
+    // the IC error code these fall through to the retry loop and stall the caller for ~13s.
+    test("a frozen or uninstalled canister is not retryable", () => {
+        // Reject codes as the replica actually sends them for these cases
+        const frozen = reject(ReplicaRejectCode.SysTransient, "Canister x is frozen.", "IC0207");
+        const noWasm = reject(
+            ReplicaRejectCode.CanisterError,
+            "...contains no Wasm module.",
+            "IC0537",
+        );
+
+        expect(toCanisterResponseError(frozen, identity)).toBeInstanceOf(CanisterUnavailableError);
+        expect(toCanisterResponseError(noWasm, identity)).toBeInstanceOf(CanisterUnavailableError);
+    });
+
+    // It may come back once topped up or reinstalled, so it must not be reported as a canister
+    // which no longer exists - that drives things like the "group moved" lookup
+    test("an unavailable canister is not reported as a destination which doesn't exist", () => {
+        const frozen = reject(ReplicaRejectCode.SysTransient, "Canister x is frozen.", "IC0207");
+
+        expect(toCanisterResponseError(frozen, identity)).not.toBeInstanceOf(
+            DestinationInvalidError,
+        );
+    });
+
+    test("other failures sharing those reject codes remain retryable", () => {
+        const trapped = reject(ReplicaRejectCode.CanisterError, "trapped", "IC0502");
+        const transient = reject(ReplicaRejectCode.SysTransient, "try again");
+
+        for (const error of [trapped, transient]) {
+            const mapped = toCanisterResponseError(error, identity);
+
+            expect(mapped).toBeInstanceOf(HttpError);
+            expect(mapped).not.toBeInstanceOf(CanisterUnavailableError);
         }
     });
 

--- a/frontend/openchat-agent/src/services/error.spec.ts
+++ b/frontend/openchat-agent/src/services/error.spec.ts
@@ -1,24 +1,22 @@
 import {
+    HttpErrorCode,
+    ProtocolError,
     RejectError,
     ReplicaRejectCode,
+    type RequestId,
     UncertifiedRejectErrorCode,
     type Identity,
 } from "@icp-sdk/core/agent";
-import { DestinationInvalidError, HttpError } from "@shared";
+import { DestinationInvalidError, HttpError, InvalidDelegationError } from "@shared";
 import { toCanisterResponseError } from "./error";
 
-// Only `getPrincipal` and `getDelegation` are ever touched for the errors under test
+// An expired session is the default - only the delegation tests need a live one
 const identity = {} as Identity;
+const requestId = new Uint8Array([1]) as unknown as RequestId;
 
 function reject(rejectCode: ReplicaRejectCode, message: string, errorCode?: string): Error {
     return RejectError.fromCode(
-        new UncertifiedRejectErrorCode(
-            new Uint8Array([1]),
-            rejectCode,
-            message,
-            errorCode,
-            undefined,
-        ),
+        new UncertifiedRejectErrorCode(requestId, rejectCode, message, errorCode, undefined),
     );
 }
 
@@ -51,5 +49,53 @@ describe("toCanisterResponseError", () => {
             expect(error).toBeInstanceOf(HttpError);
             expect(error).not.toBeInstanceOf(DestinationInvalidError);
         }
+    });
+
+    // Downstream code (eg. the dead-ledger check) only sees the mapped error, so the IC error code
+    // has to survive the mapping rather than being re-parsed out of the message
+    test("the IC error code of a rejection is carried onto the mapped error", () => {
+        const error = toCanisterResponseError(
+            reject(ReplicaRejectCode.SysTransient, "Canister x is frozen.", "IC0207"),
+            identity,
+        );
+
+        expect((error as HttpError).rejectErrorCode).toBe("IC0207");
+    });
+
+    test("a failure which carries no IC error code leaves it undefined", () => {
+        const error = toCanisterResponseError(new Error("something else went wrong"), identity);
+
+        expect((error as HttpError).rejectErrorCode).toBeUndefined();
+    });
+
+    describe("invalid delegation", () => {
+        // A session which has not expired, so the session-expiry branch doesn't swallow the case
+        const liveSession = {
+            getDelegation: () => ({
+                delegations: [
+                    { delegation: { expiration: BigInt(Date.now() + 60_000) * BigInt(1_000_000) } },
+                ],
+            }),
+        } as unknown as Identity;
+
+        function httpFailure(bodyText: string): Error {
+            return ProtocolError.fromCode(new HttpErrorCode(400, "Bad Request", [], bodyText));
+        }
+
+        test("is recognised from the response body", () => {
+            const error = toCanisterResponseError(
+                httpFailure("Invalid delegation: signature could not be verified"),
+                liveSession,
+            );
+
+            expect(error).toBeInstanceOf(InvalidDelegationError);
+        });
+
+        test("is not inferred from an unrelated 400", () => {
+            const error = toCanisterResponseError(httpFailure("Malformed request"), liveSession);
+
+            expect(error).toBeInstanceOf(HttpError);
+            expect(error).not.toBeInstanceOf(InvalidDelegationError);
+        });
     });
 });

--- a/frontend/openchat-agent/src/services/error.ts
+++ b/frontend/openchat-agent/src/services/error.ts
@@ -1,5 +1,6 @@
 import {
     AgentError,
+    type ErrorCode,
     HttpErrorCode,
     type Identity,
     ProtocolError,
@@ -32,6 +33,15 @@ export class ReplicaNotUpToDateError extends Error {
     }
 }
 
+// The SDK hangs the details of a failure off `AgentError.code`. Which fields are present depends
+// on how the call failed, so each accessor below returns `undefined` for the cases which don't
+// carry it. Always prefer these over matching on the error message.
+function errorCode(error: Error): Partial<ErrorCode & RejectFields & HttpErrorCode> | undefined {
+    return error instanceof AgentError ? error.code : undefined;
+}
+
+type RejectFields = { rejectCode: ReplicaRejectCode; rejectErrorCode: string | undefined };
+
 // A `DestinationInvalid` rejection means the target canister doesn't exist, eg. because the group
 // or community has been deleted. No amount of retrying can make it exist, so it is mapped to a
 // `DestinationInvalidError` to short-circuit the retry mechanism.
@@ -39,10 +49,23 @@ export class ReplicaNotUpToDateError extends Error {
 // The reject code has to be read from the error rather than matched on its message - the message
 // only ever contains the numeric code ("Reject code: 3"), never the name.
 function destinationInvalid(error: Error): boolean {
+    return errorCode(error)?.rejectCode === ReplicaRejectCode.DestinationInvalid;
+}
+
+// The IC error code of a rejection, eg. "IC0301". Callers use this to recognise specific failures
+// without having to match on the error message.
+function rejectErrorCode(error: Error): string | undefined {
+    return errorCode(error)?.rejectErrorCode;
+}
+
+// A delegation which the boundary node refuses is reported as a 400 whose *body* explains why.
+// Unlike a rejection there is no code for this, so the body text has to be matched - but match the
+// body specifically rather than the composed error message, which also contains the response
+// headers.
+function invalidDelegation(error: Error): boolean {
+    const code = errorCode(error);
     return (
-        error instanceof AgentError &&
-        (error.code as Partial<{ rejectCode: ReplicaRejectCode }>).rejectCode ===
-            ReplicaRejectCode.DestinationInvalid
+        code instanceof HttpErrorCode && (code.bodyText?.includes("Invalid delegation") ?? false)
     );
 }
 
@@ -59,6 +82,21 @@ function responseTooLarge(error: Error): ResponseTooLargeError | undefined {
 }
 
 export function toCanisterResponseError(
+    error: Error,
+    identity: Identity,
+): HttpError | ReplicaNotUpToDateError | TypeboxValidationError {
+    const responseError = classifyError(error, identity);
+
+    // Carry the IC error code across so that callers downstream (which only see the mapped error)
+    // can recognise specific failures without matching on the error message
+    if (responseError instanceof HttpError) {
+        responseError.rejectErrorCode = rejectErrorCode(error);
+    }
+
+    return responseError;
+}
+
+function classifyError(
     error: Error,
     identity: Identity,
 ): HttpError | ReplicaNotUpToDateError | TypeboxValidationError {
@@ -88,7 +126,7 @@ export function toCanisterResponseError(
                 timeUntilSessionExpiryMs,
             );
             return new SessionExpiryError(code, error);
-        } else if (error.message.includes("Invalid delegation")) {
+        } else if (invalidDelegation(error)) {
             return new InvalidDelegationError(error);
         }
     }

--- a/frontend/openchat-agent/src/services/error.ts
+++ b/frontend/openchat-agent/src/services/error.ts
@@ -1,4 +1,10 @@
-import { HttpErrorCode, type Identity, ProtocolError } from "@icp-sdk/core/agent";
+import {
+    AgentError,
+    HttpErrorCode,
+    type Identity,
+    ProtocolError,
+    ReplicaRejectCode,
+} from "@icp-sdk/core/agent";
 import { ResponseTooLargeError } from "@shared";
 import {
     getSessionExpiryMs,
@@ -26,6 +32,20 @@ export class ReplicaNotUpToDateError extends Error {
     }
 }
 
+// A `DestinationInvalid` rejection means the target canister doesn't exist, eg. because the group
+// or community has been deleted. No amount of retrying can make it exist, so it is mapped to a
+// `DestinationInvalidError` to short-circuit the retry mechanism.
+//
+// The reject code has to be read from the error rather than matched on its message - the message
+// only ever contains the numeric code ("Reject code: 3"), never the name.
+function destinationInvalid(error: Error): boolean {
+    return (
+        error instanceof AgentError &&
+        (error.code as Partial<{ rejectCode: ReplicaRejectCode }>).rejectCode ===
+            ReplicaRejectCode.DestinationInvalid
+    );
+}
+
 function responseTooLarge(error: Error): ResponseTooLargeError | undefined {
     const regex = /application payload size \((\d+)\) cannot be larger than (\d+)/;
     const match = error.message.match(regex);
@@ -48,8 +68,7 @@ export function toCanisterResponseError(
 
     let code = 500;
 
-    if (error.message.includes("DestinationInvalid")) {
-        // this will allow us to short-circuit the retry mechanism in this circumstance
+    if (destinationInvalid(error)) {
         return new DestinationInvalidError(error);
     }
 

--- a/frontend/openchat-agent/src/services/error.ts
+++ b/frontend/openchat-agent/src/services/error.ts
@@ -10,8 +10,10 @@ import { ResponseTooLargeError } from "@shared";
 import {
     getSessionExpiryMs,
     HttpError,
+    ICErrorCode,
     SessionExpiryError,
     AuthError,
+    CanisterUnavailableError,
     DestinationInvalidError,
     InvalidDelegationError,
     TypeboxValidationError,
@@ -56,6 +58,20 @@ function destinationInvalid(error: Error): boolean {
 // without having to match on the error message.
 function rejectErrorCode(error: Error): string | undefined {
     return errorCode(error)?.rejectErrorCode;
+}
+
+// A canister which is frozen or has been uninstalled can't serve the call, and won't start being
+// able to within the lifetime of this request, so retrying only stalls the caller. These have to be
+// recognised by their IC error code - unlike a deleted canister they share their reject codes
+// (`SysTransient` and `CanisterError`) with failures which genuinely are worth retrying.
+const UNAVAILABLE_ERROR_CODES: string[] = [
+    ICErrorCode.CanisterOutOfCycles,
+    ICErrorCode.CanisterWasmModuleNotFound,
+];
+
+function canisterUnavailable(error: Error): boolean {
+    const code = rejectErrorCode(error);
+    return code !== undefined && UNAVAILABLE_ERROR_CODES.includes(code);
 }
 
 // A delegation which the boundary node refuses is reported as a 400 whose *body* explains why.
@@ -108,6 +124,10 @@ function classifyError(
 
     if (destinationInvalid(error)) {
         return new DestinationInvalidError(error);
+    }
+
+    if (canisterUnavailable(error)) {
+        return new CanisterUnavailableError(error);
     }
 
     const tooLarge = responseTooLarge(error);

--- a/frontend/openchat-shared/src/domain/error.ts
+++ b/frontend/openchat-shared/src/domain/error.ts
@@ -10,6 +10,16 @@ export class UnsupportedValueError extends Error {
     }
 }
 
+// The IC error codes we make decisions on. These do not map onto distinct reject codes - a frozen
+// canister is `SysTransient` and one with no wasm module is `CanisterError`, both of which are
+// retryable in general - so the specific code has to be used to tell them apart.
+// See https://internetcomputer.org/docs/references/execution-errors
+export const ICErrorCode = {
+    CanisterOutOfCycles: "IC0207", // the canister is frozen
+    CanisterNotFound: "IC0301", // the canister has been deleted
+    CanisterWasmModuleNotFound: "IC0537", // the canister has been uninstalled
+} as const;
+
 export class HttpError extends Error {
     // The IC error code of the underlying rejection, eg. "IC0301", where the failure was a
     // rejection which carried one. Populated by `toCanisterResponseError`.
@@ -57,6 +67,17 @@ export class DestinationInvalidError extends HttpError {
     constructor(error: Error) {
         super(404, error);
         this.name = "DestinationInvalidError";
+    }
+}
+
+// The canister exists but cannot serve the call right now - it is frozen (out of cycles) or has no
+// wasm module (uninstalled). Unlike `DestinationInvalidError` this does not mean the canister is
+// gone: it may recover once it is topped up or reinstalled. But it cannot recover within the
+// lifetime of a single request, so retrying here only stalls the caller.
+export class CanisterUnavailableError extends HttpError {
+    constructor(error: Error) {
+        super(503, error);
+        this.name = "CanisterUnavailableError";
     }
 }
 

--- a/frontend/openchat-shared/src/domain/error.ts
+++ b/frontend/openchat-shared/src/domain/error.ts
@@ -11,6 +11,10 @@ export class UnsupportedValueError extends Error {
 }
 
 export class HttpError extends Error {
+    // The IC error code of the underlying rejection, eg. "IC0301", where the failure was a
+    // rejection which carried one. Populated by `toCanisterResponseError`.
+    public rejectErrorCode: string | undefined;
+
     constructor(
         public code: number,
         error: Error,
@@ -33,13 +37,19 @@ export class AuthError extends HttpError {
     }
 }
 
+// Errors lose their prototype when they cross the worker boundary (they are serialised with
+// `JSON.stringify`), so on the client side they can only be recognised by `name`. These constants
+// keep the names the classes set below and the checks which read them in a single place.
+export const SESSION_EXPIRY_ERROR_NAME = "SessionExpiryError";
+export const INVALID_DELEGATION_ERROR_NAME = "InvalidDelegationError";
+
 export class SessionExpiryError extends HttpError {
     constructor(
         public code: number,
         error: Error,
     ) {
         super(code, error);
-        this.name = "SessionExpiryError";
+        this.name = SESSION_EXPIRY_ERROR_NAME;
     }
 }
 
@@ -64,7 +74,7 @@ export class ResponseTooLargeError extends HttpError {
 export class InvalidDelegationError extends HttpError {
     constructor(error: Error) {
         super(403, error);
-        this.name = "InvalidDelegationError";
+        this.name = INVALID_DELEGATION_ERROR_NAME;
     }
 }
 

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -1,27 +1,18 @@
 import { describe, expect, test } from "vitest";
 
-import { HttpError } from "../domain";
-import { shouldReportWorkerError } from "./error";
+import { HttpError, INVALID_DELEGATION_ERROR_NAME, SESSION_EXPIRY_ERROR_NAME } from "../domain";
+import { requiresLogout, shouldReportWorkerError } from "./error";
 
-// Real agent (icp-sdk) reject messages - the IC error code appears on its own line.
-const frozen = new HttpError(
-    500,
-    new Error(
-        "The replica returned a rejection error:\n  Reject code: 2\n  Reject text: Canister x is frozen.\n  Error code: IC0207",
-    ),
-);
-const noWasm = new HttpError(
-    500,
-    new Error(
-        "The replica returned a rejection error:\n  Reject code: 5\n  Reject text: ...contains no Wasm module.\n  Error code: IC0537",
-    ),
-);
-const deleted = new HttpError(
-    500,
-    new Error(
-        "The replica returned a rejection error:\n  Reject code: 3\n  Reject text: Canister x not found\n  Error code: IC0301",
-    ),
-);
+// `toCanisterResponseError` copies the IC error code of the rejection onto the mapped error
+function rejection(rejectErrorCode: string): HttpError {
+    const error = new HttpError(500, new Error("The replica returned a rejection error"));
+    error.rejectErrorCode = rejectErrorCode;
+    return error;
+}
+
+const frozen = rejection("IC0207");
+const noWasm = rejection("IC0537");
+const deleted = rejection("IC0301");
 const boundary = new HttpError(503, new Error("The server returned an error: 503"));
 
 describe("shouldReportWorkerError", () => {
@@ -34,11 +25,36 @@ describe("shouldReportWorkerError", () => {
     test("still reports non-dead-ledger failures for a tolerated kind", () => {
         // a boundary/other error on balance refresh is a real signal, not an expected dead ledger
         expect(shouldReportWorkerError("refreshAccountBalance", boundary)).toBe(true);
+        expect(shouldReportWorkerError("refreshAccountBalance", rejection("IC0503"))).toBe(true);
         expect(shouldReportWorkerError("refreshAccountBalance", new TypeError("boom"))).toBe(true);
+    });
+
+    // The IC error code is read from the error, not its text, so an unrelated failure which merely
+    // quotes a dead-ledger code (eg. a trap message) is still reported
+    test("does not silence an error which only mentions a dead-ledger code in its message", () => {
+        const mentionsCode = new HttpError(500, new Error("trapped while handling IC0207"));
+
+        expect(shouldReportWorkerError("refreshAccountBalance", mentionsCode)).toBe(true);
     });
 
     test("reports everything for kinds that are not tolerated", () => {
         expect(shouldReportWorkerError("getUpdates", frozen)).toBe(true);
         expect(shouldReportWorkerError("sendMessage", noWasm)).toBe(true);
+    });
+});
+
+describe("requiresLogout", () => {
+    // These arrive from the worker as plain objects - the prototype does not survive serialisation
+    test("recognises session errors by name", () => {
+        expect(requiresLogout({ name: SESSION_EXPIRY_ERROR_NAME })).toBe(true);
+        expect(requiresLogout({ name: INVALID_DELEGATION_ERROR_NAME })).toBe(true);
+    });
+
+    test("ignores anything else", () => {
+        expect(requiresLogout({ name: "HttpError" })).toBe(false);
+        expect(requiresLogout(new TypeError("boom"))).toBe(false);
+        expect(requiresLogout(undefined)).toBe(false);
+        expect(requiresLogout(null)).toBe(false);
+        expect(requiresLogout("SessionExpiryError")).toBe(false);
     });
 });

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { HttpError, INVALID_DELEGATION_ERROR_NAME, SESSION_EXPIRY_ERROR_NAME } from "../domain";
+import {
+    CanisterUnavailableError,
+    HttpError,
+    INVALID_DELEGATION_ERROR_NAME,
+    SESSION_EXPIRY_ERROR_NAME,
+} from "../domain";
 import { requiresLogout, shouldReportWorkerError } from "./error";
 
 // `toCanisterResponseError` copies the IC error code of the rejection onto the mapped error
@@ -35,6 +40,15 @@ describe("shouldReportWorkerError", () => {
         const mentionsCode = new HttpError(500, new Error("trapped while handling IC0207"));
 
         expect(shouldReportWorkerError("refreshAccountBalance", mentionsCode)).toBe(true);
+    });
+
+    // A frozen or uninstalled ledger is mapped to `CanisterUnavailableError` so that it stops
+    // retrying, which is the form this check actually receives it in
+    test("silences an unavailable ledger", () => {
+        const unavailable = new CanisterUnavailableError(new Error("Canister x is frozen."));
+        unavailable.rejectErrorCode = "IC0207";
+
+        expect(shouldReportWorkerError("refreshAccountBalance", unavailable)).toBe(false);
     });
 
     test("reports everything for kinds that are not tolerated", () => {

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -6,6 +6,9 @@ import {
     type PinNumberFailures,
     SESSION_EXPIRY_ERROR_NAME,
 } from "../domain";
+// Imported from the module rather than the barrel: `../domain` cycles back through here, so a
+// binding read at module scope (as below) is not yet initialised when going via the barrel
+import { ICErrorCode } from "../domain/error";
 import { parseBigInt } from "./bigint";
 
 export function isError(value: unknown): value is OCError {
@@ -21,7 +24,11 @@ const callerToleratedErrorKinds = new Set<string>(["refreshAccountBalance"]);
 // expected: for the ~30 day window before the IC uninstalls a frozen canister, and until the
 // registry's uninstalled-token detection + client cache purge remove the token. Any OTHER failure
 // is a real signal.
-const DEAD_LEDGER_ERROR_CODES = ["IC0207", "IC0301", "IC0537"];
+const DEAD_LEDGER_ERROR_CODES: string[] = [
+    ICErrorCode.CanisterOutOfCycles,
+    ICErrorCode.CanisterNotFound,
+    ICErrorCode.CanisterWasmModuleNotFound,
+];
 function isDeadLedgerError(error: unknown): boolean {
     return (
         error instanceof HttpError &&

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -1,4 +1,11 @@
-import { ErrorCode, HttpError, type OCError, type PinNumberFailures } from "../domain";
+import {
+    ErrorCode,
+    HttpError,
+    INVALID_DELEGATION_ERROR_NAME,
+    type OCError,
+    type PinNumberFailures,
+    SESSION_EXPIRY_ERROR_NAME,
+} from "../domain";
 import { parseBigInt } from "./bigint";
 
 export function isError(value: unknown): value is OCError {
@@ -12,13 +19,14 @@ const callerToleratedErrorKinds = new Set<string>(["refreshAccountBalance"]);
 // A ledger canister that is frozen (IC0207), has no wasm module (IC0537) or has been deleted
 // (IC0301) is a dead / decommissioned token ledger. Balance refreshes against these are
 // expected: for the ~30 day window before the IC uninstalls a frozen canister, and until the
-// registry's uninstalled-token detection + client cache purge remove the token. The agent's
-// reject message includes the IC error code, so we can recognise these here. Any OTHER failure
+// registry's uninstalled-token detection + client cache purge remove the token. Any OTHER failure
 // is a real signal.
 const DEAD_LEDGER_ERROR_CODES = ["IC0207", "IC0301", "IC0537"];
 function isDeadLedgerError(error: unknown): boolean {
     return (
-        error instanceof HttpError && DEAD_LEDGER_ERROR_CODES.some((c) => error.message.includes(c))
+        error instanceof HttpError &&
+        error.rejectErrorCode !== undefined &&
+        DEAD_LEDGER_ERROR_CODES.includes(error.rejectErrorCode)
     );
 }
 
@@ -27,6 +35,15 @@ function isDeadLedgerError(error: unknown): boolean {
 // boundary error, a decode error, a code bug - is still reported so real regressions stay visible.
 export function shouldReportWorkerError(kind: string, error: unknown): boolean {
     return !(callerToleratedErrorKinds.has(kind) && isDeadLedgerError(error));
+}
+
+// Whether a rejected promise means the user's session is no longer usable and they must be logged
+// out. These errors reach the client through the worker, so their prototype is gone and `name` is
+// all that survives - see the constants in ../domain/error.
+export function requiresLogout(error: unknown): boolean {
+    if (error == null || typeof error !== "object" || !("name" in error)) return false;
+
+    return error.name === SESSION_EXPIRY_ERROR_NAME || error.name === INVALID_DELEGATION_ERROR_NAME;
 }
 
 export function pinNumberFailureFromError(error: OCError): PinNumberFailures | undefined {


### PR DESCRIPTION
## The bug

A message linking to a **deleted** group or community made chats take ~13 seconds to load. Resolving the link preview queries the linked group's canister, which rejects with `DestinationInvalid` ("Canister ... not found"). That was already meant to short-circuit the retry loop, but the check was:

```ts
error.message.includes("DestinationInvalid")
```

and the SDK's message only ever contains the **numeric** code. Confirmed against the real canister from the report:

```
status: rejected
reject_code: 3            <- ReplicaRejectCode.DestinationInvalid
reject_message: Canister 4vbct-tqaaa-aaaar-bljfa-cai not found
error_code: IC0301
```

which renders as `"...Reject code: 3\n  Reject text: Canister ... not found..."` — so the substring never matched. The rejection fell through to a generic `HttpError(500)` and got the full retry treatment: **8 requests over ~12.7s** with exponential backoff. `rehydrateEventResponse` awaits preview resolution, so the whole chat blocks for that time.

Now the reject code is read from the error. The query fails on the first response, the preview is skipped, and the message renders as a plain link.

This also **un-breaks two behaviours** that silently depended on `DestinationInvalidError` being produced: detecting a group which has **moved into a community** (`group_moved`), and `channel_summary` returning `canister_not_found`.

## The same bug elsewhere

A sweep for other decisions driven by error text turned up these.

**Frontend** — where a structured field exists, use it:

- `toCanisterResponseError` now carries the rejection's IC error code (eg. `IC0301`) onto the mapped error, and the dead-ledger check reads that field instead of searching the message. An unrelated failure that merely *quotes* a dead-ledger code no longer silences error reporting.
- An invalid delegation (which forces a logout) is matched against the response **body** rather than the composed message, which also contains a JSON dump of the response headers. There is no error code for this case, so body text is the best available signal.
- Both `App.svelte` copies recognised session errors via duplicated name literals. These errors lose their prototype crossing the worker boundary (serialised with `JSON.stringify`), so `instanceof` genuinely cannot work — but the names now live beside the classes that set them, behind a shared `requiresLogout`.

**Backend** — note the situation inverts here: canisters only receive the coarse `RejectCode`, so `IC0xxx` codes found in a reject message are there at the replica's discretion. Where a real structured alternative exists, it is now used:

- **proposals_bot** treated any `CanisterError` whose text mentioned `"MessageId"` as a *successfully pushed* proposal — an 9-character substring converting a failure into `mark_proposal_pushed(...)`. It now matches `OCErrorCode::MessageIdAlreadyExists`, which is what the callee actually returns. Worth noting the old check could never have matched the real case anyway: a duplicate id arrives as `Ok(Response::Error(..))`, not a rejection.
- The **group import** "give up" check now also requires the reject code, so unrelated failures can't trigger it on text alone. The message match itself has to stay — a contract violation reaches us as a plain `CanisterError`.
- Deleted the unused duplicate of `is_out_of_cycles_error`, whose `starts_with("IC0207:")` would not have matched messages built by `convert_cdk_error` anyway.

## Tests

New `error.spec.ts` for the agent plus extensions to the shared one. The key regression test was verified to actually fail against the old code (`expected HttpError ... to be an instance of DestinationInvalidError`), not just pass against the new.

Verified: `vitest` 415 passing, `typecheck` 0 errors, `typecheck:agent`, eslint, `cargo clippy --workspace --tests`, `cargo fmt --check`, and the backend unit tests all clean.

## Not included

- **No negative caching** — each chat load still costs one failed query for a dead canister. Caching "this canister is gone" needs care, because a group genuinely can move into a community, which is what the now-working `group_moved` path handles.
- `responseTooLarge` still parses its message. The size numbers exist only in the text, and it drives page-size halving, so narrowing it has real downside for no structural gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)