### PR TITLE
Emit only one final result from messagesByMessageIndexViaCache

### DIFF
--- a/frontend/openchat-agent/src/services/common/chatEvents.ts
+++ b/frontend/openchat-agent/src/services/common/chatEvents.ts
@@ -425,6 +425,7 @@ export class CachedChatEventsReader {
                             : resp,
                         true,
                     );
+                    return;
                 }
                 resolve(
                     {


### PR DESCRIPTION
## Problem

`messagesByMessageIndexViaCache` in `frontend/openchat-agent/src/services/common/chatEvents.ts` was missing a `return`.

The `if (fromCache.missing.size > 0)` block fetches the missing messages from the canister and calls `resolve(merged, true)`, but then falls through to the unconditional `resolve({ events: fromCache.messageEvents, expiredEventRanges: [], latestEventIndex: undefined }, true)` below it — emitting a **second** final result containing only the cached events and discarding everything just fetched from the canister.

## Impact

Depends on how the `Stream` is consumed:

- Consumers using `.toPromise()` (e.g. `resolveMissingMessagePreviews`) are unaffected in value terms — the first `final: true` settles the promise and the second resolve is a no-op.
- Consumers using `.mapAsync(...)` **are** affected. `OpenChatAgent.getMessagesByMessageIndex` pipes the stream through `.mapAsync(rehydrateEventResponse)`, so the mapper runs twice. Each run re-enters `resolveMissingIndexes` and `resolveMissingMessagePreviews`, firing a redundant second round of `events_by_index` / `messages_by_message_index` canister queries. The stale cache-only value (with `latestEventIndex: undefined`) is also emitted last, so any subscriber taking the latest emission rather than the first gets the wrong data.

This path is used by the pinned messages UI (`PinnedMessages.svelte`) and the activity feed.

## Fix

Add a `return` after the resolve inside the `if (fromCache.missing.size > 0)` block, so exactly one final result is emitted. When nothing is missing, control still falls through to the cache-only resolve as before.

## Testing

- `npm run typecheck:agent` — clean
- `npx vitest --run` — 33 files, 406 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)