### PR TITLE
Only push reaction activity if the reaction is on one of your messages

### DIFF
--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Only push reaction activity if the reaction is on one of your messages ([#9126](https://github.com/open-chat-labs/open-chat/pull/9126))
 - Enforce Diamond membership server-side when initiating a P2P swap
 
 ## [[2.0.1990-user](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1990-user)] - 2026-07-07

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Only push reaction activity if the reaction is on one of your messages ([#9126](https://github.com/open-chat-labs/open-chat/pull/9126))
+- Only push reaction activity in direct chats if the reaction is on one of your messages ([#9126](https://github.com/open-chat-labs/open-chat/pull/9126))
 - Enforce Diamond membership server-side when initiating a P2P swap
 
 ## [[2.0.1990-user](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1990-user)] - 2026-07-07

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -308,8 +308,8 @@ fn toggle_reaction(args: ToggleReactionArgs, caller_user_id: UserId, state: &mut
             if let Ok(result) = chat.events.add_reaction::<UserEventPusher>(add_remove_reaction_args, None) {
                 let message = result.value;
 
-                // They may be reacting to their own message, in which case there is nothing to
-                // notify this user about
+                // They may be reacting to their own message; in that case we should not generate any activity
+                // for the other user (push notification, activity-feed event, or achievement progress).
                 if message.sender != caller_user_id {
                     if !state.data.suspended.value && !args.username.is_empty() && !chat.notifications_muted.value {
                         let notification =

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -308,41 +308,41 @@ fn toggle_reaction(args: ToggleReactionArgs, caller_user_id: UserId, state: &mut
             if let Ok(result) = chat.events.add_reaction::<UserEventPusher>(add_remove_reaction_args, None) {
                 let message = result.value;
 
-                if message.sender != caller_user_id
-                    && !state.data.suspended.value
-                    && !args.username.is_empty()
-                    && !chat.notifications_muted.value
-                {
-                    let notification =
-                        DirectChatUserNotificationPayload::DirectReactionAdded(DirectReactionAddedNotification {
-                            them: chat.them,
+                // They may be reacting to their own message, in which case there is nothing to
+                // notify this user about
+                if message.sender != caller_user_id {
+                    if !state.data.suspended.value && !args.username.is_empty() && !chat.notifications_muted.value {
+                        let notification =
+                            DirectChatUserNotificationPayload::DirectReactionAdded(DirectReactionAddedNotification {
+                                them: chat.them,
+                                thread_root_message_index,
+                                message_index: message.message_index,
+                                message_event_index: result.event_index,
+                                username: args.username,
+                                display_name: args.display_name,
+                                reaction: args.reaction,
+                                user_avatar_id: args.user_avatar_id,
+                            });
+
+                        state.push_notification(Some(caller_user_id), message.sender, notification);
+                    }
+
+                    state.data.push_message_activity(
+                        MessageActivityEvent {
+                            chat: Chat::Direct(caller_user_id.into()),
                             thread_root_message_index,
                             message_index: message.message_index,
-                            message_event_index: result.event_index,
-                            username: args.username,
-                            display_name: args.display_name,
-                            reaction: args.reaction,
-                            user_avatar_id: args.user_avatar_id,
-                        });
+                            message_id: message.message_id,
+                            event_index: result.event_index,
+                            activity: MessageActivity::Reaction,
+                            timestamp: now,
+                            user_id: Some(caller_user_id),
+                        },
+                        now,
+                    );
 
-                    state.push_notification(Some(caller_user_id), message.sender, notification);
+                    state.award_achievement_and_notify(Achievement::HadMessageReactedTo, now);
                 }
-
-                state.data.push_message_activity(
-                    MessageActivityEvent {
-                        chat: Chat::Direct(caller_user_id.into()),
-                        thread_root_message_index,
-                        message_index: message.message_index,
-                        message_id: message.message_id,
-                        event_index: result.event_index,
-                        activity: MessageActivity::Reaction,
-                        timestamp: now,
-                        user_id: Some(caller_user_id),
-                    },
-                    now,
-                );
-
-                state.award_achievement_and_notify(Achievement::HadMessageReactedTo, now);
             }
         } else {
             let _ = chat.events.remove_reaction(add_remove_reaction_args);

--- a/backend/integration_tests/src/message_activity_tests.rs
+++ b/backend/integration_tests/src/message_activity_tests.rs
@@ -55,6 +55,40 @@ fn react_to_message_and_check_activity_feed(chat_type: ChatType) {
     check_updates(env, 0, &us, &them, MessageActivity::Reaction);
 }
 
+#[test]
+fn reacting_to_own_message_does_not_appear_in_other_users_activity_feed() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+    } = wrapper.env();
+
+    let TestData { them, us, .. } = init_test_data(env, canister_ids, *controller, ChatType::Direct);
+
+    let reaction = "😀";
+
+    // They send us a message then react to their own message
+    let their_message_id = random_from_u128();
+    client::user::happy_path::send_text_message(env, &them, us.user_id, "their message", Some(their_message_id));
+    env.tick();
+    client::user::happy_path::add_reaction(env, &them, us.user_id, reaction, their_message_id);
+    tick_many(env, 3);
+
+    // That is not activity on any message of ours, so our feed stays empty
+    let feed = client::user::happy_path::message_activity_feed(env, &us, 0);
+    assert_eq!(feed.total, 0, "{:?}", feed.events);
+
+    // But a reaction to a message we sent still reaches our feed
+    let our_message_id = random_from_u128();
+    client::user::happy_path::send_text_message(env, &us, them.user_id, "our message", Some(our_message_id));
+    env.tick();
+    client::user::happy_path::add_reaction(env, &them, us.user_id, reaction, our_message_id);
+    tick_many(env, 3);
+
+    check_updates(env, 0, &us, &them, MessageActivity::Reaction);
+}
+
 #[test_case(ChatType::Group)]
 #[test_case(ChatType::Channel)]
 fn mention_user_and_check_activity_feed(chat_type: ChatType) {


### PR DESCRIPTION
## The bug

In a direct chat, if the other user sent a message and then reacted to *their own* message, you got a "User X reacted on your message" event in your activity feed — for a message that wasn't yours. You were also silently awarded `HadMessageReactedTo` achievement progress.

## Cause

In the user canister's `toggle_reaction` handler (`c2c_user_canister.rs`), three things happen when the other user adds a reaction: a push notification, an activity-feed event, and the achievement. Only the notification was inside the `message.sender != caller_user_id` check — the activity event and achievement fired for every reaction the other user added, including reactions to their own messages.

The group and community canisters already gate all three on `message.sender != agent`; the direct-chat path just had the closing brace in the wrong place.

## Fix

Move the activity event and achievement inside a `message.sender != caller_user_id` block. The notification keeps its extra conditions (`suspended`, `username`, `notifications_muted`) nested inside, since those should not gate the feed event.

## Tests

New integration test `reacting_to_own_message_does_not_appear_in_other_users_activity_feed`: the other user reacts to their own message → the feed must stay empty; positive control in the same test confirms a reaction to *your* message still arrives. Verified the test fails against the unfixed canister (it captures exactly the phantom `Reaction` event) and passes with the fix. All 23 `message_activity_tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)