### PR TITLE
Clear underlying prize restrictions when "any user" is selected

### DIFF
--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -327,10 +327,9 @@
     }
 
     function onAnyUserChecked() {
-        anyUser = true;
         diamondType = "none";
-        streakOnly = false;
-        chitOnly = false;
+        minStreak = 0;
+        minChitEarned = 0;
     }
 
     function onStreakChanged() {


### PR DESCRIPTION
## Problem

A user reported that a prize message created with the restriction set to "any user" ended up restricted to users with a streak of at least 30 days.

In the desktop `PrizeContentBuilder`, `onAnyUserChecked` assigned `false` to `streakOnly` and `chitOnly`, which are `$derived` from `minStreak` and `minChitEarned`. In Svelte 5 assigning to a derived only overrides the displayed value — the underlying state is untouched. So the streak checkbox unticked visually, but `send()` still sent `streakOnly: minStreak` (e.g. 30).

This also reproduces across sessions: `minStreak` is persisted in localStorage (`openchat_prize_config`), so anyone who previously sent a streak-restricted prize would hit this on their next "any user" prize.

The mobile (`components_mobile`) builder works on `minStreak` directly and is unaffected.

## Fix

Reset `minStreak`, `minChitEarned` and `diamondType` directly in `onAnyUserChecked` and let the derived flags (`streakOnly`, `chitOnly`, `anyUser`) recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)