### PR TITLE
Fix crash when tipping with a ledger that has been removed from the registry

### DIFF
--- a/frontend/app/src/components/home/TipBuilder.svelte
+++ b/frontend/app/src/components/home/TipBuilder.svelte
@@ -11,6 +11,7 @@
         currentUserIdStore,
         exchangeRatesLookupStore as exchangeRatesLookup,
         lastCryptoSent,
+        LEDGER_CANISTER_ICP,
         mobileWidth,
     } from "@client";
     import { getContext, onMount } from "svelte";
@@ -186,7 +187,16 @@
 
         onClose();
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
+    // The ledger may have been removed from the registry (eg. if it was uninstalled)
+    // in which case fall back to ICP which will always be present
+    let tokenDetails = $derived(
+        $cryptoLookup.get(ledger) ?? $cryptoLookup.get(LEDGER_CANISTER_ICP)!,
+    );
+    $effect(() => {
+        if (!$cryptoLookup.has(ledger)) {
+            ledger = LEDGER_CANISTER_ICP;
+        }
+    });
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger) ?? 0n);
     let exchangeRate = $derived(
         to2SigFigs($exchangeRatesLookup.get(tokenDetails.symbol.toLowerCase())?.toUSD ?? 0),

--- a/frontend/app/src/components_mobile/home/TipBuilder.svelte
+++ b/frontend/app/src/components_mobile/home/TipBuilder.svelte
@@ -20,6 +20,7 @@
         currentUserIdStore,
         exchangeRatesLookupStore as exchangeRatesLookup,
         lastCryptoSent,
+        LEDGER_CANISTER_ICP,
     } from "@client";
     import { getContext, onMount } from "svelte";
     import { _ } from "svelte-i18n";
@@ -164,7 +165,16 @@
 
         onClose();
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
+    // The ledger may have been removed from the registry (eg. if it was uninstalled)
+    // in which case fall back to ICP which will always be present
+    let tokenDetails = $derived(
+        $cryptoLookup.get(ledger) ?? $cryptoLookup.get(LEDGER_CANISTER_ICP)!,
+    );
+    $effect(() => {
+        if (!$cryptoLookup.has(ledger)) {
+            ledger = LEDGER_CANISTER_ICP;
+        }
+    });
     let tokenState = $derived.by(() => {
         const s = new TokenState(tokenDetails);
         s.refreshBalance(client).then(onBalanceRefreshFinished);

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -7595,6 +7595,14 @@ export class OpenChat {
                             nervousSystemLookup.set(nsMap);
                             cryptoLookup.set(cryptoMap);
 
+                            // If the last token the user sent has since been removed from the
+                            // registry (eg. its ledger was uninstalled), clear it, otherwise
+                            // anything defaulting to it (eg. tipping) will blow up
+                            const lastSent = lastCryptoSent.value;
+                            if (lastSent !== undefined && !cryptoMap.has(lastSent)) {
+                                lastCryptoSent.set(undefined);
+                            }
+
                             messageFiltersStore.set(
                                 registry.messageFilters
                                     .map((f) => {


### PR DESCRIPTION
## Problem

A user's client-side crash log showed tipping crashing with `TypeError: Cannot read properties of undefined (reading 'decimals')` / `(reading 'symbol')`.

Root cause: `lastCryptoSent` (persisted in localStorage) pointed at a ledger which has since been uninstalled and is now filtered out of the registry's token list. The tip menu item passes `$lastCryptoSent ?? LEDGER_CANISTER_ICP` to `TipBuilder`, which dereferenced `$cryptoLookup.get(ledger)!` — undefined — so every tip attempt crashed the message row.

## Fix

- `openchat.ts#updateRegistry`: clear `lastCryptoSent` if its ledger is no longer present in the registry (covers all consumers: tip menu, send crypto, thread, prize builder).
- `TipBuilder` (both trees): fall back to ICP token details if the ledger is missing from the crypto lookup, and snap the bound `ledger` back to `LEDGER_CANISTER_ICP` (ICP is always present in the registry).

`svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)