### PR TITLE
Update CyclesDispenser changelog post 2.0.2006 release

### DIFF
--- a/backend/canisters/cycles_dispenser/CHANGELOG.md
+++ b/backend/canisters/cycles_dispenser/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2006](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2006-cycles_dispenser)] - 2026-08-06
+
 ### Changed
 
 - Expose `liquid_cycles_balance` in metrics ([#8350](https://github.com/open-chat-labs/open-chat/pull/8350))


### PR DESCRIPTION
Marks the `[unreleased]` entries as released in [2.0.2006](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2006-cycles_dispenser) (proposal 2325, executed 2026-08-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)