### PR TITLE
Update UserIndex changelog post 2.0.2007 release

### DIFF
--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2007](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2007-user_index)] - 2026-08-06
+
 ### Added
 
 - `set_vault_legal_hold` and `destroy_vault_evidence` (platform operator) - apply or lift a preservation hold on a report's vaulted evidence, and destroy it on a law enforcement request ([#9119](https://github.com/open-chat-labs/open-chat/pull/9119))

--- a/backend/canisters/user_index/impl/src/lib.rs
+++ b/backend/canisters/user_index/impl/src/lib.rs
@@ -415,7 +415,7 @@ struct Data {
     #[serde(default)]
     pub blocked_username_patterns: Vec<String>,
     pub openai_api_key: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_moderation_referral_config")]
+    #[serde(default)]
     pub moderation_referral_config: Option<ModerationReferralConfig>,
     #[serde(default)]
     pub internal_moderation_channel: Option<(CommunityId, ChannelId)>,
@@ -773,97 +773,4 @@ pub struct CanisterIds {
     pub registry: CanisterId,
     pub internet_identity: CanisterId,
     pub website: CanisterId,
-}
-
-// The referral config briefly shipped (to test envs only) as a single shared threshold;
-// accept that shape on upgrade and convert it so those envs upgrade cleanly. Inert
-// everywhere else - production never held the old shape.
-fn deserialize_moderation_referral_config<'de, D>(d: D) -> Result<Option<ModerationReferralConfig>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Compat {
-        New(ModerationReferralConfig),
-        Old { categories: u32, score_threshold: f64 },
-    }
-
-    Ok(match Option::<Compat>::deserialize(d)? {
-        Some(Compat::New(config)) => Some(config),
-        Some(Compat::Old {
-            categories,
-            score_threshold,
-        }) => {
-            let categories = (0..32)
-                .map(|i| 1u32 << i)
-                .filter(|bit| categories & bit != 0)
-                .map(|category| types::ModerationReferralCategory {
-                    category,
-                    score_threshold,
-                })
-                .collect::<Vec<_>>();
-            (!categories.is_empty()).then_some(ModerationReferralConfig { categories })
-        }
-        None => None,
-    })
-}
-
-#[cfg(test)]
-mod moderation_referral_config_compat_tests {
-    use super::*;
-
-    #[derive(Serialize, Deserialize)]
-    struct OldShape {
-        categories: u32,
-        score_threshold: f64,
-    }
-
-    #[derive(Serialize, Deserialize)]
-    struct Holder {
-        #[serde(default, deserialize_with = "deserialize_moderation_referral_config")]
-        config: Option<ModerationReferralConfig>,
-    }
-
-    #[derive(Serialize)]
-    struct OldHolder {
-        config: Option<OldShape>,
-    }
-
-    #[test]
-    fn old_shape_converts() {
-        let bytes = msgpack::serialize_then_unwrap(OldHolder {
-            config: Some(OldShape {
-                categories: 1 | 16,
-                score_threshold: 0.9,
-            }),
-        });
-        let holder: Holder = msgpack::deserialize(bytes.as_slice()).unwrap();
-        let config = holder.config.unwrap();
-        assert_eq!(config.categories.len(), 2);
-        assert!(config.categories.iter().all(|c| c.score_threshold == 0.9));
-        assert_eq!(config.categories[0].category, 1);
-        assert_eq!(config.categories[1].category, 16);
-    }
-
-    #[test]
-    fn new_shape_roundtrips() {
-        let bytes = msgpack::serialize_then_unwrap(Holder {
-            config: Some(ModerationReferralConfig {
-                categories: vec![types::ModerationReferralCategory {
-                    category: 4,
-                    score_threshold: 0.8,
-                }],
-            }),
-        });
-        let holder: Holder = msgpack::deserialize(bytes.as_slice()).unwrap();
-        assert_eq!(holder.config.unwrap().categories[0].category, 4);
-    }
-
-    #[test]
-    fn none_roundtrips() {
-        let bytes = msgpack::serialize_then_unwrap(OldHolder { config: None });
-        let holder: Holder = msgpack::deserialize(bytes.as_slice()).unwrap();
-        assert!(holder.config.is_none());
-    }
 }

--- a/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,7 +1,6 @@
+use crate::Data;
 use crate::lifecycle::init_state;
 use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
-use crate::timer_job_types::{ProcessReportClassification, TimerJob};
-use crate::{Data, mutate_state};
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use ic_cdk::post_upgrade;
@@ -27,27 +26,6 @@ fn post_upgrade(args: Args) {
     let env = Box::new(CanisterEnv::new(data.rng_seed));
     init_cycles_dispenser_client(data.cycles_dispenser_canister_id, data.test_mode);
     init_state(env, data, args.wasm_version);
-
-    // Resume any report classifications which were in-flight when the canister was upgraded,
-    // cancelling any queued retry jobs so that each pending classification has exactly one job
-    mutate_state(|state| {
-        let pending = state.data.reported_messages.pending_classification_report_indexes();
-        if !pending.is_empty() {
-            state
-                .data
-                .timer_jobs
-                .cancel_jobs(|job| matches!(job, TimerJob::ProcessReportClassification(_)));
-
-            let now = state.env.now();
-            for report_index in pending {
-                state.data.timer_jobs.enqueue_job(
-                    TimerJob::ProcessReportClassification(ProcessReportClassification { report_index }),
-                    now,
-                    now,
-                );
-            }
-        }
-    });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");

--- a/backend/canisters/user_index/impl/src/model/reported_messages.rs
+++ b/backend/canisters/user_index/impl/src/model/reported_messages.rs
@@ -135,10 +135,6 @@ impl ReportedMessages {
         })
     }
 
-    pub fn pending_classification_report_indexes(&self) -> Vec<u64> {
-        self.pending_classifications.keys().copied().collect()
-    }
-
     pub fn get(&self, index: u64) -> Option<&ReportedMessage> {
         self.messages.get(index as usize)
     }


### PR DESCRIPTION
Marks the `[unreleased]` entries as released in [2.0.2007](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2007-user_index) (proposal 2326, executed 2026-08-06), and removes upgrade code which is no longer reachable now that 2.0.2007 is released everywhere:

- The moderation-referral-config compat shim (the old single-threshold shape only ever existed in pre-release test environments).
- The post_upgrade classification-resume block: persisted timer jobs re-arm on deserialize, so the exactly-one-job invariant it enforced during the transition is now maintained by normal operation.

The `ReportOutcome` untagged compat is deliberately retained — it decodes the legacy Modclub outcomes still present in state and is permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)