### PR TITLE
Update StorageBucket changelog post 2.0.2009 release

### DIFF
--- a/backend/canisters/storage_bucket/CHANGELOG.md
+++ b/backend/canisters/storage_bucket/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2009](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2009-storage_bucket)] - 2026-08-10
+
 ### Changed
 
 - The vault log records the preservation request a legal hold was applied or cleared under, so the chain of custody shows why evidence was held rather than only that it was ([#9136](https://github.com/open-chat-labs/open-chat/issues/9136))


### PR DESCRIPTION
Moves the `[unreleased]` entries under a `2.0.2009` heading following the release to production.

Released via SNS proposal 2328 at commit `2fc0f6a402a0d19f64728c2437174384e46c25a2`, executed 2026-08-10. All 23 buckets (2 active + 21 full) are on 2.0.2009 with the vault dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)