### PR TITLE
Update StorageIndex changelog post 2.0.2010 release

### DIFF
--- a/backend/canisters/storage_index/CHANGELOG.md
+++ b/backend/canisters/storage_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2010](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2010-storage_index)] - 2026-08-10
+
 ### Changed
 
 - Legal hold ops carry the preservation request reference through to the owning bucket ([#9136](https://github.com/open-chat-labs/open-chat/issues/9136))


### PR DESCRIPTION
Moves the `[unreleased]` entries under a `2.0.2010` heading following the release to production.

Released via SNS proposal at commit `2fc0f6a402a0d19f64728c2437174384e46c25a2`, executed 2026-08-10. Post-upgrade completed in ~4.06B instructions with state intact and the vault dormant.

Note: the `[unreleased]` block carried two consecutive `### Changed` headings, which this PR preserves as-is under the new version heading. Say if you'd rather they were merged into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)