### PR TITLE
Update UserIndex changelog post 2.0.2011 release

### DIFF
--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2011](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2011-user_index)] - 2026-08-10
+
 ### Added
 
 - Dual authorization for the irreversible platform-operator actions: destroying vaulted evidence, designating vault reviewers, setting the OpenAI API key and setting the internal moderation channel are now proposed by one operator and confirmed by a different one, with proposals expiring after 14 days and every proposal, confirmation, cancellation and expiry recorded in an append-only hash-chained log whose chain head is published in metrics ([#9136](https://github.com/open-chat-labs/open-chat/issues/9136))


### PR DESCRIPTION
Moves the `[unreleased]` entries under a `2.0.2011` heading following the release to production.

Released via SNS proposal at commit `2fc0f6a402a0d19f64728c2437174384e46c25a2`, executed 2026-08-10. Post-upgrade completed in ~23.98B instructions; `protected_action_metrics` now present with an empty log, the report backlog intact, and all operator switches still unset.

Completes the dual-authorization change begun in StorageBucket 2.0.2009 and StorageIndex 2.0.2010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)