### PR TITLE
Ignore benign IndexedDB connection-closing errors on Android

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -44,7 +44,11 @@
         routeStore,
         subscribe,
     } from "@client";
-    import { eventToError, recordError } from "@utils/errorPostmortem";
+    import {
+        eventToError,
+        isIdbConnectionClosingError,
+        recordError,
+    } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
@@ -628,6 +632,10 @@
         }
 
         const err = eventToError(ev);
+        if (isIdbConnectionClosingError(err)) {
+            ev.preventDefault();
+            return;
+        }
         recordError("window", err);
         logger?.error("Unhandled error: ", err);
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -37,7 +37,11 @@
         routeForScope,
         subscribe,
     } from "@client";
-    import { eventToError, recordError } from "@utils/errorPostmortem";
+    import {
+        eventToError,
+        isIdbConnectionClosingError,
+        recordError,
+    } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
@@ -313,6 +317,10 @@
         }
 
         const err = eventToError(ev);
+        if (isIdbConnectionClosingError(err)) {
+            ev.preventDefault();
+            return;
+        }
         recordError("window", err);
         logger?.error("Unhandled error: ", err);
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {

--- a/frontend/app/src/utils/emojis.ts
+++ b/frontend/app/src/utils/emojis.ts
@@ -25,24 +25,32 @@ export function summaryToSelectedEmoji(match: EmojiSummary): SelectedEmoji {
 }
 
 export function searchAllEmojis(query: string) {
-    return emojiDatabase.getPreferredSkinTone().then((tone) => {
-        return emojiDatabase.getEmojiBySearchQuery(query!).then((m) => {
-            const native: NativeEmojiSummary[] = (m as NativeEmoji[])
-                .filter((m) => m.version < 14)
-                .map((match) => {
-                    const unicode =
-                        match.skins?.find((s) => s.tone === tone)?.unicode ?? match.unicode;
-                    return {
-                        kind: "native" as const,
-                        unicode,
-                        code: match.shortcodes
-                            ? match.shortcodes[match.shortcodes.length - 1]
-                            : match.annotation,
-                    };
-                });
-            return [...searchCustomEmojis(query), ...native];
+    return emojiDatabase
+        .getPreferredSkinTone()
+        .then((tone) => {
+            return emojiDatabase.getEmojiBySearchQuery(query!).then((m) => {
+                const native: NativeEmojiSummary[] = (m as NativeEmoji[])
+                    .filter((m) => m.version < 14)
+                    .map((match) => {
+                        const unicode =
+                            match.skins?.find((s) => s.tone === tone)?.unicode ?? match.unicode;
+                        return {
+                            kind: "native" as const,
+                            unicode,
+                            code: match.shortcodes
+                                ? match.shortcodes[match.shortcodes.length - 1]
+                                : match.annotation,
+                        };
+                    });
+                return [...searchCustomEmojis(query), ...native];
+            });
+        })
+        .catch((err) => {
+            // the emoji database can transiently fail if the browser has closed the
+            // IndexedDB connection (eg. Android backgrounding the app)
+            console.error("Emoji search failed: ", err);
+            return searchCustomEmojis(query);
         });
-    });
 }
 
 export function searchCustomEmojis(query: string): CustomEmojiSummary[] {

--- a/frontend/app/src/utils/errorPostmortem.ts
+++ b/frontend/app/src/utils/errorPostmortem.ts
@@ -60,3 +60,15 @@ export function eventToError(ev: Event): unknown {
     if (ev instanceof ErrorEvent) return ev.error ?? ev.message;
     return ev;
 }
+
+// Chrome on Android closes IndexedDB connections when the app is backgrounded.
+// Any in-flight cache operation (most commonly the emoji database's fire-and-forget
+// background update check) then rejects with this error. The connection is re-opened
+// on next use so nothing is actually broken - keep these out of the crash log.
+export function isIdbConnectionClosingError(err: unknown): boolean {
+    return (
+        err instanceof DOMException &&
+        err.name === "InvalidStateError" &&
+        err.message.includes("database connection is closing")
+    );
+}


### PR DESCRIPTION
## Problem

A user's crash log (mobile web on Android) was dominated by repeated instances of:

```
InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.
```

The stack points at `emoji-picker-element`'s internal database. Its `Database` constructor kicks off a fire-and-forget background update check (`this._lazyUpdate = checkForUpdates(...)`) which is never awaited or caught. Chrome on Android closes IndexedDB connections when the app is backgrounded, so on resume the update check rejects and surfaces as an unhandled rejection.

Nothing is actually broken - the library re-opens the connection on next use via its own `onclose` handling - but the rejection spams the crash log (drowning out real errors) and Rollbar.

## Fix

- Add `isIdbConnectionClosingError` to `errorPostmortem.ts` and swallow this specific rejection in the `unhandledError` handlers of both App.svelte trees.
- Give `searchAllEmojis` a catch fallback (custom emojis only) so an emoji search hitting the same transient condition degrades gracefully instead of rejecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)