### PR TITLE
Terms and privacy: media is not sent to general-purpose classifiers

### DIFF
--- a/frontend/app/src/components/landingpages/PrivacyContent.svelte
+++ b/frontend/app/src/components/landingpages/PrivacyContent.svelte
@@ -234,9 +234,9 @@
             state as described in section 3.
         </li>
         <li>
-            <strong>Safety processors.</strong> Content classification is currently performed by OpenAI.
-            Specialist providers, such as services which match images against databases of known child
-            sexual abuse material, may be added.
+            <strong>Safety processors.</strong> Text classification is currently performed by OpenAI;
+            message media is not sent to OpenAI. Specialist providers, such as services which match
+            images against databases of known child sexual abuse material, may be added.
         </li>
         <li>
             <strong>Feature service providers.</strong> Some features are delivered using third-party

--- a/frontend/app/src/components/landingpages/TermsContent.svelte
+++ b/frontend/app/src/components/landingpages/TermsContent.svelte
@@ -1079,12 +1079,13 @@
                     action may be taken in accordance with these Terms.
                 </li>
                 <li>
-                    Messages sent to public Groups and Channels (including text and media) are
-                    subject to automated classification for safety purposes. This classification is
-                    performed using third-party processors (currently OpenAI; specialist providers,
-                    such as services which match images against databases of known child sexual
-                    abuse material, may be added). Private messages are never proactively scanned;
-                    the content of a private message is classified only if a recipient reports it.
+                    Messages sent to public Groups and Channels are subject to automated
+                    classification for safety purposes. Message text is classified using
+                    third-party processors (currently OpenAI). Message media is not sent to
+                    general-purpose classifiers; it may be checked against databases of known
+                    child sexual abuse material maintained by specialist child-safety
+                    organisations. Private messages are never proactively scanned; the content
+                    of a private message is checked only if a recipient reports it.
                 </li>
                 <li>
                     Where suspected child sexual exploitation or abuse ("<strong>CSEA</strong>")

--- a/frontend/app/src/components_mobile/TermsContent.svelte
+++ b/frontend/app/src/components_mobile/TermsContent.svelte
@@ -1082,12 +1082,13 @@
                     action may be taken in accordance with these Terms.
                 </li>
                 <li>
-                    Messages sent to public Groups and Channels (including text and media) are
-                    subject to automated classification for safety purposes. This classification is
-                    performed using third-party processors (currently OpenAI; specialist providers,
-                    such as services which match images against databases of known child sexual
-                    abuse material, may be added). Private messages are never proactively scanned;
-                    the content of a private message is classified only if a recipient reports it.
+                    Messages sent to public Groups and Channels are subject to automated
+                    classification for safety purposes. Message text is classified using
+                    third-party processors (currently OpenAI). Message media is not sent to
+                    general-purpose classifiers; it may be checked against databases of known
+                    child sexual abuse material maintained by specialist child-safety
+                    organisations. Private messages are never proactively scanned; the content
+                    of a private message is checked only if a recipient reports it.
                 </li>
                 <li>
                     Where suspected child sexual exploitation or abuse ("<strong>CSEA</strong>")


### PR DESCRIPTION
The terms stated that public-message media ("including text and media") is subject to automated classification via OpenAI. Media must never be sent to OpenAI (#9149): their policy prohibits uploads of material that may include CSAM (NCMEC report + account ban), and `omni-moderation`'s `sexual/minors` category is text-only so images could never be scored for it anyway.

Changes (wording only, three files):

- **Terms** (desktop + mobile fork): text is classified via third-party processors (currently OpenAI); media is not sent to general-purpose classifiers and may instead be checked against known-CSAM databases maintained by specialist child-safety organisations. "Classified" → "checked" for reported private messages, since reported media takes the hash/quarantine path rather than classification.
- **Privacy** §6 safety processors: "Content classification" → "Text classification", with an explicit "message media is not sent to OpenAI".

No `CURRENT_TERMS_VERSION` bump: v1 has never been published — the website release carrying it is still pending, so no user has accepted the previous wording.

After merge, `v2.0.2012-website` needs re-cutting onto the new commit before the website proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)