### PR TITLE
Defer group_index moderation-flag back-fill out of post_upgrade

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Defer the moderation-flag back-fill to a timer: pushing to the local-index event queue makes an inter-canister call, which is forbidden during post-upgrade and failed the 2.0.2017 upgrade ([#9155](https://github.com/open-chat-labs/open-chat/pull/9155))
+
 ### Added
 
 - Forward the CSAM assertion flag on reports so quarantine and deletion apply immediately (the suspension waits for the human verdict) ([#9119](https://github.com/open-chat-labs/open-chat/pull/9119))

--- a/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -7,6 +7,7 @@ use group_index_canister::post_upgrade::Args;
 use ic_cdk::post_upgrade;
 use local_user_index_canister::{GroupIndexEvent as LocalIndexEvent, ModerationFlagsChanged};
 use stable_memory::get_reader;
+use std::time::Duration;
 use tracing::info;
 use utils::cycles::init_cycles_dispenser_client;
 use utils::env::canister::CanisterEnv;
@@ -26,27 +27,33 @@ fn post_upgrade(args: Args) {
     init_cycles_dispenser_client(data.cycles_dispenser_canister_id, data.test_mode);
     init_state(env, data, args.wasm_version);
 
-    // One-off: sync existing moderation flags to the community canisters
-    mutate_state(|state| {
-        let flagged: Vec<_> = state
-            .data
-            .public_communities
-            .iter()
-            .filter(|c| !c.moderation_flags().is_empty())
-            .map(|c| (c.id(), c.moderation_flags().bits()))
-            .collect();
+    // One-off: sync existing moderation flags to the community canisters. Deferred to a
+    // zero-delay timer because pushing to the local-index event queue flushes it synchronously,
+    // and the resulting inter-canister call is forbidden while still in init mode - this trap
+    // failed the 2.0.2017 upgrade. (The prod-test rehearsal passed because it had no flagged
+    // communities, so the loop body never ran: rehearsing this path requires at least one.)
+    ic_cdk_timers::set_timer(Duration::ZERO, async {
+        mutate_state(|state| {
+            let flagged: Vec<_> = state
+                .data
+                .public_communities
+                .iter()
+                .filter(|c| !c.moderation_flags().is_empty())
+                .map(|c| (c.id(), c.moderation_flags().bits()))
+                .collect();
 
-        let now = state.env.now();
-        for (community_id, flags) in flagged {
-            state.push_community_event_to_local_index(
-                community_id,
-                LocalIndexEvent::CommunityModerationFlagsChanged(ModerationFlagsChanged {
-                    canister_id: community_id.into(),
-                    flags,
-                }),
-                now,
-            );
-        }
+            let now = state.env.now();
+            for (community_id, flags) in flagged {
+                state.push_community_event_to_local_index(
+                    community_id,
+                    LocalIndexEvent::CommunityModerationFlagsChanged(ModerationFlagsChanged {
+                        canister_id: community_id.into(),
+                        flags,
+                    }),
+                    now,
+                );
+            }
+        })
     });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();


### PR DESCRIPTION
The 2.0.2017 group_index upgrade failed on prod with \`"ic0_call_new" cannot be executed in init mode\`: the post_upgrade one-off back-fill pushes \`CommunityModerationFlagsChanged\` events, and the local-index event queue's \`push_many\` flushes synchronously when \`defer_processing\` is off — spawning the c2c send inside the init context. The install was atomically rolled back; prod group_index is untouched on 2.0.1932.

Why rehearsal missed it: prod-test has zero flagged communities, so the back-fill loop body never ran there. The fix's comment records that rehearsing this path requires at least one flagged community — the 2.0.2018 rehearsal should set one on prod-test first.

Fix: run the back-fill on a zero-delay timer, after init completes. The one-off remains value-idempotent across repeated upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)