### PR TITLE
Update GroupIndex changelog post 2.0.2018 release

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -6,15 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
-### Fixed
+### Removed
 
-- Defer the moderation-flag back-fill to a timer: pushing to the local-index event queue makes an inter-canister call, which is forbidden during post-upgrade and failed the 2.0.2017 upgrade ([#9155](https://github.com/open-chat-labs/open-chat/pull/9155))
+- Remove the one-off moderation-flag back-fill now that it has run on prod in the 2.0.2018 release ([#9156](https://github.com/open-chat-labs/open-chat/pull/9156))
+
+## [[2.0.2018](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2018-group_index)] - 2026-08-13
 
 ### Added
 
 - Forward the CSAM assertion flag on reports so quarantine and deletion apply immediately (the suspension waits for the human verdict) ([#9119](https://github.com/open-chat-labs/open-chat/pull/9119))
 - `c2c_moderation_referral` - forwards moderation referrals from group/community canisters to the user_index ([#9119](https://github.com/open-chat-labs/open-chat/pull/9119))
-
 - Add `c2c_csam_detected` endpoint forwarding CSAM detections from groups/communities to user_index ([#9093](https://github.com/open-chat-labs/open-chat/pull/9093))
 - Add `set_group_moderation_flags` endpoint and filter group search by moderation flags ([#9089](https://github.com/open-chat-labs/open-chat/pull/9089))
 
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Defer the moderation-flag back-fill to a timer: pushing to the local-index event queue makes an inter-canister call, which is forbidden during post-upgrade and failed the 2.0.2017 upgrade ([#9155](https://github.com/open-chat-labs/open-chat/pull/9155))
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))
 
 ## [[2.0.1932](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1932-group_index)] - 2025-12-04

--- a/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,13 +1,11 @@
+use crate::Data;
 use crate::lifecycle::init_state;
 use crate::memory::get_upgrades_memory;
-use crate::{Data, mutate_state};
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use group_index_canister::post_upgrade::Args;
 use ic_cdk::post_upgrade;
-use local_user_index_canister::{GroupIndexEvent as LocalIndexEvent, ModerationFlagsChanged};
 use stable_memory::get_reader;
-use std::time::Duration;
 use tracing::info;
 use utils::cycles::init_cycles_dispenser_client;
 use utils::env::canister::CanisterEnv;
@@ -26,35 +24,6 @@ fn post_upgrade(args: Args) {
     let env = Box::new(CanisterEnv::new(data.rng_seed));
     init_cycles_dispenser_client(data.cycles_dispenser_canister_id, data.test_mode);
     init_state(env, data, args.wasm_version);
-
-    // One-off: sync existing moderation flags to the community canisters. Deferred to a
-    // zero-delay timer because pushing to the local-index event queue flushes it synchronously,
-    // and the resulting inter-canister call is forbidden while still in init mode - this trap
-    // failed the 2.0.2017 upgrade. (The prod-test rehearsal passed because it had no flagged
-    // communities, so the loop body never ran: rehearsing this path requires at least one.)
-    ic_cdk_timers::set_timer(Duration::ZERO, async {
-        mutate_state(|state| {
-            let flagged: Vec<_> = state
-                .data
-                .public_communities
-                .iter()
-                .filter(|c| !c.moderation_flags().is_empty())
-                .map(|c| (c.id(), c.moderation_flags().bits()))
-                .collect();
-
-            let now = state.env.now();
-            for (community_id, flags) in flagged {
-                state.push_community_event_to_local_index(
-                    community_id,
-                    LocalIndexEvent::CommunityModerationFlagsChanged(ModerationFlagsChanged {
-                        canister_id: community_id.into(),
-                        flags,
-                    }),
-                    now,
-                );
-            }
-        })
-    });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");


### PR DESCRIPTION
Moves the \`[unreleased]\` entries under a released heading for [2.0.2018](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2018-group_index) (proposal 2336, executed 2026-08-13, superseding the failed 2.0.2017).

Also removes the one-off moderation-flag back-fill from post_upgrade, per the runbook's post-release tidy list — it has now run on prod and re-running it on every future upgrade is pointless traffic. (The remaining tidy items — the storage_bucket \`backfill_csam_hashes\` one-off and the serde compat shims — wait for their own canisters' next cycles.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)