### PR TITLE
Update UserIndex changelog post 2.0.2030 release

### DIFF
--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2030](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2030-user_index)] - 2026-08-20
+
 ### Added
 
 - Create a first-class resolvable moderation report, with an authority-report register entry, for every blocked attempt to re-post CSAM content: immediately due for adjudicated content, mirroring the original report's verdict for content pending review ([#9162](https://github.com/open-chat-labs/open-chat/pull/9162))


### PR DESCRIPTION
Rolls the `[unreleased]` section of the user_index changelog into `2.0.2030`, released to prod 2026-08-20. No code tidy-up was warranted for this release: the train shipped no one-off post-upgrade code or deserialisation shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)