### PR TITLE
Update StorageIndex changelog post 2.0.2031 release

### DIFF
--- a/backend/canisters/storage_index/CHANGELOG.md
+++ b/backend/canisters/storage_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2031](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2031-storage_index)] - 2026-08-20
+
 ### Added
 
 - Relay pending-quarantine blocked-attempt matches to the user_index ([#9162](https://github.com/open-chat-labs/open-chat/pull/9162))


### PR DESCRIPTION
Rolls the `[unreleased]` section of the storage_index changelog into `2.0.2031`, released to prod 2026-08-20. No code tidy-up was warranted for this release: the train shipped no one-off post-upgrade code or deserialisation shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)