### PR TITLE
Update GroupIndex changelog post 2.0.2034 release

### DIFF
--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2034](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2034-group_index)] - 2026-08-20
+
 ### Added
 
 - Relay media hash-match provenance on `c2c_csam_detected` to the user_index ([#9161](https://github.com/open-chat-labs/open-chat/pull/9161))


### PR DESCRIPTION
Rolls the `[unreleased]` section of the group_index changelog into `2.0.2034`, released to prod 2026-08-20. No code tidy-up was warranted for this release: the train shipped no one-off post-upgrade code or deserialisation shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)