### PR TITLE
Update Community changelog post 2.0.2035 release

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2035](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2035-community)] - 2026-08-20
+
 ### Added
 
 - Queue media posted to public channels of public communities for hash scanning and escalate scan matches via the existing CSAM detection path ([#9161](https://github.com/open-chat-labs/open-chat/pull/9161))


### PR DESCRIPTION
Rolls the `[unreleased]` section of the community changelog into `2.0.2035`, released to prod 2026-08-20. No code tidy-up was warranted for this release: the train shipped no one-off post-upgrade code or deserialisation shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)