### PR TITLE
Update Group changelog post 2.0.2036 release

### DIFF
--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
+
 ### Added
 
 - Queue media posted to public groups for hash scanning and escalate scan matches via the existing CSAM detection path ([#9161](https://github.com/open-chat-labs/open-chat/pull/9161))


### PR DESCRIPTION
Rolls the `[unreleased]` section of the group changelog into `2.0.2036`, released to prod 2026-08-20. No code tidy-up was warranted for this release: the train shipped no one-off post-upgrade code or deserialisation shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)