### PR TITLE
Fix OG preview image dimensions being ignored (snake_case vs camelCase)

### DIFF
--- a/frontend/openchat-shared/src/utils/linkPreviews.spec.ts
+++ b/frontend/openchat-shared/src/utils/linkPreviews.spec.ts
@@ -1,7 +1,9 @@
+import { vi } from "vitest";
 import {
     classifyUrl,
     extractEnabledLinks,
     extractMessagePreviews,
+    fetchOgPreviews,
     MAX_LINK_PREVIEWS,
 } from "./linkPreviews";
 
@@ -176,5 +178,76 @@ describe("extractEnabledLinks", () => {
     test("deduplicates URLs", () => {
         const result = extractEnabledLinks("https://example.com https://example.com");
         expect(result).toHaveLength(1);
+    });
+});
+
+describe("fetchOgPreviews", () => {
+    const proxyUrl = "https://preview.test";
+    let imagesCreated = 0;
+
+    beforeEach(() => {
+        imagesCreated = 0;
+        class FakeImage {
+            onload: (() => void) | null = null;
+            onerror: (() => void) | null = null;
+            naturalWidth = 800;
+            naturalHeight = 600;
+            constructor() {
+                imagesCreated++;
+            }
+            set src(value: string) {
+                if (value !== "") {
+                    setTimeout(() => this.onload?.(), 0);
+                }
+            }
+        }
+        vi.stubGlobal("Image", FakeImage);
+        vi.stubGlobal("fetch", (input: string) => {
+            const target = new URL(input).searchParams.get("url");
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve(ogResponses[target ?? ""]),
+            });
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const ogResponses: Record<string, unknown> = {
+        "https://with-dimensions.test": {
+            title: "With dimensions",
+            description: "desc",
+            image: "https://with-dimensions.test/img.png",
+            imageAlt: "alt text",
+            imageWidth: 1200,
+            imageHeight: 630,
+        },
+        "https://without-dimensions.test": {
+            title: "Without dimensions",
+            description: "desc",
+            image: "https://without-dimensions.test/img.png",
+        },
+    };
+
+    test("uses the camelCase dimensions from the service without measuring the image", async () => {
+        const [preview] = await fetchOgPreviews(["https://with-dimensions.test"], proxyUrl);
+        expect(preview.image).toEqual({
+            url: "https://with-dimensions.test/img.png",
+            width: 1200,
+            height: 630,
+        });
+        expect(imagesCreated).toBe(0);
+    });
+
+    test("falls back to measuring the image when the service sends no dimensions", async () => {
+        const [preview] = await fetchOgPreviews(["https://without-dimensions.test"], proxyUrl);
+        expect(preview.image).toEqual({
+            url: "https://without-dimensions.test/img.png",
+            width: 800,
+            height: 600,
+        });
+        expect(imagesCreated).toBe(1);
     });
 });

--- a/frontend/openchat-shared/src/utils/linkPreviews.ts
+++ b/frontend/openchat-shared/src/utils/linkPreviews.ts
@@ -18,9 +18,9 @@ export type OgData = {
     title?: string;
     description?: string;
     image?: string;
-    image_alt?: string;
-    image_width?: number;
-    image_height?: number;
+    imageAlt?: string;
+    imageWidth?: number;
+    imageHeight?: number;
 };
 
 const ogPromiseCache = new Map<string, Promise<OgData | null>>();
@@ -191,9 +191,12 @@ async function fetchSinglePreview(url: string, proxyUrl: string): Promise<OgPrev
     };
 
     if (data.image) {
-        let width = data.image_width;
-        let height = data.image_height;
+        let width = data.imageWidth;
+        let height = data.imageHeight;
         if (width === undefined || height === undefined) {
+            // The preview service only reports dimensions when the source page
+            // provides og:image:width/height, so fall back to measuring in the
+            // browser - otherwise GenericPreview drops the image altogether.
             const dims = await getImageDimensions(data.image);
             width = dims?.width;
             height = dims?.height;


### PR DESCRIPTION
## Problem

`OgData` in `frontend/openchat-shared/src/utils/linkPreviews.ts` declared the wire fields as `image_alt`, `image_width`, `image_height`, but the preview service behind `OC_PREVIEW_PROXY_URL` (openchat-preview-go) emits camelCase: `imageAlt`, `imageWidth`, `imageHeight`.

So `data.image_width` / `data.image_height` were `undefined` on *every* response, and `fetchSinglePreview` always fell through to `getImageDimensions()`, which constructs a browser `Image()` and re-downloads the preview image purely to measure it. That's a wasted network fetch per preview image, per viewer.

## Fix

Rename the `OgData` fields to the camelCase names the service actually sends, and read those in `fetchSinglePreview`.

`image_alt` / `imageAlt` was not read anywhere else in the codebase (checked both `components/` and `components_mobile/`), so the rename is confined to the type.

## The fallback is deliberate — please don't tidy it away

`getImageDimensions` and the code path that calls it when dimensions are missing are **intentionally retained**.

The upstream service is being changed separately to measure image dimensions server-side when the source page lacks `og:image:width` / `og:image:height` meta tags, but that ships on its own schedule. Until then, such pages still return no dimensions — and `GenericPreview.svelte` (both desktop and mobile) drops the image entirely when width or height is 0. Removing the client-side fallback now would turn this into a visible regression. Belt and braces.

## Tests

Added two cases to `linkPreviews.spec.ts` covering `fetchOgPreviews`:
- camelCase dimensions from the service are used directly, and **no** `Image()` is constructed (the regression this PR fixes)
- when the service sends no dimensions, the fallback fires and measures the image

Verified the first test fails against the old snake_case code.

## Verification

- `npx vitest --run` (whole frontend workspace): 34 files, 424 tests passed
- `npm run typecheck` (svelte-check): 0 errors

Frontend only — no canister/Rust changes, no candid regeneration, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)