### PR TITLE
Bump backend terms version so the acceptance notice fires

### DIFF
--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Bump the current terms version to 2 so users are asked to accept the updated terms naming the PhotoDNA/Microsoft media-matching processor ([#9174](https://github.com/open-chat-labs/open-chat/pull/9174))
+
 ## [[2.0.2030](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2030-user_index)] - 2026-08-20
 
 ### Added

--- a/backend/canisters/user_index/impl/src/updates/accept_terms.rs
+++ b/backend/canisters/user_index/impl/src/updates/accept_terms.rs
@@ -30,3 +30,34 @@ fn accept_terms_impl(args: Args, state: &mut RuntimeState) -> Response {
         Response::Error(OCErrorCode::InitiatorNotFound.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The frontend holds its own copy of this constant (it labels the terms text and acts
+    // as a fallback when the server value is absent); the two must move in lockstep or the
+    // terms-updated notice either never fires (backend behind) or loops forever (frontend
+    // behind). Parses the frontend source so a half-bump fails CI.
+    #[test]
+    fn terms_version_matches_frontend() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../../frontend/openchat-shared/src/constants.ts"
+        );
+        let src = std::fs::read_to_string(path).unwrap();
+        let line = src
+            .lines()
+            .find(|l| l.contains("CURRENT_TERMS_VERSION"))
+            .expect("CURRENT_TERMS_VERSION not found in frontend constants.ts");
+        let frontend_version: u32 = line
+            .split('=')
+            .nth(1)
+            .unwrap()
+            .trim()
+            .trim_end_matches(';')
+            .parse()
+            .expect("failed to parse frontend CURRENT_TERMS_VERSION");
+        assert_eq!(frontend_version, CURRENT_TERMS_VERSION);
+    }
+}

--- a/backend/canisters/user_index/impl/src/updates/accept_terms.rs
+++ b/backend/canisters/user_index/impl/src/updates/accept_terms.rs
@@ -7,7 +7,7 @@ use user_index_canister::accept_terms::*;
 // Bump alongside the frontend CURRENT_TERMS_VERSION whenever the terms change. Acceptance is
 // clamped to this so a client cannot pre-accept future terms (eg. u32::MAX) and suppress
 // every future notice.
-pub const CURRENT_TERMS_VERSION: u32 = 1;
+pub const CURRENT_TERMS_VERSION: u32 = 2;
 
 // Records the user's acceptance of the platform terms (an affirmative click on the
 // terms-updated notice). The version and timestamp are kept as evidence of acceptance.


### PR DESCRIPTION
Completes the terms-version bump started in #9173. The modal gate (`Home.svelte`) compares the user's accepted version against `current_terms_version` from the user_index `current_user` response — the frontend `CURRENT_TERMS_VERSION` is only a fallback — and `accept_terms` clamps submissions to the backend constant. So without this, website 2.0.2038 shows no acceptance notice (as observed on web-test) and any acceptance would record version 1.

Needs a user_index release; website 2.0.2038 is correct as-is and the modal fires once the upgraded user_index reports version 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)