### PR TITLE
Load only the selected App tree at startup

### DIFF
--- a/frontend/app/rollup.extras.mjs
+++ b/frontend/app/rollup.extras.mjs
@@ -151,6 +151,17 @@ export function initEnv() {
 // rebuilds always start with a clean slate.
 const lazyModuleCache = new Map();
 
+// The desktop and mobile App trees are loaded from main.ts via dynamic import() so
+// that only the selected tree is fetched. For chunking purposes they are still
+// treated as roots: a node_modules package statically reachable from either tree
+// belongs in the shared, separately-cached vendor chunk, exactly as it did when the
+// trees were imported statically. Without this, every dependency would count as
+// "only dynamically reachable" and the vendor chunk would dissolve into the app chunks.
+const APP_ROOTS = ["/src/components/App.svelte", "/src/components_mobile/App.svelte"];
+function isAppRoot(id) {
+    return APP_ROOTS.some((root) => id.endsWith(root));
+}
+
 // Returns true when every path from `id` back to a bundle entry point passes through
 // at least one dynamic import(), meaning the module will never be loaded on the initial
 // page render.  Circular imports are handled by optimistically treating a module as lazy
@@ -166,7 +177,7 @@ function isOnlyDynamicallyReachable(id, getModuleInfo) {
     lazyModuleCache.set(id, true);
 
     const info = getModuleInfo(id);
-    if (!info || info.isEntry) {
+    if (!info || info.isEntry || isAppRoot(id)) {
         lazyModuleCache.set(id, false);
         return false;
     }

--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -11,25 +11,33 @@ import "./web-components/spoiler";
 import { mobileWidth } from "@client";
 import "svelte";
 import { mount } from "svelte";
-import App from "./components/App.svelte";
-import AppV2 from "./components_mobile/App.svelte";
 import { setNativeTheme, writeNativeCssVariables } from "./theme/themes";
+import { selectLayout } from "./utils/layout";
 
 // Picks the app variant once at startup. The native Android build ships
-// OC_MOBILE_LAYOUT=v2, so phones (viewport < 768px) always mount AppV2
-// (components_mobile). AppV2 is where the native cold-start machinery lives —
+// OC_MOBILE_LAYOUT=v2, so phones (viewport < 768px) always mount the mobile
+// App (components_mobile). That is where the native cold-start machinery lives —
 // reliable notification-tap routing, pending deep-link/tap consumption in
 // Router.svelte, and the listeners-before-svelteReady sequencing. The v1 App
 // (components) only renders on >=768px viewports (desktop web, large tablets)
 // and intentionally does not implement that native cold-start routing.
-const v2 = import.meta.env.OC_MOBILE_LAYOUT === "v2" && mobileWidth.value;
+//
+// The two trees are loaded with dynamic import() so that only the selected one
+// is downloaded and parsed. The decision is made synchronously before either
+// import starts, and the native side queues cold-start events until the mobile
+// App signals svelteReady, so deferring the mount by one chunk load is safe.
+const layout = selectLayout(import.meta.env.OC_MOBILE_LAYOUT, mobileWidth.value);
 
-if (v2) {
+if (layout === "v2") {
     setNativeTheme();
 } else {
     writeNativeCssVariables();
 }
 
-const app = v2 ? mount(AppV2, { target: document.body }) : mount(App, { target: document.body });
+const app = (
+    layout === "v2"
+        ? import("./components_mobile/App.svelte")
+        : import("./components/App.svelte")
+).then(({ default: App }) => mount(App, { target: document.body }));
 
 export default app;

--- a/frontend/app/src/utils/layout.spec.ts
+++ b/frontend/app/src/utils/layout.spec.ts
@@ -1,0 +1,17 @@
+import { selectLayout } from "./layout";
+
+describe("selectLayout", () => {
+    test("v2 flag on a narrow viewport selects the mobile app", () => {
+        expect(selectLayout("v2", true)).toBe("v2");
+    });
+    test("v2 flag on a wide viewport selects the desktop app", () => {
+        expect(selectLayout("v2", false)).toBe("v1");
+    });
+    test("v1 flag always selects the desktop app", () => {
+        expect(selectLayout("v1", true)).toBe("v1");
+        expect(selectLayout("v1", false)).toBe("v1");
+    });
+    test("missing flag selects the desktop app", () => {
+        expect(selectLayout(undefined, true)).toBe("v1");
+    });
+});

--- a/frontend/app/src/utils/layout.ts
+++ b/frontend/app/src/utils/layout.ts
@@ -1,0 +1,8 @@
+export type AppLayout = "v1" | "v2";
+
+// Picks the app variant once at startup. The native Android build ships
+// OC_MOBILE_LAYOUT=v2, so phones (viewport < 768px) always get "v2"
+// (components_mobile). Everything else gets "v1" (components).
+export function selectLayout(mobileLayoutFlag: string | undefined, isMobileWidth: boolean): AppLayout {
+    return mobileLayoutFlag === "v2" && isMobileWidth ? "v2" : "v1";
+}


### PR DESCRIPTION
Closes #9197. Part of #9179.

`main.ts` statically imported both the desktop and mobile App trees and chose between them at runtime, so every page load downloaded and parsed both (~2.5 MB + ~2.3 MB of component source in the main chunk). The layout flag is a runtime `window.OC_CONFIG` override, so Rollup could not tree-shake either branch.

Both trees are now dynamic `import()`s; the decision is still made synchronously before either import starts. The native side queues cold-start events until the mobile App signals `svelteReady`, so deferring the mount by one chunk load is safe.

`manualChunks` treats the two App roots as entry points so the vendor chunk is unchanged and stays separately cacheable across releases. The layout selection is extracted to `utils/layout.ts` with a small spec.

**Measured on webtest vs prod (same user, SW cache bypassed):**

| | prod 2.0.2038 | webtest 2.0.2040 |
|---|---|---|
| JS on initial load, gz | 1,981 KB | 1,643 KB (−17%) |
| JS on initial load, decoded | 8,002 KB | 6,444 KB |
| `main-*.js` | 941 KB gz | 97 KB gz |
| desktop `App-*.js` | (in main) | 444 KB gz |
| mobile `App-*.js` | (in main) | not requested |
| `vendor-*.js` | 755 KB gz | 755 KB gz |
| JS heap after load | 80 MB | 68 MB |

Verified: webtest V1 (2.0.2040), webtest V2 at narrow viewport (2.0.2040.1, mobile chunk only), native Android build cold start + manual flows. Details in #9197.

Noted in passing (pre-existing, not changed here): `components_mobile/Router.svelte`'s `startViewTransition` feature probe never catches its promises, producing an unhandled `InvalidStateError` on the first real transition in V2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e