### PR TITLE
Fix leaked pollers and unbounded client caches

### DIFF
--- a/frontend/app/src/stores/video.ts
+++ b/frontend/app/src/stores/video.ts
@@ -41,6 +41,7 @@ export type RequestToSpeakMessage = DailyEventObjectAppMessage<RequestToSpeak>;
 export type RequestToSpeakMessageResponse = DailyEventObjectAppMessage<RequestToSpeakResponse>;
 export type DemoteParticipantMessage = DailyEventObjectAppMessage<DemoteParticipant>;
 
+const MAX_PREVIOUS_CALLS = 100;
 const previousCalls = new Set<bigint>();
 
 export type IncomingVideoCall = {
@@ -85,6 +86,9 @@ export const incomingVideoCall = {
             if (!previousCalls.has(call.messageId)) {
                 incomingStore.set(call);
                 previousCalls.add(call.messageId);
+                if (previousCalls.size > MAX_PREVIOUS_CALLS) {
+                    previousCalls.delete(previousCalls.values().next().value as bigint);
+                }
             }
         }
     },

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -334,7 +334,7 @@ import {
 } from "@shared";
 import { tick } from "svelte";
 import { locale } from "svelte-i18n";
-import { get } from "svelte/store";
+import { get, type Unsubscriber } from "svelte/store";
 import { AndroidWebAuthnErrorCode } from "tauri-plugin-oc-api";
 import type { OpenChatConfig } from "./config";
 import {
@@ -661,6 +661,10 @@ export class OpenChat {
     #chatsPoller: Poller | undefined = undefined;
     #botsPoller: Poller | undefined = undefined;
     #registryPoller: Poller | undefined = undefined;
+    #onlinePoller: Poller | undefined = undefined;
+    #btcBalancePoller: Poller | undefined = undefined;
+    #btcAddressUnsub: Unsubscriber | undefined = undefined;
+    #oneSecAddressUnsub: Unsubscriber | undefined = undefined;
     #userUpdatePoller: Poller | undefined = undefined;
     #exchangeRatePoller: Poller | undefined = undefined;
     #proposalTalliesPoller: Poller | undefined = undefined;
@@ -1166,7 +1170,8 @@ export class OpenChat {
 
     #startOnlinePoller() {
         if (!anonUserStore.value) {
-            new Poller(
+            this.#onlinePoller?.stop();
+            this.#onlinePoller = new Poller(
                 () =>
                     (this.#worker.send({ kind: "markAsOnline" }) ?? Promise.resolve()).then(
                         (minutesOnline) => minutesOnlineStore.set(minutesOnline),
@@ -8235,21 +8240,25 @@ export class OpenChat {
     }
 
     #startBtcBalanceUpdateJob() {
-        bitcoinAddress.subscribe((addr) => {
+        this.#btcAddressUnsub?.();
+        this.#btcAddressUnsub = bitcoinAddress.subscribe((addr) => {
+            // store subscribers cannot return a cleanup, so stop the previous poller explicitly
+            this.#btcBalancePoller?.stop();
+            this.#btcBalancePoller = undefined;
             if (addr !== undefined) {
-                const poller = new Poller(
+                this.#btcBalancePoller = new Poller(
                     () => this.#updateBtcBalance(addr),
                     ONE_MINUTE_MILLIS,
                     5 * ONE_MINUTE_MILLIS,
                     true,
                 );
-                return () => poller.stop();
             }
         });
     }
 
     #startOneSecBalanceUpdateJob() {
-        oneSecAddress.subscribe((addr) => {
+        this.#oneSecAddressUnsub?.();
+        this.#oneSecAddressUnsub = oneSecAddress.subscribe((addr) => {
             if (addr !== undefined) {
                 this.#oneSecEnableForwarding(currentUserIdStore.value, addr).then(() => {
                     // Check balances in case a deposit was made before the OneSecForwarder

--- a/frontend/openchat-client/src/stores/background.spec.ts
+++ b/frontend/openchat-client/src/stores/background.spec.ts
@@ -1,0 +1,38 @@
+import { vi } from "vitest";
+import { background } from "./background";
+
+describe("background store", () => {
+    test("tracks document.visibilityState and removes its listener when unsubscribed", () => {
+        const addSpy = vi.spyOn(document, "addEventListener");
+        const removeSpy = vi.spyOn(document, "removeEventListener");
+        const visibility = vi.spyOn(document, "visibilityState", "get");
+        visibility.mockReturnValue("visible");
+
+        const values: boolean[] = [];
+        const unsub = background.subscribe((v) => values.push(v));
+        expect(values).toEqual([false]);
+
+        visibility.mockReturnValue("hidden");
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(values).toEqual([false, true]);
+
+        visibility.mockReturnValue("visible");
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(values).toEqual([false, true, false]);
+
+        unsub();
+
+        const added = addSpy.mock.calls.find((c) => c[0] === "visibilitychange");
+        const removed = removeSpy.mock.calls.find((c) => c[0] === "visibilitychange");
+        expect(added).toBeDefined();
+        expect(removed).toBeDefined();
+        expect(removed?.[1]).toBe(added?.[1]);
+
+        // no longer listening
+        visibility.mockReturnValue("hidden");
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(values).toEqual([false, true, false]);
+
+        vi.restoreAllMocks();
+    });
+});

--- a/frontend/openchat-client/src/stores/background.ts
+++ b/frontend/openchat-client/src/stores/background.ts
@@ -7,12 +7,10 @@ export const background = readable(
             set(document.visibilityState === "hidden");
         }
 
-        document.addEventListener("visibilitychange", function () {
-            setVisibility();
-        });
+        document.addEventListener("visibilitychange", setVisibility);
 
         return function stop() {
-            window.removeEventListener("visibilitychange", setVisibility);
+            document.removeEventListener("visibilitychange", setVisibility);
         };
     }
 );

--- a/frontend/openchat-client/src/utils/poller.spec.ts
+++ b/frontend/openchat-client/src/utils/poller.spec.ts
@@ -1,0 +1,54 @@
+import { vi } from "vitest";
+import { Poller } from "./poller";
+
+describe("Poller", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test("runs immediately and then on the interval", async () => {
+        const fn = vi.fn(() => Promise.resolve());
+        const poller = new Poller(fn, 1000, undefined, true);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fn).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fn).toHaveBeenCalledTimes(2);
+        poller.stop();
+    });
+
+    test("does not run immediately when immediate is false", async () => {
+        const fn = vi.fn(() => Promise.resolve());
+        const poller = new Poller(fn, 1000, undefined, false);
+        await vi.advanceTimersByTimeAsync(999);
+        expect(fn).toHaveBeenCalledTimes(0);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(fn).toHaveBeenCalledTimes(1);
+        poller.stop();
+    });
+
+    test("stop prevents further runs", async () => {
+        const fn = vi.fn(() => Promise.resolve());
+        const poller = new Poller(fn, 1000, undefined, true);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fn).toHaveBeenCalledTimes(1);
+        poller.stop();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("an unreferenced poller keeps running (the leak shape fixed in openchat.ts)", async () => {
+        const fn = vi.fn(() => Promise.resolve());
+        const first = new Poller(fn, 1000, undefined, false);
+        const second = new Poller(fn, 1000, undefined, false);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fn).toHaveBeenCalledTimes(2);
+        first.stop();
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fn).toHaveBeenCalledTimes(3);
+        second.stop();
+    });
+});

--- a/frontend/openchat-shared/src/utils/linkPreviews.spec.ts
+++ b/frontend/openchat-shared/src/utils/linkPreviews.spec.ts
@@ -3,8 +3,12 @@ import {
     classifyUrl,
     extractEnabledLinks,
     extractMessagePreviews,
+    fetchOgData,
     fetchOgPreviews,
+    getCachedOgData,
     MAX_LINK_PREVIEWS,
+    OG_CACHE_MAX,
+    ogCacheSizes,
 } from "./linkPreviews";
 
 describe("extractMessagePreviews", () => {
@@ -249,5 +253,45 @@ describe("fetchOgPreviews", () => {
             height: 600,
         });
         expect(imagesCreated).toBe(1);
+    });
+});
+
+describe("fetchOgData cache bounds", () => {
+    const proxyUrl = "https://preview.test";
+
+    beforeEach(() => {
+        vi.stubGlobal("fetch", (input: string) => {
+            const target = new URL(input).searchParams.get("url");
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ title: `title for ${target}` }),
+            });
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test("same url is fetched once and resolved data is cached", async () => {
+        const url = "https://bounded-0.test";
+        const a = fetchOgData(url, proxyUrl);
+        const b = fetchOgData(url, proxyUrl);
+        expect(a).toBe(b);
+        const data = await a;
+        expect(data?.title).toBe(`title for ${url}`);
+        expect(getCachedOgData(url)?.title).toBe(`title for ${url}`);
+    });
+
+    test("caches never exceed OG_CACHE_MAX and evict the oldest entry", async () => {
+        const oldest = "https://bounded-0.test";
+        for (let i = 0; i <= OG_CACHE_MAX + 20; i++) {
+            await fetchOgData(`https://bounded-${i}.test`, proxyUrl);
+        }
+        const sizes = ogCacheSizes();
+        expect(sizes.promises).toBe(OG_CACHE_MAX);
+        expect(sizes.resolved).toBe(OG_CACHE_MAX);
+        expect(getCachedOgData(oldest)).toBeUndefined();
+        expect(getCachedOgData(`https://bounded-${OG_CACHE_MAX + 20}.test`)).toBeDefined();
     });
 });

--- a/frontend/openchat-shared/src/utils/linkPreviews.ts
+++ b/frontend/openchat-shared/src/utils/linkPreviews.ts
@@ -23,8 +23,22 @@ export type OgData = {
     imageHeight?: number;
 };
 
+// Bounded caches: Map preserves insertion order, so deleting the first key evicts the oldest entry
+export const OG_CACHE_MAX = 300;
 const ogPromiseCache = new Map<string, Promise<OgData | null>>();
 const ogResolvedCache = new Map<string, OgData | null>();
+
+function cacheSet<V>(cache: Map<string, V>, key: string, value: V) {
+    cache.delete(key);
+    cache.set(key, value);
+    if (cache.size > OG_CACHE_MAX) {
+        cache.delete(cache.keys().next().value as string);
+    }
+}
+
+export function ogCacheSizes(): { promises: number; resolved: number } {
+    return { promises: ogPromiseCache.size, resolved: ogResolvedCache.size };
+}
 
 export function getCachedOgData(url: string): OgData | null | undefined {
     return ogResolvedCache.get(url); // undefined = not yet resolved
@@ -170,12 +184,12 @@ export function fetchOgData(url: string, proxyUrl: string): Promise<OgData | nul
         .then((data) => (data?.title ? data : null))
         .catch(() => null)
         .then((data) => {
-            if (data !== null) ogResolvedCache.set(url, data);
+            if (data !== null) cacheSet(ogResolvedCache, url, data);
             else ogPromiseCache.delete(url); // don't cache failures — let next mount retry
             return data;
         });
 
-    ogPromiseCache.set(url, promise);
+    cacheSet(ogPromiseCache, url, promise);
     return promise;
 }
 


### PR DESCRIPTION
Closes #9185. Part of #9179.

- `#startBtcBalanceUpdateJob`: the subscriber returned a cleanup function, which Svelte stores discard, so a new one-minute `Poller` (each holding a `derived([background, offline])` subscription) leaked on every `bitcoinAddress` emission. The previous poller is now stopped explicitly and the subscription itself is held so repeat `onCreatedUser` calls do not stack subscriptions. Same subscription handling for `#startOneSecBalanceUpdateJob` (which has no poller).
- `#startOnlinePoller`: held in a field and stopped before recreate, matching `#startRegistryPoller`.
- `stores/background.ts`: add and remove the same listener on the same target (`document`); previously removal targeted `window` with a different function.
- `linkPreviews.ts`: OG preview caches bounded to 300 entries (insertion-order eviction).
- `video.ts`: `previousCalls` capped at 100.

Skipped deliberately: pruning ephemeral messages / drafts / translations on chat switch — product implication needs a decision first.

Tests: new `poller.spec.ts`, `background.spec.ts`, extended `linkPreviews.spec.ts`; full suite 462 passing; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e