### PR TITLE
Skip store publishes that change nothing

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -2803,14 +2803,15 @@ export class OpenChat {
             allUserIds.add(u);
         }
         userStore.addWebhookIds([...webhooks]);
-        selectedChatUserIdsStore.update((set) => {
-            [...allUserIds].forEach((u) => {
-                if (u !== userId) {
-                    set.add(u);
-                }
+        const newChatUserIds = [...allUserIds].filter(
+            (u) => u !== userId && !selectedChatUserIdsStore.value.has(u),
+        );
+        if (newChatUserIds.length > 0) {
+            selectedChatUserIdsStore.update((set) => {
+                newChatUserIds.forEach((u) => set.add(u));
+                return set;
             });
-            return set;
-        });
+        }
         await this.getMissingUsers(allUserIds);
     }
 

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -37,6 +37,7 @@ import {
 import { addToWritableMap } from "../utils";
 import {
     allChatsStore,
+    cryptoBalanceStore,
     allServerChatsStore,
     chatListScopeStore,
     chatSummariesStore,
@@ -752,3 +753,20 @@ function chatMessage(): EventWrapper<Message> {
         },
     };
 }
+
+describe("cryptoBalanceStore", () => {
+    test("setBalance only publishes when the balance changes", () => {
+        let publishes = 0;
+        const unsub = cryptoBalanceStore.subscribe(() => publishes++);
+        publishes = 0;
+        cryptoBalanceStore.setBalance("ledger1", 100n);
+        expect(publishes).toBe(1);
+        cryptoBalanceStore.setBalance("ledger1", 100n);
+        expect(publishes).toBe(1);
+        cryptoBalanceStore.setBalance("ledger1", 200n);
+        expect(publishes).toBe(2);
+        expect(cryptoBalanceStore.value.get("ledger1")).toBe(200n);
+        expect(cryptoBalanceStore.valueIfUpdatedRecently("ledger1")).toBe(200n);
+        unsub();
+    });
+});

--- a/frontend/openchat-client/src/state/app/stores.ts
+++ b/frontend/openchat-client/src/state/app/stores.ts
@@ -144,7 +144,9 @@ function createCryptoBalanceStore() {
         subscribe: (sub: Subscriber<Map<LedgerCanister, bigint>>, invalidate?: () => void) =>
             store.subscribe(sub, invalidate),
         setBalance(ledger: string, balance: bigint) {
-            store.update((s) => s.set(ledger, balance));
+            if (store.value.get(ledger) !== balance) {
+                store.update((s) => s.set(ledger, balance));
+            }
             cryptoBalancesLastUpdated.set(ledger, Date.now());
         },
         valueIfUpdatedRecently(ledger: string): bigint | undefined {

--- a/frontend/openchat-client/src/state/users/state.spec.ts
+++ b/frontend/openchat-client/src/state/users/state.spec.ts
@@ -1,0 +1,104 @@
+import type { UserSummary } from "@shared";
+import { allUsersStore, suspendedUsersStore } from "./stores";
+import { userStore } from "./state";
+
+function user(userId: string, suspended = false): UserSummary {
+    return {
+        kind: "user",
+        userId,
+        username: userId,
+        displayName: undefined,
+        updated: BigInt(0),
+        suspended,
+        diamondStatus: "inactive",
+        chitBalance: 0,
+        totalChitEarned: 0,
+        streak: 0,
+        maxStreak: 0,
+        isUniquePerson: false,
+    };
+}
+
+describe("user store no-op publishes", () => {
+    let publishes = 0;
+    let suspendedPublishes = 0;
+    let unsubs: (() => void)[] = [];
+
+    beforeEach(() => {
+        allUsersStore.set(new Map());
+        suspendedUsersStore.set(new Set());
+        userStore.addMany([user("a"), user("b")]);
+        unsubs = [
+            allUsersStore.subscribe(() => publishes++),
+            suspendedUsersStore.subscribe(() => suspendedPublishes++),
+        ];
+        publishes = 0;
+        suspendedPublishes = 0;
+    });
+
+    afterEach(() => unsubs.forEach((u) => u()));
+
+    describe("setUpdated", () => {
+        test("real update publishes once", () => {
+            userStore.setUpdated(["a", "b"], BigInt(5));
+            expect(publishes).toBe(1);
+            expect(userStore.get("a")?.updated).toBe(BigInt(5));
+            expect(userStore.get("b")?.updated).toBe(BigInt(5));
+        });
+
+        test("empty list does not publish", () => {
+            userStore.setUpdated([], BigInt(5));
+            expect(publishes).toBe(0);
+        });
+
+        test("unknown users do not publish", () => {
+            userStore.setUpdated(["x", "y"], BigInt(5));
+            expect(publishes).toBe(0);
+        });
+
+        test("already at that timestamp does not publish", () => {
+            userStore.setUpdated(["a"], BigInt(5));
+            publishes = 0;
+            userStore.setUpdated(["a"], BigInt(5));
+            expect(publishes).toBe(0);
+        });
+
+        test("mix of known and unknown users publishes once", () => {
+            userStore.setUpdated(["x", "a"], BigInt(5));
+            expect(publishes).toBe(1);
+            expect(userStore.get("a")?.updated).toBe(BigInt(5));
+        });
+    });
+
+    describe("userSuspended", () => {
+        test("real change publishes both stores", () => {
+            userStore.userSuspended("a", true);
+            expect(publishes).toBe(1);
+            expect(suspendedPublishes).toBe(1);
+            expect(userStore.get("a")?.suspended).toBe(true);
+            expect(userStore.suspendedUsers.has("a")).toBe(true);
+        });
+
+        test("unknown user does not publish", () => {
+            userStore.userSuspended("x", true);
+            expect(publishes).toBe(0);
+            expect(suspendedPublishes).toBe(0);
+        });
+
+        test("already in that state does not publish", () => {
+            userStore.userSuspended("a", true);
+            publishes = 0;
+            suspendedPublishes = 0;
+            userStore.userSuspended("a", true);
+            expect(publishes).toBe(0);
+            expect(suspendedPublishes).toBe(0);
+        });
+    });
+
+    describe("addMany", () => {
+        test("empty list does not publish", () => {
+            userStore.addMany([]);
+            expect(publishes).toBe(0);
+        });
+    });
+});

--- a/frontend/openchat-client/src/state/users/state.ts
+++ b/frontend/openchat-client/src/state/users/state.ts
@@ -60,8 +60,14 @@ export class UsersState {
     }
 
     setUpdated(userIds: string[], timestamp: bigint) {
+        const toUpdate = userIds.filter((id) => {
+            const user = allUsersStore.value.get(id);
+            return user !== undefined && user.updated !== timestamp;
+        });
+        if (toUpdate.length === 0) return;
+
         allUsersStore.update((map) => {
-            for (const userId of userIds) {
+            for (const userId of toUpdate) {
                 const user = map.get(userId);
                 if (user !== undefined) {
                     user.updated = timestamp;
@@ -73,6 +79,9 @@ export class UsersState {
     }
 
     userSuspended(userId: string, suspended: boolean) {
+        const existing = allUsersStore.value.get(userId);
+        if (existing === undefined || existing.suspended === suspended) return;
+
         allUsersStore.update((users) => {
             const u = users.get(userId);
             if (u) {

--- a/frontend/openchat-client/src/utils/stores.spec.ts
+++ b/frontend/openchat-client/src/utils/stores.spec.ts
@@ -259,3 +259,32 @@ describe("store value can be accessed", () => {
         });
     });
 });
+
+describe("writable with notEq equality check", () => {
+    const notEq = () => false;
+
+    test("publishes on every set, even with the same reference", () => {
+        const map = new Map<string, number>();
+        const w = writable(map, undefined, notEq);
+        let publishes = 0;
+        w.subscribe(() => publishes++);
+        publishes = 0;
+        w.set(map);
+        w.update((m) => m);
+        expect(publishes).toBe(2);
+    });
+
+    test("not calling set/update is the only way to skip a publish", () => {
+        const w = writable(new Map<string, number>(), undefined, notEq);
+        let publishes = 0;
+        w.subscribe(() => publishes++);
+        publishes = 0;
+        if (w.value.get("a") !== 1) {
+            w.update((m) => m.set("a", 1));
+        }
+        if (w.value.get("a") !== 1) {
+            w.update((m) => m.set("a", 1));
+        }
+        expect(publishes).toBe(1);
+    });
+});


### PR DESCRIPTION
Closes #9180 (items 1 and 2). Part of #9179.

Most client stores use `notEq`, so every `set`/`update` publishes and synchronously recomputes every live derived store even when nothing changed. This adds cheap guards at the mutation sites where the caller can tell:

- `userStore.setUpdated`: only touches users whose `updated` differs; returns before publishing when there are none. This ran `allUsersStore.update` on every 60-second user poll even with an empty list, which in turn re-derived chat summaries and re-parsed mention-bearing Markdown.
- `userStore.userSuspended`: no publish for unknown users or when already in the requested state.
- `cryptoBalanceStore.setBalance`: no publish when the balance is unchanged (timestamp still refreshed).
- `updateUserStoreFromEvents`: `selectedChatUserIdsStore` only updated when the events introduce user ids not already in the set (runs on every events load / scroll-back).

Left alone: undo-paired local-update stores, `markMessageRead` (callers already gate on `isRead`), and stores that receive fresh server objects where equality would need a deep compare. The lazy derived `.value` idea in the issue is out of scope — it needs new invalidation machinery.

Tests: new `state/users/state.spec.ts` (no-op cases failed before the change, pass after), `appStores.spec.ts`, extended `stores.spec.ts`; full suite 467 passing; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e