### PR TITLE
Stop the cache primer on agent replacement; fix stranded worker requests

### DIFF
--- a/frontend/openchat-agent/src/services/localUserIndex/localUserIndex.client.ts
+++ b/frontend/openchat-agent/src/services/localUserIndex/localUserIndex.client.ts
@@ -142,14 +142,15 @@ export class LocalUserIndexClient extends MultiCanisterMsgpackAgent {
         const partialCachedResults = [] as EventWrapper<ChatEvent>[][];
         const requestsToBackend = [] as ChatEventsArgs[];
 
+        const cacheResults = await Promise.all(
+            requests.map((request) =>
+                this.getEventsFromCache(request.context, request.args, !cachePrimer),
+            ),
+        );
+
         for (let i = 0; i < requests.length; i++) {
             const request = requests[i];
-
-            const [cached, missing, dirty, totalMiss] = await this.getEventsFromCache(
-                request.context,
-                request.args,
-                !cachePrimer,
-            );
+            const [cached, missing, dirty, totalMiss] = cacheResults[i];
 
             if (missing.size + dirty.size > MAX_MISSING || totalMiss) {
                 requestsToBackend.push(request);
@@ -184,15 +185,20 @@ export class LocalUserIndexClient extends MultiCanisterMsgpackAgent {
                 requestsToBackend,
             );
 
+            const cacheWrites: Promise<void>[] = [];
             for (let i = 0; i < batchResponse.responses.length; i++) {
                 const request = requestsToBackend[i];
                 const response = batchResponse.responses[i];
 
                 if (response.kind === "success") {
-                    await this.chatsDb.setCachedEvents(
-                        request.context.chatId,
-                        response.result,
-                        request.context.threadRootMessageIndex,
+                    // Snapshot `result` since `events` may be reassigned below (merged with cached events)
+                    // before the write reads it
+                    cacheWrites.push(
+                        this.chatsDb.setCachedEvents(
+                            request.context.chatId,
+                            { ...response.result },
+                            request.context.threadRootMessageIndex,
+                        ),
                     );
                     if (cachePrimer) {
                         this.chatsDb.setCachePrimerEventIndex(
@@ -219,6 +225,7 @@ export class LocalUserIndexClient extends MultiCanisterMsgpackAgent {
                     }
                 }
             }
+            await Promise.all(cacheWrites);
         }
 
         return responses;

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1985,6 +1985,11 @@ export class OpenChatAgent extends EventTarget {
         };
     }
 
+    // Called when this agent instance is replaced or discarded so that background timers do not keep it alive
+    dispose() {
+        this._cachePrimer?.stop();
+    }
+
     #initializeCachePrimer(userCanisterLocalUserIndex: string): Promise<CachePrimer> {
         return this._chatsDb.getCachePrimerEventIndexes().then((idx) => {
             return (this._cachePrimer = new CachePrimer(

--- a/frontend/openchat-agent/src/utils/cachePrimer.spec.ts
+++ b/frontend/openchat-agent/src/utils/cachePrimer.spec.ts
@@ -1,0 +1,94 @@
+import type { ChatEventsArgs, GroupChatSummary, MultiUserChatIdentifier } from "@shared";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { CachePrimer } from "./cachePrimer";
+
+const LUI = "lui-1";
+
+function proposalChat(groupId: string, latestEventIndex = 5): GroupChatSummary {
+    return {
+        kind: "group_chat",
+        id: { kind: "group_chat", groupId },
+        subtype: { kind: "governance_proposals" },
+        localUserIndex: LUI,
+        lastUpdated: BigInt(1),
+        latestEventIndex,
+        latestMessageIndex: latestEventIndex,
+        minVisibleEventIndex: 0,
+        membership: { archived: false, readByMeUpTo: latestEventIndex },
+    } as unknown as GroupChatSummary;
+}
+
+describe("CachePrimer", () => {
+    let getEventsBatch: ReturnType<typeof vi.fn>;
+    let updateProposalTallies: ReturnType<typeof vi.fn>;
+    let primer: CachePrimer;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(console, "debug").mockImplementation(() => {});
+        getEventsBatch = vi.fn((_lui: string, reqs: ChatEventsArgs[]) =>
+            Promise.resolve(reqs.map(() => ({ kind: "failure" }))),
+        );
+        updateProposalTallies = vi.fn(() => Promise.resolve());
+        primer = new CachePrimer(
+            LUI,
+            {},
+            getEventsBatch as never,
+            updateProposalTallies as never,
+            () => {},
+        );
+    });
+
+    afterEach(() => {
+        primer.stop();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    test("proposal chats are passed to updateProposalTallies once each, even when seen on repeated iterations", async () => {
+        const chat = proposalChat("g1");
+        primer.processUpdates([], [chat], []);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(updateProposalTallies).toHaveBeenCalledTimes(1);
+        expect(updateProposalTallies.mock.calls[0][1]).toEqual([chat.id]);
+
+        // Subsequent update iterations re-present the same chat (latestEventIndex bumped so it is queued again)
+        primer.processUpdates([], [proposalChat("g1", 6), proposalChat("g1", 7)], []);
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(updateProposalTallies).toHaveBeenCalledTimes(2);
+        const ids = updateProposalTallies.mock.calls[1][1] as MultiUserChatIdentifier[];
+        expect(ids).toEqual([chat.id]);
+    });
+
+    test("a removed proposal chat is no longer polled", async () => {
+        primer.processUpdates([], [proposalChat("g1"), proposalChat("g2")], []);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(updateProposalTallies.mock.calls[0][1]).toHaveLength(2);
+
+        primer.processUpdates([], [], [], undefined, undefined, ["g1"]);
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(updateProposalTallies).toHaveBeenCalledTimes(2);
+        expect(updateProposalTallies.mock.calls[1][1]).toEqual([
+            { kind: "group_chat", groupId: "g2" },
+        ]);
+    });
+
+    test("stop() cancels the proposal tally poll and the batch runner", async () => {
+        primer.processUpdates([], [proposalChat("g1")], []);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(updateProposalTallies).toHaveBeenCalledTimes(1);
+        expect(getEventsBatch).toHaveBeenCalledTimes(1);
+
+        primer.stop();
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
+        expect(updateProposalTallies).toHaveBeenCalledTimes(1);
+
+        // Further updates after stop are ignored
+        primer.processUpdates([], [proposalChat("g2", 9)], []);
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
+        expect(updateProposalTallies).toHaveBeenCalledTimes(1);
+        expect(getEventsBatch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/openchat-agent/src/utils/cachePrimer.ts
+++ b/frontend/openchat-agent/src/utils/cachePrimer.ts
@@ -31,7 +31,10 @@ export class CachePrimer {
     #proposalTalliesJobStarted: boolean = false;
     #inProgress: Set<string> = new Set();
     #blockedChats: Set<string> = new Set();
-    #proposalChats: Map<string, MultiUserChatIdentifier[]> = new Map();
+    // localUserIndex -> (chatId string -> chatId), keyed by string so each chat is tracked once
+    #proposalChats: Map<string, Map<string, MultiUserChatIdentifier>> = new Map();
+    #proposalTalliesTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+    #stopped: boolean = false;
     #isFirstIteration: boolean = true;
 
     constructor(
@@ -54,6 +57,16 @@ export class CachePrimer {
         return this.#isFirstIteration;
     }
 
+    // Stops the background jobs so a replaced/logged-out agent is not kept alive by their timers
+    stop() {
+        this.#stopped = true;
+        clearTimeout(this.#proposalTalliesTimer);
+        this.#proposalTalliesTimer = undefined;
+        this.#pending = [];
+        this.#proposalChats.clear();
+        debug("stopped");
+    }
+
     processUpdates(
         directChats: DirectChatSummary[],
         groupChats: GroupChatSummary[],
@@ -63,6 +76,8 @@ export class CachePrimer {
         groupsRemoved?: string[],
         communitiesRemoved?: string[],
     ) {
+        if (this.#stopped) return;
+
         directChatsRemoved?.forEach((userId) =>
             this.removeFromPending((c) => c.kind === "direct_chat" && c.userId === userId),
         );
@@ -118,10 +133,10 @@ export class CachePrimer {
         if (chat.kind !== "direct_chat" && chat.subtype?.kind === "governance_proposals") {
             let proposalChatIds = this.#proposalChats.get(localUserIndex);
             if (proposalChatIds === undefined) {
-                proposalChatIds = [];
+                proposalChatIds = new Map();
                 this.#proposalChats.set(localUserIndex, proposalChatIds);
             }
-            proposalChatIds.push(chat.id);
+            proposalChatIds.set(chatIdString, chat.id);
         }
 
         const eventIndexLoadedUpTo = this.eventIndexesLoadedUpTo[chatIdString];
@@ -246,7 +261,7 @@ export class CachePrimer {
             debug(`batch of size ${batch.length} completed`);
         } finally {
             this.#inProgress.clear();
-            if (this.#pending.length === 0) {
+            if (this.#stopped || this.#pending.length === 0) {
                 debug("runner stopped");
                 this.#jobActive = false;
             } else {
@@ -373,17 +388,28 @@ export class CachePrimer {
     private async processProposalTallies() {
         try {
             for (const [localUserIndex, chatIds] of this.#proposalChats) {
-                for (const batch of chunk(chatIds, 10)) {
+                for (const batch of chunk([...chatIds.values()], 10)) {
+                    if (this.#stopped) return;
                     await this.updateProposalTallies(localUserIndex, batch);
                 }
             }
         } finally {
-            setTimeout(() => this.processProposalTallies(), ONE_MINUTE_MILLIS);
+            if (!this.#stopped) {
+                this.#proposalTalliesTimer = setTimeout(
+                    () => this.processProposalTallies(),
+                    ONE_MINUTE_MILLIS,
+                );
+            }
         }
     }
 
     private removeFromPending(excludeFn: (value: ChatIdentifier) => boolean) {
         retain(this.#pending, (c) => !excludeFn(c.chatId));
+        for (const chatIds of this.#proposalChats.values()) {
+            for (const [key, chatId] of chatIds) {
+                if (excludeFn(chatId)) chatIds.delete(key);
+            }
+        }
     }
 
     private filterDirtyEvents(

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -1207,15 +1207,11 @@ async function readAll<Name extends StoreNames<ChatSchema>>(
 ): Promise<Record<string, StoreValue<ChatSchema, Name>>> {
     const transaction = (await db).transaction([storeName]);
     const store = transaction.objectStore(storeName);
-    const cursor = await store.openCursor();
+    const [keys, vals] = await Promise.all([store.getAllKeys(), store.getAll()]);
+    await transaction.done;
     const values: Record<string, StoreValue<ChatSchema, Name>> = {};
-    while (cursor?.key !== undefined) {
-        values[cursor.key as string] = cursor.value;
-        try {
-            await cursor.continue();
-        } catch {
-            break;
-        }
+    for (let i = 0; i < keys.length; i++) {
+        values[keys[i] as string] = vals[i];
     }
     return values;
 }

--- a/frontend/openchat-client/src/workerAgent.spec.ts
+++ b/frontend/openchat-client/src/workerAgent.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { OpenChatConfig } from "./config";
+import { WorkerAgent } from "./workerAgent";
+
+class FakeWorker {
+    static instance: FakeWorker | undefined;
+    onmessage: ((ev: MessageEvent) => void) | undefined;
+    posted: unknown[] = [];
+    constructor() {
+        FakeWorker.instance = this;
+    }
+    postMessage(msg: unknown) {
+        this.posted.push(msg);
+    }
+}
+
+describe("WorkerAgent", () => {
+    beforeEach(() => {
+        vi.stubGlobal("Worker", FakeWorker);
+        vi.spyOn(console, "debug").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    test("a worker_error for an in-flight request rejects its promise with the parsed error", async () => {
+        const agent = new WorkerAgent({
+            websiteVersion: "test",
+            logger: { error: vi.fn(), debug: vi.fn(), warn: vi.fn(), log: vi.fn() },
+        } as unknown as OpenChatConfig);
+        const worker = FakeWorker.instance!;
+
+        const promise = agent.send({ kind: "getUser" } as never);
+        const sent = worker.posted.at(-1) as { correlationId: number };
+
+        const error = new Error("Worker has no agent to handle request: getUser");
+        worker.onmessage!({
+            data: {
+                kind: "worker_error",
+                requestKind: "getUser",
+                correlationId: sent.correlationId,
+                error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
+            },
+        } as MessageEvent);
+
+        await expect(promise).rejects.toMatchObject({
+            message: "Worker has no agent to handle request: getUser",
+        });
+    });
+});

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -283,6 +283,7 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
                     console.debug("anon: init worker", principal, response.kind !== "success");
 
                     logger.debug("WORKER: constructing agent instance");
+                    agent?.dispose();
                     agent = new OpenChatAgent(id, authPrincipalString ?? "", config);
                     agent.addEventListener("openchat_event", handleAgentEvent);
                     return response;
@@ -298,6 +299,7 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
                 correlationId,
                 createOpenChatIdentity(payload.webAuthnCredentialId).then((resp) => {
                     const id = typeof resp !== "string" ? resp : new AnonymousIdentity();
+                    agent?.dispose();
                     agent = new OpenChatAgent(id, authPrincipalString ?? "", config);
                     agent.addEventListener("openchat_event", handleAgentEvent);
                     return typeof resp !== "string"
@@ -317,7 +319,10 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
                 payload,
                 kind,
                 correlationId,
-                ocIdentityStorage.remove().then((_) => (agent = undefined)),
+                ocIdentityStorage.remove().then((_) => {
+                    agent?.dispose();
+                    agent = undefined;
+                }),
             );
             return;
         }
@@ -329,7 +334,16 @@ self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) =>
         }
 
         if (!agent) {
+            // Reject rather than drop the request, otherwise the caller's promise would never settle.
+            // Not routed via sendError since this is expected around login/logout and should not be reported.
             logger.debug("WORKER: agent does not exist: ", msg.data);
+            const error = new Error(`Worker has no agent to handle request: ${kind}`);
+            postMessage({
+                kind: "worker_error",
+                requestKind: kind,
+                correlationId,
+                error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
+            });
             return;
         }
 


### PR DESCRIPTION
Closes #9186. Part of #9179.

- `CachePrimer` tracked governance-proposal chats in a plain array with no dedupe, so ids were appended every time a proposal chat had updates, and the per-minute tally job re-armed itself forever — a replaced or logged-out `OpenChatAgent` stayed alive through that timer (with its HttpAgent, clients and IndexedDB connection). Now keyed by chat id, removed chats are dropped, and `CachePrimer.stop()` / `OpenChatAgent.dispose()` are called from the worker before constructing a new agent and on logout.
- `localUserIndex.client.ts`: independent cache reads and writes in the batch loop run concurrently instead of serially.
- `chatsDb.readAll`: `getAllKeys` + `getAll` in one transaction instead of one `await` per cursor step; `transaction.done` awaited.
- `worker.ts`: a request arriving while there is no agent (logout / before `setAuthIdentity` resolves) was logged and dropped, leaving the caller's promise and the `#inflightRequests` entry hanging forever. It now posts a `worker_error` so the promise rejects. **Behaviour note:** callers in that window now get a rejection instead of a hang; no dependence on "never settles" was found.

Tests: new `cachePrimer.spec.ts` (fails against the old code), `workerAgent.spec.ts`; full suite 459 passing; `tsc` for openchat-agent clean; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e