### PR TITLE
Lazy-load rarely used dependencies out of the initial bundle

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -16,7 +16,6 @@
         expectNotificationTap,
         expectPushNotifications,
     } from "@utils/native/notification_channels";
-    import "@utils/scream";
     import {
         isLandingPageRoute,
         isScrollingRoute,

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -62,7 +62,6 @@
     import Head from "./Head.svelte";
     import Profiler from "./Profiler.svelte";
     import Router from "./Router.svelte";
-    import Snow from "@shared_components/Snow.svelte";
     import UpgradeBanner from "./UpgradeBanner.svelte";
     import Witch from "@shared_components/Witch.svelte";
     import InstallPrompt from "./home/InstallPrompt.svelte";
@@ -723,7 +722,9 @@
     <UpgradeBanner />
 
     {#if $snowing}
-        <Snow />
+        {#await import("@shared_components/Snow.svelte") then { default: Snow }}
+            <Snow />
+        {/await}
     {/if}
 
     {#snippet failed(error, reset)}

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -723,6 +723,8 @@
     {#if $snowing}
         {#await import("@shared_components/Snow.svelte") then { default: Snow }}
             <Snow />
+        {:catch}
+            <!-- snow is cosmetic; ignore a failed chunk load -->
         {/await}
     {/if}
 

--- a/frontend/app/src/components/DateInput.svelte
+++ b/frontend/app/src/components/DateInput.svelte
@@ -21,6 +21,7 @@
     // TODO i18n localisation for the date picker!
 
     import type { ResourceKey } from "@client";
+    import { Spinner } from "component-lib";
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
     import Information from "svelte-material-icons/Information.svelte";
@@ -57,7 +58,9 @@
 </script>
 
 <div class={`input-wrapper date-time ${align} ${!dateIsValid ? "error" : ""}`}>
-    {#await import("svelty-picker") then { default: SveltyPicker }}
+    {#await import("svelty-picker")}
+        <div aria-busy="true"><Spinner /></div>
+    {:then { default: SveltyPicker }}
         <SveltyPicker
             value={localDate}
             {disabled}
@@ -80,6 +83,8 @@
                     ? onchange?.(BigInt(dateValue.getTime()))
                     : onchange?.(null);
             }} />
+    {:catch}
+        <span>Unable to load date picker</span>
     {/await}
     {#if !dateIsValid}
         <div class="error-icon">

--- a/frontend/app/src/components/DateInput.svelte
+++ b/frontend/app/src/components/DateInput.svelte
@@ -24,7 +24,6 @@
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
     import Information from "svelte-material-icons/Information.svelte";
-    import SveltyPicker from "svelty-picker";
     import { i18nKey, interpolate } from "../i18n/i18n";
     import Tooltip from "./tooltip/Tooltip.svelte";
     import Translatable from "./Translatable.svelte";
@@ -58,26 +57,30 @@
 </script>
 
 <div class={`input-wrapper date-time ${align} ${!dateIsValid ? "error" : ""}`}>
-    <SveltyPicker
-        value={localDate}
-        {disabled}
-        {endDate}
-        {format}
-        {inputId}
-        inputClasses={`date-time ${inputClasses}`}
-        {mode}
-        {pickerOnly}
-        placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
-        {required}
-        {startDate}
-        onDateChange={({ dateValue }) => {
-            if (futureOnly && dateValue instanceof Date && dateValue < new Date()) {
-                dateIsValid = false;
-            } else {
-                dateIsValid = true;
-            }
-            dateValue instanceof Date ? onchange?.(BigInt(dateValue.getTime())) : onchange?.(null);
-        }} />
+    {#await import("svelty-picker") then { default: SveltyPicker }}
+        <SveltyPicker
+            value={localDate}
+            {disabled}
+            {endDate}
+            {format}
+            {inputId}
+            inputClasses={`date-time ${inputClasses}`}
+            {mode}
+            {pickerOnly}
+            placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
+            {required}
+            {startDate}
+            onDateChange={({ dateValue }) => {
+                if (futureOnly && dateValue instanceof Date && dateValue < new Date()) {
+                    dateIsValid = false;
+                } else {
+                    dateIsValid = true;
+                }
+                dateValue instanceof Date
+                    ? onchange?.(BigInt(dateValue.getTime()))
+                    : onchange?.(null);
+            }} />
+    {/await}
     {#if !dateIsValid}
         <div class="error-icon">
             <Tooltip position={"top"} align={"middle"}>

--- a/frontend/app/src/components/QRCode.svelte
+++ b/frontend/app/src/components/QRCode.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { QRCodeImage } from "svelte-qrcode-image";
-
     interface Props {
         text: string;
         size?: "default" | "smaller" | "larger";
@@ -24,7 +22,9 @@
         class:smaller={size === "smaller"}
         class:larger={size === "larger"}
         class:full-width-on-mobile={fullWidthOnMobile}>
-        <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {#await import("svelte-qrcode-image") then { QRCodeImage }}
+            <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {/await}
         {#if logo !== undefined}
             <img class="icon" src={logo} />
         {/if}

--- a/frontend/app/src/components/QRCode.svelte
+++ b/frontend/app/src/components/QRCode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { Spinner } from "component-lib";
+
     interface Props {
         text: string;
         size?: "default" | "smaller" | "larger";
@@ -22,8 +24,12 @@
         class:smaller={size === "smaller"}
         class:larger={size === "larger"}
         class:full-width-on-mobile={fullWidthOnMobile}>
-        {#await import("svelte-qrcode-image") then { QRCodeImage }}
+        {#await import("svelte-qrcode-image")}
+            <div aria-busy="true"><Spinner size="2em" /></div>
+        {:then { QRCodeImage }}
             <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {:catch}
+            <p>Unable to load QR code</p>
         {/await}
         {#if logo !== undefined}
             <img class="icon" src={logo} />

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -313,8 +313,9 @@
             preferredDarkThemeName.set("halloween");
         }
         document.body.classList.add("witch");
-        scream.currentTime = 0;
-        scream.play();
+        const audio = scream();
+        audio.currentTime = 0;
+        audio.play();
         window.setTimeout(() => {
             document.body.classList.remove("witch");
         }, 2000);

--- a/frontend/app/src/components/home/profile/Scanner.svelte
+++ b/frontend/app/src/components/home/profile/Scanner.svelte
@@ -35,12 +35,13 @@
     });
 
     export function scan() {
-        import("jsqr-es6")
-            .then((m) => {
-                jsQR = m.default;
-                return navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
-            })
+        navigator.mediaDevices
+            .getUserMedia({ video: { facingMode: "environment" } })
             .then((s) => {
+                if (destroyed) {
+                    s.getTracks().forEach((t) => t.stop());
+                    return;
+                }
                 console.debug("QR: camera stream obtained");
                 stream = new MediaStream(s.getVideoTracks());
                 const video = document.createElement("video");
@@ -52,10 +53,14 @@
                     .play()
                     .then(() => {
                         console.debug("QR: video play promise resolved");
+                        return import("jsqr-es6");
+                    })
+                    .then((m) => {
+                        jsQR = m.default;
                         requestAnimationFrame(() => checkResult(video));
                     })
                     .catch((err) => {
-                        console.debug("QR: error playing video", err);
+                        console.debug("QR: error playing video or loading decoder", err);
                     });
             })
             .catch((err) => {

--- a/frontend/app/src/components/home/profile/Scanner.svelte
+++ b/frontend/app/src/components/home/profile/Scanner.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import jsQR from "jsqr-es6";
     import type { Point } from "jsqr-es6/dist/locator";
+
+    let jsQR: typeof import("jsqr-es6").default | undefined;
 
     interface Props {
         autoscan?: boolean;
@@ -34,8 +35,11 @@
     });
 
     export function scan() {
-        navigator.mediaDevices
-            .getUserMedia({ video: { facingMode: "environment" } })
+        import("jsqr-es6")
+            .then((m) => {
+                jsQR = m.default;
+                return navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
+            })
             .then((s) => {
                 console.debug("QR: camera stream obtained");
                 stream = new MediaStream(s.getVideoTracks());
@@ -84,7 +88,7 @@
                     canvasElement.width,
                     canvasElement.height,
                 );
-                const code = jsQR(imageData.data, imageData.width, imageData.height, {
+                const code = jsQR?.(imageData.data, imageData.width, imageData.height, {
                     inversionAttempts: "dontInvert",
                 });
                 if (code) {

--- a/frontend/app/src/components/onboard/SignUp.svelte
+++ b/frontend/app/src/components/onboard/SignUp.svelte
@@ -16,7 +16,6 @@
     import ErrorMessage from "../ErrorMessage.svelte";
     import FindUser from "../FindUser.svelte";
     import Input from "../Input.svelte";
-    import TermsContent from "../landingpages/TermsContent.svelte";
     import Legend from "../Legend.svelte";
     import ModalContent from "../ModalContent.svelte";
     import Overlay from "../Overlay.svelte";
@@ -46,9 +45,15 @@
     let createdUser: CreatedUser | undefined = undefined;
     let passkeyCreated = $state(false);
 
+    let TermsContent: typeof import("../landingpages/TermsContent.svelte").default | undefined =
+        $state(undefined);
+
     function onShowGuidelines() {
         showGuidelines = true;
         client.gaTrack("show_guidelines_clicked", "registration");
+        if (TermsContent === undefined) {
+            import("../landingpages/TermsContent.svelte").then((m) => (TermsContent = m.default));
+        }
     }
     function onCloseGuidelines() {
         showGuidelines = false;
@@ -177,12 +182,18 @@
             {/snippet}
             {#snippet body()}
                 <span class="guidelines-modal">
-                    <TermsContent />
+                    {#if TermsContent}
+                        <TermsContent />
+                    {/if}
                 </span>
             {/snippet}
             {#snippet footer(onClose)}
                 <span>
-                    <Button onClick={() => onClose?.()} small={!$mobileWidth} tiny={$mobileWidth}>
+                    <Button
+                        onClick={() => onClose?.()}
+                        disabled={TermsContent === undefined}
+                        small={!$mobileWidth}
+                        tiny={$mobileWidth}>
                         <Translatable resourceKey={i18nKey("register.agree")} />
                     </Button>
                 </span>

--- a/frontend/app/src/components/onboard/SignUp.svelte
+++ b/frontend/app/src/components/onboard/SignUp.svelte
@@ -14,6 +14,7 @@
     import Button from "../Button.svelte";
     import ButtonGroup from "../ButtonGroup.svelte";
     import ErrorMessage from "../ErrorMessage.svelte";
+    import { Spinner } from "component-lib";
     import FindUser from "../FindUser.svelte";
     import Input from "../Input.svelte";
     import Legend from "../Legend.svelte";
@@ -47,12 +48,16 @@
 
     let TermsContent: typeof import("../landingpages/TermsContent.svelte").default | undefined =
         $state(undefined);
+    let termsLoadFailed = $state(false);
 
     function onShowGuidelines() {
         showGuidelines = true;
         client.gaTrack("show_guidelines_clicked", "registration");
         if (TermsContent === undefined) {
-            import("../landingpages/TermsContent.svelte").then((m) => (TermsContent = m.default));
+            termsLoadFailed = false;
+            import("../landingpages/TermsContent.svelte")
+                .then((m) => (TermsContent = m.default))
+                .catch(() => (termsLoadFailed = true));
         }
     }
     function onCloseGuidelines() {
@@ -184,6 +189,10 @@
                 <span class="guidelines-modal">
                     {#if TermsContent}
                         <TermsContent />
+                    {:else if termsLoadFailed}
+                        <ErrorMessage>Unable to load the terms. Please try again.</ErrorMessage>
+                    {:else}
+                        <div aria-busy="true"><Spinner /></div>
                     {/if}
                 </span>
             {/snippet}
@@ -191,7 +200,7 @@
                 <span>
                     <Button
                         onClick={() => onClose?.()}
-                        disabled={TermsContent === undefined}
+                        disabled={TermsContent === undefined && !termsLoadFailed}
                         small={!$mobileWidth}
                         tiny={$mobileWidth}>
                         <Translatable resourceKey={i18nKey("register.agree")} />

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -59,7 +59,6 @@
     import IncomingCall from "./home/video/IncomingCall.svelte";
     import VideoCallAccessRequests from "./home/video/VideoCallAccessRequests.svelte";
     import Router from "./Router.svelte";
-    import Snow from "@shared_components/Snow.svelte";
     import UpgradeBanner from "./UpgradeBanner.svelte";
     import { keyboard } from "@src/stores/keyboard.svelte";
 
@@ -391,7 +390,9 @@
     {/if}
 
     {#if $snowing}
-        <Snow />
+        {#await import("@shared_components/Snow.svelte") then { default: Snow }}
+            <Snow />
+        {/await}
     {/if}
 
     {#snippet failed(error, reset)}

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -391,6 +391,8 @@
     {#if $snowing}
         {#await import("@shared_components/Snow.svelte") then { default: Snow }}
             <Snow />
+        {:catch}
+            <!-- snow is cosmetic; ignore a failed chunk load -->
         {/await}
     {/if}
 

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -21,7 +21,6 @@
         expectWindowInsetChange,
     } from "@utils/native/notification_channels";
     import { expectShareTarget, handleShareTarget } from "@utils/native/share_target";
-    import "@utils/scream";
     import { portalState } from "component-lib";
     import {
         type ChatIdentifier,

--- a/frontend/app/src/components_mobile/DateInput.svelte
+++ b/frontend/app/src/components_mobile/DateInput.svelte
@@ -25,7 +25,6 @@
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
     import Information from "svelte-material-icons/Information.svelte";
-    import SveltyPicker from "svelty-picker";
     import { i18nKey, interpolate } from "../i18n/i18n";
     import Translatable from "./Translatable.svelte";
 
@@ -58,26 +57,30 @@
 </script>
 
 <div class={`input-wrapper date-time ${align} ${!dateIsValid ? "error" : ""}`}>
-    <SveltyPicker
-        value={localDate}
-        {disabled}
-        {endDate}
-        {format}
-        {inputId}
-        inputClasses={`date-time ${inputClasses}`}
-        {mode}
-        {pickerOnly}
-        placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
-        {required}
-        {startDate}
-        onDateChange={({ dateValue }) => {
-            if (futureOnly && dateValue instanceof Date && dateValue < new Date()) {
-                dateIsValid = false;
-            } else {
-                dateIsValid = true;
-            }
-            dateValue instanceof Date ? onchange?.(BigInt(dateValue.getTime())) : onchange?.(null);
-        }} />
+    {#await import("svelty-picker") then { default: SveltyPicker }}
+        <SveltyPicker
+            value={localDate}
+            {disabled}
+            {endDate}
+            {format}
+            {inputId}
+            inputClasses={`date-time ${inputClasses}`}
+            {mode}
+            {pickerOnly}
+            placeholder={placeholder !== undefined ? interpolate($_, placeholder) : ""}
+            {required}
+            {startDate}
+            onDateChange={({ dateValue }) => {
+                if (futureOnly && dateValue instanceof Date && dateValue < new Date()) {
+                    dateIsValid = false;
+                } else {
+                    dateIsValid = true;
+                }
+                dateValue instanceof Date
+                    ? onchange?.(BigInt(dateValue.getTime()))
+                    : onchange?.(null);
+            }} />
+    {/await}
     {#if !dateIsValid}
         <div class="error-icon">
             <Tooltip position={"top"} align={"middle"}>

--- a/frontend/app/src/components_mobile/DateInput.svelte
+++ b/frontend/app/src/components_mobile/DateInput.svelte
@@ -20,7 +20,7 @@
 <script lang="ts">
     // TODO i18n localisation for the date picker!
 
-    import { Tooltip } from "component-lib";
+    import { Spinner, Tooltip } from "component-lib";
     import type { ResourceKey } from "@client";
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
@@ -57,7 +57,9 @@
 </script>
 
 <div class={`input-wrapper date-time ${align} ${!dateIsValid ? "error" : ""}`}>
-    {#await import("svelty-picker") then { default: SveltyPicker }}
+    {#await import("svelty-picker")}
+        <div aria-busy="true"><Spinner /></div>
+    {:then { default: SveltyPicker }}
         <SveltyPicker
             value={localDate}
             {disabled}
@@ -80,6 +82,8 @@
                     ? onchange?.(BigInt(dateValue.getTime()))
                     : onchange?.(null);
             }} />
+    {:catch}
+        <span>Unable to load date picker</span>
     {/await}
     {#if !dateIsValid}
         <div class="error-icon">

--- a/frontend/app/src/components_mobile/QRCode.svelte
+++ b/frontend/app/src/components_mobile/QRCode.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { QRCodeImage } from "svelte-qrcode-image";
-
     interface Props {
         text: string;
         size?: "default" | "smaller" | "larger";
@@ -24,7 +22,9 @@
         class:smaller={size === "smaller"}
         class:larger={size === "larger"}
         class:full-width-on-mobile={fullWidthOnMobile}>
-        <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {#await import("svelte-qrcode-image") then { QRCodeImage }}
+            <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {/await}
         {#if logo !== undefined}
             <img class="icon" src={logo} />
         {/if}

--- a/frontend/app/src/components_mobile/QRCode.svelte
+++ b/frontend/app/src/components_mobile/QRCode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { Spinner } from "component-lib";
+
     interface Props {
         text: string;
         size?: "default" | "smaller" | "larger";
@@ -22,8 +24,12 @@
         class:smaller={size === "smaller"}
         class:larger={size === "larger"}
         class:full-width-on-mobile={fullWidthOnMobile}>
-        {#await import("svelte-qrcode-image") then { QRCodeImage }}
+        {#await import("svelte-qrcode-image")}
+            <div aria-busy="true"><Spinner size="2em" /></div>
+        {:then { QRCodeImage }}
             <QRCodeImage {text} errorCorrectionLevel="Q" margin={2} displayClass="qr-code-image" />
+        {:catch}
+            <p>Unable to load QR code</p>
         {/await}
         {#if logo !== undefined}
             <img class="icon" src={logo} />

--- a/frontend/app/src/components_mobile/home/wallet/Scanner.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/Scanner.svelte
@@ -35,12 +35,13 @@
     });
 
     export function scan() {
-        import("jsqr-es6")
-            .then((m) => {
-                jsQR = m.default;
-                return navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
-            })
+        navigator.mediaDevices
+            .getUserMedia({ video: { facingMode: "environment" } })
             .then((s) => {
+                if (destroyed) {
+                    s.getTracks().forEach((t) => t.stop());
+                    return;
+                }
                 console.debug("QR: camera stream obtained");
                 stream = new MediaStream(s.getVideoTracks());
                 const video = document.createElement("video");
@@ -52,10 +53,14 @@
                     .play()
                     .then(() => {
                         console.debug("QR: video play promise resolved");
+                        return import("jsqr-es6");
+                    })
+                    .then((m) => {
+                        jsQR = m.default;
                         requestAnimationFrame(() => checkResult(video));
                     })
                     .catch((err) => {
-                        console.debug("QR: error playing video", err);
+                        console.debug("QR: error playing video or loading decoder", err);
                     });
             })
             .catch((err) => {

--- a/frontend/app/src/components_mobile/home/wallet/Scanner.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/Scanner.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import jsQR from "jsqr-es6";
     import type { Point } from "jsqr-es6/dist/locator";
     import { onMount } from "svelte";
+
+    let jsQR: typeof import("jsqr-es6").default | undefined;
 
     interface Props {
         autoscan?: boolean;
@@ -34,8 +35,11 @@
     });
 
     export function scan() {
-        navigator.mediaDevices
-            .getUserMedia({ video: { facingMode: "environment" } })
+        import("jsqr-es6")
+            .then((m) => {
+                jsQR = m.default;
+                return navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
+            })
             .then((s) => {
                 console.debug("QR: camera stream obtained");
                 stream = new MediaStream(s.getVideoTracks());
@@ -84,7 +88,7 @@
                     canvasElement.width,
                     canvasElement.height,
                 );
-                const code = jsQR(imageData.data, imageData.width, imageData.height, {
+                const code = jsQR?.(imageData.data, imageData.width, imageData.height, {
                     inversionAttempts: "dontInvert",
                 });
                 if (code) {

--- a/frontend/app/src/components_mobile/onboard/SignUp.svelte
+++ b/frontend/app/src/components_mobile/onboard/SignUp.svelte
@@ -9,6 +9,7 @@
         Form,
         Input,
         Sheet,
+        Spinner,
         StatusCard,
         Subtitle,
         Switch,
@@ -49,12 +50,16 @@
 
     let TermsContent: typeof import("../TermsContent.svelte").default | undefined =
         $state(undefined);
+    let termsLoadFailed = $state(false);
 
     function onShowGuidelines() {
         showGuidelines = true;
         client.gaTrack("show_guidelines_clicked", "registration");
         if (TermsContent === undefined) {
-            import("../TermsContent.svelte").then((m) => (TermsContent = m.default));
+            termsLoadFailed = false;
+            import("../TermsContent.svelte")
+                .then((m) => (TermsContent = m.default))
+                .catch(() => (termsLoadFailed = true));
         }
     }
     function onCloseGuidelines() {
@@ -180,8 +185,14 @@
             <Subtitle>OpenChat Terms</Subtitle>
             {#if TermsContent}
                 <TermsContent />
+            {:else if termsLoadFailed}
+                <ErrorMessage>Unable to load the terms. Please try again.</ErrorMessage>
+            {:else}
+                <div aria-busy="true"><Spinner /></div>
             {/if}
-            <Button onClick={onCloseGuidelines} disabled={TermsContent === undefined}>
+            <Button
+                onClick={onCloseGuidelines}
+                disabled={TermsContent === undefined && !termsLoadFailed}>
                 <Translatable resourceKey={i18nKey("register.agree")} />
             </Button>
         </Container>

--- a/frontend/app/src/components_mobile/onboard/SignUp.svelte
+++ b/frontend/app/src/components_mobile/onboard/SignUp.svelte
@@ -20,7 +20,6 @@
     import { _ } from "svelte-i18n";
     import ErrorMessage from "../ErrorMessage.svelte";
     import FindUser from "../FindUser.svelte";
-    import TermsContent from "../TermsContent.svelte";
     import Translatable from "../Translatable.svelte";
     import UsernameInput from "../UsernameInput.svelte";
     import UserPill from "../UserPill.svelte";
@@ -48,9 +47,15 @@
     let passkeyCreated = $state(false);
     let termsAccepted = $state(false);
 
+    let TermsContent: typeof import("../TermsContent.svelte").default | undefined =
+        $state(undefined);
+
     function onShowGuidelines() {
         showGuidelines = true;
         client.gaTrack("show_guidelines_clicked", "registration");
+        if (TermsContent === undefined) {
+            import("../TermsContent.svelte").then((m) => (TermsContent = m.default));
+        }
     }
     function onCloseGuidelines() {
         showGuidelines = false;
@@ -173,8 +178,10 @@
     <Sheet onDismiss={onCloseGuidelines}>
         <Container gap={"lg"} direction={"vertical"} padding={"xl"}>
             <Subtitle>OpenChat Terms</Subtitle>
-            <TermsContent />
-            <Button onClick={onCloseGuidelines}>
+            {#if TermsContent}
+                <TermsContent />
+            {/if}
+            <Button onClick={onCloseGuidelines} disabled={TermsContent === undefined}>
                 <Translatable resourceKey={i18nKey("register.agree")} />
             </Button>
         </Container>

--- a/frontend/app/src/components_shared/RichTextEditor.svelte
+++ b/frontend/app/src/components_shared/RichTextEditor.svelte
@@ -1,3 +1,18 @@
+<script module lang="ts">
+    import bash from "highlight.js/lib/languages/bash";
+    import css from "highlight.js/lib/languages/css";
+    import rust from "highlight.js/lib/languages/rust";
+    import typescript from "highlight.js/lib/languages/typescript";
+    import { createLowlight } from "lowlight";
+
+    // Register the same grammars as utils/markdown.ts rather than `common` (37 grammars)
+    const lowlight = createLowlight();
+    lowlight.register("typescript", typescript);
+    lowlight.register("rust", rust);
+    lowlight.register("bash", bash);
+    lowlight.register("css", css);
+</script>
+
 <script lang="ts">
     import { rtlStore } from "@src/stores/rtl";
     import { Editor, type Content, type JSONContent } from "@tiptap/core";
@@ -7,7 +22,6 @@
     import StarterKit from "@tiptap/starter-kit";
     import { isTouchOnlyDevice } from "component-lib";
     import "highlight.js/styles/base16/helios.css";
-    import { common, createLowlight } from "lowlight";
     import {
         allUsersStore,
         userGroupSummariesStore,
@@ -23,8 +37,6 @@
     import { markdownToDoc, nodeToMarkdown } from "./markdownConversion";
     import { GroupMentionExtension, UserMentionExtension } from "./mentionExtension";
     import { transformPastedHTML } from "./pasteTransform";
-
-    const lowlight = createLowlight(common);
 
     const client = getContext<OpenChat>("client");
 

--- a/frontend/app/src/utils/scream.ts
+++ b/frontend/app/src/utils/scream.ts
@@ -1,1 +1,8 @@
-export const scream = new Audio("/assets/scream.mp3");
+let audio: HTMLAudioElement | undefined;
+
+export function scream(): HTMLAudioElement {
+    if (audio === undefined) {
+        audio = new Audio("/assets/scream.mp3");
+    }
+    return audio;
+}

--- a/frontend/openchat-client/src/utils/rtcConnectionsManager.spec.ts
+++ b/frontend/openchat-client/src/utils/rtcConnectionsManager.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type Handler = (...args: unknown[]) => void;
+
+class FakeConn {
+    open = true;
+    sent: unknown[] = [];
+    handlers = new Map<string, Handler>();
+    constructor(public peer: string) {}
+    on(evt: string, h: Handler) {
+        this.handlers.set(evt, h);
+    }
+    send(m: unknown) {
+        this.sent.push(m);
+    }
+    emit(evt: string, ...args: unknown[]) {
+        this.handlers.get(evt)?.(...args);
+    }
+}
+
+const peers = vi.hoisted(() => ({ instances: [] as FakePeer[] }));
+
+class FakePeer {
+    destroyed = false;
+    disconnected = false;
+    handlers = new Map<string, Handler>();
+    connections: FakeConn[] = [];
+    constructor(
+        public id: string,
+        public options: unknown,
+    ) {
+        peers.instances.push(this);
+    }
+    on(evt: string, h: Handler) {
+        this.handlers.set(evt, h);
+    }
+    connect(id: string) {
+        const c = new FakeConn(id);
+        this.connections.push(c);
+        return c;
+    }
+    emit(evt: string, ...args: unknown[]) {
+        this.handlers.get(evt)?.(...args);
+    }
+}
+
+vi.mock("peerjs", () => ({ default: FakePeer }));
+
+const iceServers = [{ urls: "turn:example" }];
+
+describe("RtcConnectionsManager", () => {
+    beforeEach(() => {
+        peers.instances.length = 0;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(() => Promise.resolve({ json: () => Promise.resolve(iceServers) })),
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    async function setup() {
+        vi.resetModules();
+        const { RtcConnectionsManager } = await import("./rtcConnectionsManager");
+        const mgr = new RtcConnectionsManager();
+        const initPromise = mgr.init("me", "api-key");
+        await vi.waitFor(() => expect(peers.instances.length).toBe(1));
+        const peer = peers.instances[0];
+        peer.emit("open", peer.id);
+        await initPromise;
+        return { mgr, peer };
+    }
+
+    it("creates one peer with fetched ice servers and a prefixed id", async () => {
+        const { peer } = await setup();
+        expect(fetch).toHaveBeenCalledWith(
+            "https://openchat.metered.live/api/v1/turn/credentials?apiKey=api-key",
+        );
+        expect(peer.id).toBe("d_me");
+        expect(peer.options).toEqual({ config: { iceServers } });
+    });
+
+    it("reuses the existing peer on subsequent init", async () => {
+        const { mgr } = await setup();
+        await mgr.init("me", "api-key");
+        expect(peers.instances.length).toBe(1);
+    });
+
+    it("connects to both device ids of a user and sends only on open connections", async () => {
+        const { mgr, peer } = await setup();
+        mgr.create("me", "them", "api-key");
+        await vi.waitFor(() => expect(peer.connections.length).toBe(2));
+        expect(peer.connections.map((c) => c.peer)).toEqual(["m_them", "d_them"]);
+
+        peer.connections[0].emit("open");
+        peer.connections[1].open = false;
+        peer.connections[1].emit("open");
+
+        const msg = { kind: "remote_user_typing" } as never;
+        mgr.sendMessage(["them"], msg);
+        expect(peer.connections[0].sent).toEqual([msg]);
+        expect(peer.connections[1].sent).toEqual([]);
+
+        mgr.disconnectFromUser("them");
+        mgr.sendMessage(["them"], msg);
+        expect(peer.connections[0].sent).toEqual([msg]);
+    });
+
+    it("delivers incoming data to the subscriber", async () => {
+        const { mgr, peer } = await setup();
+        const received: unknown[] = [];
+        mgr.subscribe((m) => received.push(m));
+        const incoming = new FakeConn("m_other");
+        peer.emit("connection", incoming);
+        incoming.emit("data", { hello: 1 });
+        expect(received).toEqual([{ hello: 1 }]);
+    });
+});

--- a/frontend/openchat-client/src/utils/rtcConnectionsManager.ts
+++ b/frontend/openchat-client/src/utils/rtcConnectionsManager.ts
@@ -1,5 +1,5 @@
 import type { WebRtcMessage } from "@shared";
-import Peer, { type DataConnection } from "peerjs";
+import type { DataConnection, default as Peer } from "peerjs";
 
 export class RtcConnectionsManager {
     private connections: Map<string, DataConnection> = new Map<string, DataConnection>();
@@ -61,12 +61,16 @@ export class RtcConnectionsManager {
             return Promise.resolve(this._peer);
         }
 
-        const iceServers = await this.getIceServers(meteredApiKey);
+        // peerjs (and its webrtc-adapter dependency) is only loaded once a peer is needed
+        const [iceServers, { default: PeerCtor }] = await Promise.all([
+            this.getIceServers(meteredApiKey),
+            import("peerjs"),
+        ]);
 
         return new Promise((resolve) => {
             const connectionId = this.getMyConnectionId(me);
 
-            this._peer = new Peer(connectionId, {
+            this._peer = new PeerCtor(connectionId, {
                 // host: "localhost",
                 // port: 4000,
                 // secure: false,

--- a/frontend/openchat-client/src/utils/tracking.spec.ts
+++ b/frontend/openchat-client/src/utils/tracking.spec.ts
@@ -51,6 +51,16 @@ describe("tracking", () => {
         expect(usergeek.trackEvent).not.toHaveBeenCalled();
     });
 
+    it("passes a timeout to requestIdleCallback", async () => {
+        const ric = vi.fn((fn: () => void) => fn());
+        vi.stubGlobal("requestIdleCallback", ric);
+        const t = await load("production");
+        t.initialiseTracking(config);
+        await flush();
+        expect(ric).toHaveBeenCalledWith(expect.any(Function), { timeout: 3000 });
+        expect(usergeek.init).toHaveBeenCalledTimes(1);
+    });
+
     it("initialises usergeek with apiKey and host in production", async () => {
         const t = await load("production");
         t.initialiseTracking(config);
@@ -78,5 +88,21 @@ describe("tracking", () => {
         expect(usergeek.trackSession).toHaveBeenCalledTimes(1);
         expect(usergeek.trackEvent).toHaveBeenCalledWith("evt");
         expect(usergeek.setPrincipal).toHaveBeenNthCalledWith(2, undefined);
+    });
+
+    it("swallows a failed usergeek load and keeps later calls inert", async () => {
+        vi.resetModules();
+        vi.doMock("usergeek-ic-js", () => {
+            throw new Error("chunk failed");
+        });
+        vi.stubEnv("OC_NODE_ENV", "production");
+        const t = await import("./tracking");
+        t.initialiseTracking(config);
+        t.startTrackingSession(principal);
+        t.trackEvent("evt");
+        await flush();
+        expect(usergeek.init).not.toHaveBeenCalled();
+        expect(usergeek.trackEvent).not.toHaveBeenCalled();
+        vi.doMock("usergeek-ic-js", () => ({ Usergeek: usergeek }));
     });
 });

--- a/frontend/openchat-client/src/utils/tracking.spec.ts
+++ b/frontend/openchat-client/src/utils/tracking.spec.ts
@@ -1,0 +1,82 @@
+import { Principal } from "@icp-sdk/core/principal";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenChatConfig } from "../config";
+
+const usergeek = vi.hoisted(() => ({
+    init: vi.fn(),
+    setPrincipal: vi.fn(),
+    trackSession: vi.fn(),
+    trackEvent: vi.fn(),
+}));
+
+vi.mock("usergeek-ic-js", () => ({ Usergeek: usergeek }));
+
+const config = { icUrl: "https://ic0.app", userGeekApiKey: "key" } as OpenChatConfig;
+const principal = "2vxsx-fae";
+
+async function load(nodeEnv: string) {
+    vi.resetModules();
+    vi.stubEnv("OC_NODE_ENV", nodeEnv);
+    return await import("./tracking");
+}
+
+async function flush() {
+    vi.runAllTimers();
+    await vi.runAllTimersAsync();
+}
+
+describe("tracking", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.stubGlobal("requestIdleCallback", undefined);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("does nothing outside production", async () => {
+        const t = await load("development");
+        t.initialiseTracking(config);
+        t.startTrackingSession(principal);
+        t.trackEvent("x");
+        t.endTrackingSession();
+        await flush();
+        expect(usergeek.init).not.toHaveBeenCalled();
+        expect(usergeek.setPrincipal).not.toHaveBeenCalled();
+        expect(usergeek.trackSession).not.toHaveBeenCalled();
+        expect(usergeek.trackEvent).not.toHaveBeenCalled();
+    });
+
+    it("initialises usergeek with apiKey and host in production", async () => {
+        const t = await load("production");
+        t.initialiseTracking(config);
+        await flush();
+        expect(usergeek.init).toHaveBeenCalledTimes(1);
+        expect(usergeek.init).toHaveBeenCalledWith({ apiKey: "key", host: "https://ic0.app" });
+    });
+
+    it("starts a session, tracks events and ends the session after init", async () => {
+        const t = await load("production");
+        t.initialiseTracking(config);
+        t.startTrackingSession(principal);
+        t.trackEvent("evt");
+        t.endTrackingSession();
+        await flush();
+        const order = [
+            usergeek.init.mock.invocationCallOrder[0],
+            usergeek.setPrincipal.mock.invocationCallOrder[0],
+            usergeek.trackSession.mock.invocationCallOrder[0],
+            usergeek.trackEvent.mock.invocationCallOrder[0],
+            usergeek.setPrincipal.mock.invocationCallOrder[1],
+        ];
+        expect([...order].sort((a, b) => a - b)).toEqual(order);
+        expect(usergeek.setPrincipal).toHaveBeenNthCalledWith(1, Principal.fromText(principal));
+        expect(usergeek.trackSession).toHaveBeenCalledTimes(1);
+        expect(usergeek.trackEvent).toHaveBeenCalledWith("evt");
+        expect(usergeek.setPrincipal).toHaveBeenNthCalledWith(2, undefined);
+    });
+});

--- a/frontend/openchat-client/src/utils/tracking.ts
+++ b/frontend/openchat-client/src/utils/tracking.ts
@@ -9,9 +9,16 @@ const shouldTrack = import.meta.env.OC_NODE_ENV === "production";
 // initialised) off the critical path, once the browser is idle.
 let usergeek: Promise<UsergeekApi> | undefined;
 
+const noopUsergeek = {
+    init: () => undefined,
+    setPrincipal: () => undefined,
+    trackSession: () => undefined,
+    trackEvent: () => undefined,
+} as unknown as UsergeekApi;
+
 function whenIdle(fn: () => void): void {
     if (typeof requestIdleCallback === "function") {
-        requestIdleCallback(fn);
+        requestIdleCallback(fn, { timeout: 3000 });
     } else {
         setTimeout(fn, 0);
     }
@@ -23,11 +30,16 @@ export function initialiseTracking({ icUrl, userGeekApiKey }: OpenChatConfig): v
         const host = icUrl;
         usergeek = new Promise((resolve) => {
             whenIdle(() => {
-                import("usergeek-ic-js").then(({ Usergeek }) => {
-                    Usergeek.init({ apiKey, host });
-                    console.log("Usergeek initialised");
-                    resolve(Usergeek);
-                });
+                import("usergeek-ic-js")
+                    .then(({ Usergeek }) => {
+                        Usergeek.init({ apiKey, host });
+                        console.log("Usergeek initialised");
+                        resolve(Usergeek);
+                    })
+                    .catch((err) => {
+                        console.debug("Usergeek failed to initialise", err);
+                        resolve(noopUsergeek);
+                    });
             });
         });
     }

--- a/frontend/openchat-client/src/utils/tracking.ts
+++ b/frontend/openchat-client/src/utils/tracking.ts
@@ -1,33 +1,55 @@
 import { Principal } from "@icp-sdk/core/principal";
 import type { OpenChatConfig } from "../config";
-import { Usergeek } from "usergeek-ic-js";
+
+type UsergeekApi = typeof import("usergeek-ic-js").Usergeek;
 
 const shouldTrack = import.meta.env.OC_NODE_ENV === "production";
+
+// Resolves to the initialised Usergeek instance. The library is only loaded (and
+// initialised) off the critical path, once the browser is idle.
+let usergeek: Promise<UsergeekApi> | undefined;
+
+function whenIdle(fn: () => void): void {
+    if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(fn);
+    } else {
+        setTimeout(fn, 0);
+    }
+}
 
 export function initialiseTracking({ icUrl, userGeekApiKey }: OpenChatConfig): void {
     if (shouldTrack) {
         const apiKey = userGeekApiKey;
         const host = icUrl;
-        Usergeek.init({ apiKey, host });
-        console.log("Usergeek initialised");
+        usergeek = new Promise((resolve) => {
+            whenIdle(() => {
+                import("usergeek-ic-js").then(({ Usergeek }) => {
+                    Usergeek.init({ apiKey, host });
+                    console.log("Usergeek initialised");
+                    resolve(Usergeek);
+                });
+            });
+        });
     }
 }
 
 export function startTrackingSession(identityPrincipal: string): void {
     if (shouldTrack) {
-        Usergeek.setPrincipal(Principal.fromText(identityPrincipal));
-        Usergeek.trackSession();
+        usergeek?.then((u) => {
+            u.setPrincipal(Principal.fromText(identityPrincipal));
+            u.trackSession();
+        });
     }
 }
 
 export function endTrackingSession(): void {
     if (shouldTrack) {
-        Usergeek.setPrincipal(undefined);
+        usergeek?.then((u) => u.setPrincipal(undefined));
     }
 }
 
 export function trackEvent(eventName: string): void {
     if (shouldTrack) {
-        Usergeek.trackEvent(eventName);
+        usergeek?.then((u) => u.trackEvent(eventName));
     }
 }


### PR DESCRIPTION
Closes #9198. Part of #9179.

One commit per item, all low-risk lazy loads:
- `RichTextEditor`: `createLowlight(common)` ran at *instance* scope with 37 highlight.js grammars (~376 KB source in vendor). Now a module-level registry with the same four grammars `utils/markdown.ts` renders with (typescript, rust, bash, css). **User-visible:** composer syntax colouring for other languages (python, json, …) is gone while typing — it now matches the rendered message, which never highlighted them.
- `Snow.svelte` (~100 KB generated CSS, in both App trees) loaded with `{#await import()}` only when `$snowing`; failed chunk ignored rather than tripping the root error boundary.
- `TermsContent` (126 KB × 2) imported when the guidelines modal opens; spinner while loading, inline error + dismissable if the chunk fails; Agree stays disabled until content is shown.
- `scream.mp3` `Audio` constructed on first use instead of at boot.
- Usergeek tracking dynamically imported and initialised on idle (`requestIdleCallback` with 3 s timeout); calls made before init are queued and replayed in order; import failure degrades to a no-op.
- `jsqr-es6`, `svelty-picker`, `svelte-qrcode-image`, `peerjs` (+ transitive `webrtc-adapter`) imported at their trigger points. Scanner keeps `getUserMedia` synchronous with the user gesture and loads the decoder before starting the frame loop.

Addressed from independent review: `{:catch}` + pending branches on every `{#await}`, tracking import failure path, scanner gesture ordering and post-teardown stream cleanup.

Local prod build vs base: vendor 2,644,836 → 1,973,551 B (−671 KB), main 4,149,451 → 3,782,124 B (−367 KB). Webtest numbers to follow.

Tests: new `tracking.spec.ts`, `rtcConnectionsManager.spec.ts`; full suite 464 passing; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e