### PR TITLE
Load daily-js only when a video call starts

### DIFF
--- a/frontend/app/src/components/home/video/ActiveCall.svelte
+++ b/frontend/app/src/components/home/video/ActiveCall.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import type { DailyThemeConfig } from "@daily-co/daily-js";
-    import daily, { type DailyCall } from "@daily-co/daily-js";
+    import type { DailyCall, DailyThemeConfig } from "@daily-co/daily-js";
     import {
         allUsersStore,
         chatIdentifiersEqual,
@@ -137,6 +136,9 @@
                 await call.destroy();
                 call = undefined;
             }
+
+            // daily-js is only loaded when a call actually starts so it stays out of the initial bundle
+            const { default: daily } = await import("@daily-co/daily-js");
 
             call = daily.createFrame(iframeContainer, {
                 token,

--- a/frontend/app/src/components_mobile/home/video/ActiveCall.svelte
+++ b/frontend/app/src/components_mobile/home/video/ActiveCall.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import type { DailyThemeConfig } from "@daily-co/daily-js";
-    import daily, { type DailyCall } from "@daily-co/daily-js";
+    import type { DailyCall, DailyThemeConfig } from "@daily-co/daily-js";
     import { Column, Sheet, Title } from "component-lib";
     import {
         allUsersStore,
@@ -132,6 +131,9 @@
                 await call.destroy();
                 call = undefined;
             }
+
+            // daily-js is only loaded when a call actually starts so it stays out of the initial bundle
+            const { default: daily } = await import("@daily-co/daily-js");
 
             call = daily.createFrame(iframeContainer, {
                 token,

--- a/frontend/app/src/stores/video.spec.ts
+++ b/frontend/app/src/stores/video.spec.ts
@@ -1,0 +1,45 @@
+import { get } from "svelte/store";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@daily-co/daily-js", () => {
+    throw new Error("@daily-co/daily-js must not be loaded when stores/video is imported");
+});
+
+describe("stores/video", () => {
+    test("importing the store does not load @daily-co/daily-js", async () => {
+        await expect(import("./video")).resolves.toBeDefined();
+    });
+
+    test("incomingVideoCall ignores a second ring for the same messageId", async () => {
+        const { incomingVideoCall } = await import("./video");
+        const chatId = { kind: "direct_chat", userId: "u1" } as const;
+        incomingVideoCall.set({ chatId, userId: "u1", messageId: 1n, callType: "default" });
+        expect(get(incomingVideoCall)?.messageId).toBe(1n);
+        incomingVideoCall.set(undefined);
+        incomingVideoCall.set({ chatId, userId: "u1", messageId: 1n, callType: "default" });
+        expect(get(incomingVideoCall)).toBeUndefined();
+        incomingVideoCall.set({ chatId, userId: "u1", messageId: 2n, callType: "default" });
+        expect(get(incomingVideoCall)?.messageId).toBe(2n);
+    });
+
+    test("joining / setView / endCall lifecycle", async () => {
+        const { activeVideoCall, microphone, camera } = await import("./video");
+        const chatId = { kind: "direct_chat", userId: "u1" } as const;
+        activeVideoCall.joining(chatId, "default");
+        expect(get(activeVideoCall)).toMatchObject({
+            status: "joining",
+            chatId,
+            view: "default",
+            accessRequests: [],
+            isOwner: false,
+        });
+        activeVideoCall.setView("minimised");
+        expect(get(activeVideoCall)?.view).toBe("minimised");
+        microphone.set(true);
+        camera.set(true);
+        activeVideoCall.endCall();
+        expect(get(activeVideoCall)).toBeUndefined();
+        expect(get(microphone)).toBe(false);
+        expect(get(camera)).toBe(false);
+    });
+});

--- a/frontend/app/src/stores/video.ts
+++ b/frontend/app/src/stores/video.ts
@@ -3,11 +3,12 @@
  * DailyCall object in a store
  */
 
-import {
-    type DailyCall,
-    type DailyEventObjectAppMessage,
-    type DailyParticipantUpdateOptions,
-    type DailyThemeConfig,
+// type-only so daily-js is not pulled into the initial bundle (verbatimModuleSyntax keeps `import { type X }`)
+import type {
+    DailyCall,
+    DailyEventObjectAppMessage,
+    DailyParticipantUpdateOptions,
+    DailyThemeConfig,
 } from "@daily-co/daily-js";
 import { type ChatIdentifier, type VideoCallType } from "@client";
 import { get, type Subscriber, writable } from "svelte/store";


### PR DESCRIPTION
Part of #9179; first half of #9199 (daily-js). The tiptap/ProseMirror half is deferred to a separate PR.

`@daily-co/daily-js` (~222 KB raw in vendor) was statically reachable from both App trees: `stores/video.ts` used `import { type … }`, which under `verbatimModuleSyntax` is kept as a side-effect import, and both `ActiveCall.svelte` components value-imported it at the top. Now `video.ts` is `import type`, and `ActiveCall` dynamically imports daily-js inside `startOrJoinVideoCall` right before `createFrame` — the existing `try/catch` (toast + `endCall()`) handles a failed chunk load without reaching the root error boundary, and the existing `joining` status is the pending state. `manualChunks` routes it to its own lazy chunk automatically.

Not done on purpose: gating `<ActiveCall>` itself behind `{#await import}` — `App` drives it via `bind:this` and the method needs its container mounted, so that would need a request queue; the in-method import gets the same bundle result in four lines.

**Measured (prod build):** vendor 2,644,878 → 2,422,693 B (−222 KB raw); `@daily-co` absent from vendor's sourcemap; new lazy `daily-esm-*.js` (225 KB) fetched only when a call starts/joins. One extra fetch on the first call after the access-token round trip; cached thereafter.

Tests: new `video.spec.ts` (daily-js mocked to throw on import — fails before, passes after); full suite 458 passing; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e