### PR TITLE
Service worker: notification-only imports, capped media cache

### DIFF
--- a/frontend/openchat-agent/src/notifications.spec.ts
+++ b/frontend/openchat-agent/src/notifications.spec.ts
@@ -1,0 +1,75 @@
+import { Principal } from "@icp-sdk/core/principal";
+import { TypeboxValidationError } from "@shared";
+import { describe, expect, test } from "vitest";
+import * as agent from "./index";
+import * as entry from "./notifications";
+import { serializeToMsgPack } from "./utils/msgpack";
+
+// Characterisation: the service worker decodes push payloads through the
+// notification-only entry point. It must behave exactly like decoding through
+// the full agent barrel, and must still reject malformed payloads.
+
+const sender = Principal.fromText("2vxsx-fae").toUint8Array();
+const timestamp = 1_700_000_000_000n;
+
+const payload = {
+    dm: {
+        s: sender,
+        m: 7,
+        e: 12,
+        sn: "alice",
+        sd: "Alice",
+        ty: "Text",
+        tx: "hello",
+        a: 5n,
+    },
+};
+
+function decode(
+    mod: typeof entry,
+    bytes: Uint8Array,
+): ReturnType<typeof entry.notification> {
+    const deserialized = mod.deserializeFromMsgPack(bytes);
+    const validated = mod.typeboxValidate(deserialized, mod.Notification);
+    return mod.notification(validated, timestamp);
+}
+
+describe("notification entry point", () => {
+    test("exports the same functions and schema as the agent barrel", () => {
+        expect(entry.deserializeFromMsgPack).toBe(agent.deserializeFromMsgPack);
+        expect(entry.typeboxValidate).toBe(agent.typeboxValidate);
+        expect(entry.Notification).toBe(agent.Notification);
+        expect(entry.notification).toBe(agent.notification);
+    });
+
+    test("a valid payload decodes identically via either path", () => {
+        const bytes = serializeToMsgPack(payload);
+        const viaEntry = decode(entry, bytes);
+        const viaAgent = decode(agent, bytes);
+        expect(viaEntry).toEqual(viaAgent);
+        expect(viaEntry).toEqual({
+            kind: "direct_notification",
+            chatId: { kind: "direct_chat", userId: "2vxsx-fae" },
+            messageIndex: 7,
+            messageEventIndex: 12,
+            username: "alice",
+            displayName: "Alice",
+            messageType: "Text",
+            messageText: "hello",
+            imageUrl: undefined,
+            userAvatarId: 5n,
+            cryptoTransfer: undefined,
+            timestamp,
+        });
+    });
+
+    test("a malformed payload fails validation", () => {
+        const bytes = serializeToMsgPack({ dm: { s: sender, sn: "alice" } });
+        expect(() => decode(entry, bytes)).toThrow(TypeboxValidationError);
+    });
+
+    test("an unknown payload variant fails validation", () => {
+        const bytes = serializeToMsgPack({ xx: { anything: true } });
+        expect(() => decode(entry, bytes)).toThrow(TypeboxValidationError);
+    });
+});

--- a/frontend/openchat-agent/src/notifications.ts
+++ b/frontend/openchat-agent/src/notifications.ts
@@ -1,0 +1,7 @@
+// Minimal entry point for the service worker. It exports only what push payload
+// decoding needs so the service worker does not bundle the full agent barrel
+// (every API schema, mapper and client).
+export { deserializeFromMsgPack } from "./utils/msgpack";
+export { typeboxValidate } from "./utils/typebox";
+export { UserNotificationPayload as Notification } from "./typebox";
+export { notification } from "./services/notifications/mappersV2";

--- a/frontend/openchat-agent/src/services/notifications/mappersV2.ts
+++ b/frontend/openchat-agent/src/services/notifications/mappersV2.ts
@@ -12,7 +12,7 @@ import type {
     GroupReaction,
     Notification,
 } from "@shared";
-import { toBigInt32 } from "@shared";
+import { toBigInt32 } from "@shared/utils/bigint";
 import {
     AddedToChannelNotification as TAddedToChannelNotification,
     ChannelMessageNotification as TChannelMessageNotification,

--- a/frontend/openchat-agent/src/utils/mapping.ts
+++ b/frontend/openchat-agent/src/utils/mapping.ts
@@ -1,9 +1,5 @@
-import {
-    type ApiOptionUpdate,
-    type ApiOptionUpdateV2,
-    type OptionUpdate,
-    UnsupportedValueError,
-} from "@shared";
+import type { ApiOptionUpdate, ApiOptionUpdateV2, OptionUpdate } from "@shared";
+import { UnsupportedValueError } from "@shared/domain/error";
 import { Principal } from "@icp-sdk/core/principal";
 import type { ApiPrincipal } from "../services";
 

--- a/frontend/openchat-agent/src/utils/typebox.ts
+++ b/frontend/openchat-agent/src/utils/typebox.ts
@@ -1,7 +1,7 @@
 import { Value } from "@sinclair/typebox/value";
 import type { Static, TSchema } from "@sinclair/typebox";
 import { deepRemoveNullishFields } from "./nullish";
-import { TypeboxValidationError } from "@shared";
+import { TypeboxValidationError } from "@shared/domain/error";
 
 export function typeboxValidate<T extends TSchema>(value: unknown, validator: T): Static<T> {
     try {

--- a/frontend/openchat-service-worker/src/service_worker.ts
+++ b/frontend/openchat-service-worker/src/service_worker.ts
@@ -3,7 +3,7 @@ import {
     Notification as TNotification,
     notification as toNotification,
     typeboxValidate,
-} from "@agent";
+} from "@agent/notifications";
 import type {
     AddedToChannelNotification,
     ChannelIdentifier,
@@ -19,14 +19,12 @@ import type {
     GroupReaction,
     Notification,
 } from "@shared";
-import {
-    isMessageNotification,
-    routeForChatIdentifier,
-    routeForMessage,
-    routeForMessageContext,
-    toTitleCase,
-    UnsupportedValueError,
-} from "@shared";
+// Runtime imports come from the specific modules rather than the @shared barrel so
+// the service worker does not bundle the whole shared package (rollbar, idb, ...).
+import { UnsupportedValueError } from "@shared/domain/error";
+import { isMessageNotification } from "@shared/utils/notifications";
+import { routeForChatIdentifier, routeForMessage, routeForMessageContext } from "@shared/utils/routes";
+import { toTitleCase } from "@shared/utils/string";
 import { ExpirationPlugin } from "workbox-expiration";
 import { staticResourceCache } from "workbox-recipes";
 import { registerRoute } from "workbox-routing";

--- a/frontend/openchat-service-worker/src/service_worker.ts
+++ b/frontend/openchat-service-worker/src/service_worker.ts
@@ -60,6 +60,11 @@ staticResourceCache({
         new CustomCachePlugin(),
         new ExpirationPlugin({
             maxAgeSeconds: 30 * 24 * 60 * 60,
+            // This cache also holds user-uploaded chat media, so cap the number of
+            // entries (the app's own hashed js/css take ~125 of these) and let the
+            // cache be purged rather than failing silently when the origin hits quota.
+            maxEntries: 500,
+            purgeOnQuotaError: true,
         }),
     ],
 });

--- a/frontend/openchat-shared/src/utils/chat.ts
+++ b/frontend/openchat-shared/src/utils/chat.ts
@@ -3,7 +3,6 @@ import type {
     AttachmentContent,
     ChatEvent,
     ChatIdentifier,
-    ChatListScope,
     ChatSummary,
     CryptocurrencyDetails,
     EventsResponse,
@@ -13,7 +12,6 @@ import type {
     IndexRange,
     MemberRole,
     MessageContent,
-    MessageContext,
     MessagePermission,
     Metrics,
     MultiUserChat,
@@ -326,51 +324,7 @@ export function compareRoles(a: MemberRole, b: MemberRole): number {
     return a - b;
 }
 
-export function routeForMessage(
-    scope: ChatListScope["kind"],
-    ctx: MessageContext,
-    messageIndex: number,
-): string {
-    return ctx.threadRootMessageIndex === undefined
-        ? `${routeForMessageContext(scope, ctx)}/${messageIndex}`
-        : `${routeForMessageContext(scope, ctx)}/${messageIndex}?open=true`;
-}
-
-export function routeForMessageContext(
-    scope: ChatListScope["kind"],
-    { chatId, threadRootMessageIndex }: MessageContext,
-    open = false,
-): string {
-    return threadRootMessageIndex === undefined
-        ? routeForChatIdentifier(scope, chatId)
-        : `${routeForChatIdentifier(scope, chatId)}/${threadRootMessageIndex}${
-              open ? "?open=true" : ""
-          }`;
-}
-
-export function routeForChatIdentifier(scope: ChatListScope["kind"], id: ChatIdentifier): string {
-    switch (scope) {
-        case "favourite":
-            switch (id.kind) {
-                case "direct_chat":
-                    return `/favourite/user/${id.userId}`;
-                case "group_chat":
-                    return `/favourite/group/${id.groupId}`;
-                case "channel":
-                    return `/favourite/community/${id.communityId}/channel/${id.channelId}`;
-            }
-            break;
-        default:
-            switch (id.kind) {
-                case "direct_chat":
-                    return `/chats/user/${id.userId}`;
-                case "group_chat":
-                    return `/chats/group/${id.groupId}`;
-                case "channel":
-                    return `/community/${id.communityId}/channel/${id.channelId}`;
-            }
-    }
-}
+export { routeForChatIdentifier, routeForMessage, routeForMessageContext } from "./routes";
 
 export function chatIdentifierToString(chatId: ChatIdentifier): string {
     switch (chatId.kind) {

--- a/frontend/openchat-shared/src/utils/routes.ts
+++ b/frontend/openchat-shared/src/utils/routes.ts
@@ -1,0 +1,50 @@
+import type { ChatIdentifier, ChatListScope, MessageContext } from "../domain";
+
+// Kept free of runtime imports: the service worker bundles this module directly
+// (see openchat-service-worker) and must not pull in the rest of the shared package.
+
+export function routeForMessage(
+    scope: ChatListScope["kind"],
+    ctx: MessageContext,
+    messageIndex: number,
+): string {
+    return ctx.threadRootMessageIndex === undefined
+        ? `${routeForMessageContext(scope, ctx)}/${messageIndex}`
+        : `${routeForMessageContext(scope, ctx)}/${messageIndex}?open=true`;
+}
+
+export function routeForMessageContext(
+    scope: ChatListScope["kind"],
+    { chatId, threadRootMessageIndex }: MessageContext,
+    open = false,
+): string {
+    return threadRootMessageIndex === undefined
+        ? routeForChatIdentifier(scope, chatId)
+        : `${routeForChatIdentifier(scope, chatId)}/${threadRootMessageIndex}${
+              open ? "?open=true" : ""
+          }`;
+}
+
+export function routeForChatIdentifier(scope: ChatListScope["kind"], id: ChatIdentifier): string {
+    switch (scope) {
+        case "favourite":
+            switch (id.kind) {
+                case "direct_chat":
+                    return `/favourite/user/${id.userId}`;
+                case "group_chat":
+                    return `/favourite/group/${id.groupId}`;
+                case "channel":
+                    return `/favourite/community/${id.communityId}/channel/${id.channelId}`;
+            }
+            break;
+        default:
+            switch (id.kind) {
+                case "direct_chat":
+                    return `/chats/user/${id.userId}`;
+                case "group_chat":
+                    return `/chats/group/${id.groupId}`;
+                case "channel":
+                    return `/community/${id.communityId}/channel/${id.channelId}`;
+            }
+    }
+}


### PR DESCRIPTION
Part of #9179; addresses #9201 items 1 and 2 (item 3, sourcemap upload, is split into its own PR).

- The service worker imported from the `@agent` and `@shared` barrels and so bundled every API schema, `chatMappersV2`, rollbar, idb, emoji and more — 550 KB that must parse before the navigation `fetch` handler can answer on a cold start (the iOS PWA white-screen area). A new `openchat-agent/src/notifications.ts` entry exports only what push decoding needs (`deserializeFromMsgPack`, `typeboxValidate`, the `UserNotificationPayload` schema, `notification` mapper); the three route builders move to `openchat-shared/src/utils/routes.ts` (re-exported from `utils/chat.ts`, no call-site changes) and the SW imports specific `@shared/...` modules. **Push payload validation is unchanged** — same schema, same `Value.Parse`; the typebox runtime stays in the bundle for that reason.
- `staticResourceCache` `ExpirationPlugin` gains `maxEntries: 500` and `purgeOnQuotaError: true` (it also holds user-uploaded media; previously unbounded for 30 days and a quota error failed silently). Video kept in scope. Navigation buffering logic, cache routes/matchers and CSP untouched — only import lines and the plugin options changed in `service_worker.ts`.

**Measured (built SW):** 550,316 B / **124.2 KB gz → 390,574 B / 82.5 KB gz** (−29% raw, −34% gz). Removed from the bundle: rollbar, md5/js-sha3/identicon, `chatMappersV2`, externalBot/icpSwap/icpcoins/governance mappers, shared domain/emoji/webrtc modules. Remaining node_modules: `@icp-sdk/core` (Principal), `@noble/hashes`, `@sinclair/typebox`, `idb` (workbox-expiration), `msgpackr`, workbox-*. The largest remaining piece is the generated `typebox.ts` (~133 KB min) because `Type.*` calls are not `/* @__PURE__ */`-annotated — a generator change could cut ~120 KB more; noted as follow-up.

Tests: new `notifications.spec.ts` (entry exports identical to the barrel's; valid DM payload decodes identically via either path; malformed and unknown-variant payloads throw); full suite 459 passing; tsc + svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e