### PR TITLE
Worker: 48× faster response validation; no reply-buffer copy

### DIFF
--- a/frontend/openchat-agent/src/services/canisterAgent/msgpack.spec.ts
+++ b/frontend/openchat-agent/src/services/canisterAgent/msgpack.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+import { TypeboxValidationError } from "@shared";
+import { CommunitySendMessageResponse } from "../../typebox";
+import { serializeToMsgPack } from "../../utils/msgpack";
+import { SingleCanisterMsgpackAgent } from "./msgpack";
+
+// deserializeResponse is the single point where every msgpack canister reply is decoded
+// and validated. It is private static, so reach it through the exported subclass.
+const deserializeResponse = (
+    SingleCanisterMsgpackAgent as unknown as {
+        deserializeResponse: (bytes: Uint8Array, validator: unknown) => unknown;
+    }
+).deserializeResponse;
+
+function replyBytes(value: unknown): Uint8Array {
+    // Mimic a reply that is a view into a larger buffer (non-zero byteOffset).
+    const packed = serializeToMsgPack(value);
+    const buffer = new Uint8Array(packed.length + 8);
+    buffer.set(packed, 8);
+    return buffer.subarray(8);
+}
+
+describe("MsgpackCanisterAgent.deserializeResponse", () => {
+    test("decodes and validates a well-formed reply", () => {
+        const out = deserializeResponse(
+            replyBytes({ Success: { event_index: 1, message_index: 2, timestamp: 3 } }),
+            CommunitySendMessageResponse,
+        );
+        expect(out).toEqual({
+            Success: { event_index: 1, message_index: 2, timestamp: BigInt(3) },
+        });
+    });
+
+    test("a malformed reply still throws TypeboxValidationError", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            for (const bad of [
+                { Success: { event_index: "one", message_index: 2, timestamp: 3 } },
+                { Success: { event_index: 1 } },
+                { Bogus: null },
+                "Success",
+                42,
+            ]) {
+                expect(() =>
+                    deserializeResponse(replyBytes(bad), CommunitySendMessageResponse),
+                ).toThrow(TypeboxValidationError);
+            }
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});

--- a/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
+++ b/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
@@ -226,6 +226,8 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
         responseBytes: Uint8Array,
         validator: Resp,
     ): Static<Resp> {
+        // Passed through without copying: @dfinity/cbor hands us an exact-length `.slice()`
+        // copy of the reply, so re-check this if a cbor upgrade switches to subarray views.
         const response = deserializeFromMsgPack(responseBytes);
         return typeboxValidate(response, validator);
     }

--- a/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
+++ b/frontend/openchat-agent/src/services/canisterAgent/msgpack.ts
@@ -53,7 +53,7 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
                         return Promise.resolve(
                             mapper(
                                 MsgpackCanisterAgent.deserializeResponse(
-                                    resp.reply.arg.slice().buffer,
+                                    resp.reply.arg,
                                     responseValidator,
                                 ),
                                 timestampMs,
@@ -130,7 +130,7 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
                             return Promise.resolve(
                                 mapper(
                                     MsgpackCanisterAgent.deserializeResponse(
-                                        reply.slice().buffer,
+                                        reply,
                                         responseValidator,
                                     ),
                                 ),
@@ -201,12 +201,7 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
                     requestId,
                 );
                 return Promise.resolve(
-                    mapper(
-                        MsgpackCanisterAgent.deserializeResponse(
-                            reply.slice().buffer,
-                            responseValidator,
-                        ),
-                    ),
+                    mapper(MsgpackCanisterAgent.deserializeResponse(reply, responseValidator)),
                 );
             } else {
                 throw new Error(
@@ -228,10 +223,10 @@ abstract class MsgpackCanisterAgent extends CanisterAgent {
     }
 
     private static deserializeResponse<Resp extends TSchema>(
-        responseBytes: ArrayBuffer,
+        responseBytes: Uint8Array,
         validator: Resp,
     ): Static<Resp> {
-        const response = deserializeFromMsgPack(new Uint8Array(responseBytes));
+        const response = deserializeFromMsgPack(responseBytes);
         return typeboxValidate(response, validator);
     }
 }

--- a/frontend/openchat-agent/src/utils/msgpack.spec.ts
+++ b/frontend/openchat-agent/src/utils/msgpack.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { deserializeFromMsgPack, serializeToMsgPack } from "./msgpack";
+
+describe("msgpack", () => {
+    const value = {
+        Success: {
+            events: [
+                { index: 1, timestamp: 1_700_000_000_000, event: { Message: { text: "hi" } } },
+            ],
+            big: BigInt("123456789012345678901234567890"),
+            bytes: new Uint8Array([1, 2, 3]),
+            nested: { a: null, b: undefined, c: [1, "two", 3.5] },
+        },
+    };
+
+    test("round trips", () => {
+        const out = deserializeFromMsgPack(serializeToMsgPack(value));
+        expect(out).toEqual({
+            Success: {
+                events: value.Success.events,
+                big: "123456789012345678901234567890",
+                bytes: new Uint8Array([1, 2, 3]),
+                nested: { c: [1, "two", 3.5] },
+            },
+        });
+    });
+
+    test("decodes a view into a larger buffer with a non-zero byteOffset", () => {
+        // Reply bytes from the agent can be a subarray of a larger response buffer; the
+        // decoder must honour byteOffset/byteLength rather than reading from offset 0.
+        const packed = serializeToMsgPack(value);
+        const padded = new Uint8Array(packed.length + 16);
+        padded.set([0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8], 0);
+        padded.set(packed, 8);
+        const view = padded.subarray(8, 8 + packed.length);
+        expect(view.byteOffset).toBe(8);
+        expect(deserializeFromMsgPack(view)).toEqual(deserializeFromMsgPack(packed.slice()));
+    });
+});

--- a/frontend/openchat-agent/src/utils/msgpack.spec.ts
+++ b/frontend/openchat-agent/src/utils/msgpack.spec.ts
@@ -36,4 +36,14 @@ describe("msgpack", () => {
         expect(view.byteOffset).toBe(8);
         expect(deserializeFromMsgPack(view)).toEqual(deserializeFromMsgPack(packed.slice()));
     });
+
+    test("decoded bytes fields are copies, not views into the reply buffer", () => {
+        const principal = new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+        const packed = serializeToMsgPack({ user_id: principal, text: "x".repeat(2000) });
+        const out = deserializeFromMsgPack<{ user_id: Uint8Array }>(packed);
+        expect(out.user_id).toEqual(principal);
+        expect(out.user_id.byteLength).toBe(principal.byteLength);
+        expect(out.user_id.buffer).not.toBe(packed.buffer);
+        expect(out.user_id.buffer.byteLength).toBe(principal.byteLength);
+    });
 });

--- a/frontend/openchat-agent/src/utils/msgpack.ts
+++ b/frontend/openchat-agent/src/utils/msgpack.ts
@@ -4,6 +4,9 @@ const Packer = new Packr({
     useRecords: false,
     skipValues: [null, undefined],
     largeBigIntToString: true,
+    // Decoded bin fields must be copies, not views into the whole reply buffer: retained
+    // bytes (principals, keys) would otherwise pin and structured-clone the entire reply.
+    copyBuffers: true,
 } as unknown as Options);
 
 export function serializeToMsgPack<T>(value: T): Uint8Array {

--- a/frontend/openchat-agent/src/utils/typebox.spec.ts
+++ b/frontend/openchat-agent/src/utils/typebox.spec.ts
@@ -1,0 +1,324 @@
+// Characterisation tests for typeboxValidate, the validator every msgpack request arg and
+// every canister response passes through. The reference path is the original
+// Value.Parse(["Default", "Convert", "Assert"]) pipeline; typeboxValidate must stay
+// deep-equal to it for valid inputs and must throw wherever it throws.
+import { describe, expect, test, vi } from "vitest";
+import { Value } from "@sinclair/typebox/value";
+import type { TSchema } from "@sinclair/typebox";
+import { TypeboxValidationError } from "@shared";
+import {
+    CommunityEventsResponse,
+    CommunitySendMessageResponse,
+    LocalUserIndexChatEventsArgs,
+    UserIndexUsersArgs,
+    UserIndexUsersResponse,
+    UserUpdatesResponse,
+} from "../typebox";
+import { deepRemoveNullishFields } from "./nullish";
+import { typeboxValidate } from "./typebox";
+
+function reference<T extends TSchema>(value: unknown, schema: T): unknown {
+    return Value.Parse(["Default", "Convert", "Assert"], schema, deepRemoveNullishFields(value));
+}
+
+function message(i: number, extra: Record<string, unknown> = {}) {
+    return {
+        index: i,
+        timestamp: String(1_700_000_000_000 + i), // string -> bigint via Convert
+        expires_at: i % 3 === 0 ? null : undefined, // optional field, removed by nullish walk
+        event: {
+            Message: {
+                message_index: i,
+                message_id: 1_000_000 + i, // number -> bigint via Convert
+                sender: new Uint8Array([1, 2, 3, i % 256]),
+                content:
+                    i % 2 === 0
+                        ? { Text: { text: `m${i}` } }
+                        : { Deleted: { deleted_by: [1, 2, 3], timestamp: BigInt(i) } },
+                reactions: [["👍", [new Uint8Array([9]), "abc"]]],
+                tips: [["aaaaa-aa", [[[1, 2], BigInt(5)]]]],
+                thread_summary:
+                    i % 5 === 0
+                        ? {
+                              participant_ids: ["u1"],
+                              followed_by_me: false,
+                              reply_count: 2,
+                              latest_event_index: 7,
+                              latest_event_timestamp: "123",
+                          }
+                        : undefined,
+                edited: null,
+                forwarded: false,
+                og_previews: null,
+                ...extra,
+            },
+        },
+    };
+}
+
+function eventsResponse(n: number) {
+    return {
+        Success: {
+            events: Array.from({ length: n }, (_, i) => message(i)),
+            unauthorized: null,
+            expired_event_ranges: [[1, 2]],
+            latest_event_index: n,
+            chat_last_updated: 1_700_000_000_000,
+        },
+    };
+}
+
+// Fixtures are factories: structuredClone in jsdom yields Uint8Arrays from another realm
+// which fail Type.Uint8Array, so every case builds a fresh input instead of cloning.
+const updatesResponse = () => ({
+    Success: {
+        timestamp: "1700000000000",
+        username: null,
+        display_name: { SetToSome: "Julian" },
+        blocked_users: [[1, 2, 3], "u2"],
+        achievements_last_seen: 5,
+        total_chit_earned: 1,
+        chit_balance: 2,
+        streak: 3,
+        streak_ends: 4,
+        max_streak: 5,
+        next_daily_claim: "6",
+        premium_items: [1, 2],
+        referrals: null,
+        message_activity_summary: undefined,
+    },
+});
+
+const usersResponse = () => ({
+    Success: {
+        users: [
+            {
+                user_id: "aaaaa-aa",
+                stable: {
+                    username: "bob",
+                    display_name: null,
+                    avatar_id: "12",
+                    diamond_membership_status: "Active",
+                },
+                volatile: { total_chit_earned: 1, chit_balance: 1, streak: 0, max_streak: 0 },
+            },
+            { user_id: [1, 2, 3], stable: undefined, volatile: null },
+        ],
+        deleted: null,
+        timestamp: 99,
+    },
+});
+
+const chatEventsArgs = () => ({
+    requests: [
+        {
+            context: { Group: ["aaaaa-aa", null] },
+            args: { Page: { start_index: 1, ascending: false, max_messages: 50, max_events: 50 } },
+            latest_known_update: null,
+        },
+        {
+            context: { Channel: [[1, 2], "3", 7] },
+            args: { ByIndex: { events: [1, 2, 3] } },
+            latest_known_update: 5,
+        },
+    ],
+});
+
+// getUpdates-shaped: direct_chats.updated items carry OptionUpdate fields which have
+// `default: "NoChange"` annotations, so Value.Default is not a no-op here.
+const updatesWithChats = (bigints: boolean) => ({
+    Success: {
+        timestamp: bigints ? BigInt(1) : 1,
+        direct_chats: {
+            added: [],
+            updated: [
+                {
+                    chat_id: "aaaaa-aa",
+                    last_updated: bigints ? BigInt(2) : "2",
+                    latest_event_index: 5,
+                    notifications_muted: null,
+                    updated_events: [[1, bigints ? BigInt(3) : 3]],
+                    events_ttl: { SetToSome: bigints ? BigInt(9) : 9 },
+                    video_call_in_progress: undefined,
+                },
+                { chat_id: [1, 2], last_updated: bigints ? BigInt(4) : 4, events_ttl: null },
+            ],
+            removed: ["u9"],
+        },
+        total_chit_earned: 1,
+        chit_balance: 2,
+        streak: 3,
+        streak_ends: bigints ? BigInt(4) : 4,
+        max_streak: 5,
+        next_daily_claim: bigints ? BigInt(6) : 6,
+    },
+});
+
+const cases: [string, TSchema, () => unknown][] = [
+    ["CommunityEventsResponse Success", CommunityEventsResponse, () => eventsResponse(12)],
+    ["CommunityEventsResponse Error", CommunityEventsResponse, () => ({ Error: [5, null] })],
+    ["UserUpdatesResponse Success", UserUpdatesResponse, updatesResponse],
+    ["UserUpdatesResponse literal", UserUpdatesResponse, () => "SuccessNoUpdates"],
+    ["UserUpdatesResponse with chats (bigints)", UserUpdatesResponse, () => updatesWithChats(true)],
+    [
+        "UserUpdatesResponse with chats (numbers)",
+        UserUpdatesResponse,
+        () => updatesWithChats(false),
+    ],
+    ["UserIndexUsersResponse", UserIndexUsersResponse, usersResponse],
+    [
+        "CommunitySendMessageResponse",
+        CommunitySendMessageResponse,
+        () => ({ Success: { event_index: 1, message_index: 2, timestamp: "3", expires_at: null } }),
+    ],
+    ["LocalUserIndexChatEventsArgs", LocalUserIndexChatEventsArgs, chatEventsArgs],
+    [
+        "UserIndexUsersArgs",
+        UserIndexUsersArgs,
+        () => ({
+            user_groups: [{ users: ["u1"], updated_since: 10 }],
+            users_suspended_since: null,
+        }),
+    ],
+];
+
+describe("typeboxValidate matches the Value.Parse reference", () => {
+    test.each(cases)("%s", (_name, schema, input) => {
+        const expected = reference(input(), schema);
+        const actual = typeboxValidate(input(), schema);
+        expect(actual).toEqual(expected);
+        // Convert must have produced real bigints, not left strings/numbers behind
+        expect(JSON.stringify(actual, (_k, v) => (typeof v === "bigint" ? "BIGINT" : v))).toEqual(
+            JSON.stringify(expected, (_k, v) => (typeof v === "bigint" ? "BIGINT" : v)),
+        );
+    });
+
+    test("bigint fields are converted from string and number", () => {
+        const out = typeboxValidate(eventsResponse(2), CommunityEventsResponse) as {
+            Success: {
+                events: { timestamp: bigint; event: { Message: { message_id: bigint } } }[];
+            };
+        };
+        expect(typeof out.Success.events[0].timestamp).toBe("bigint");
+        expect(typeof out.Success.events[0].event.Message.message_id).toBe("bigint");
+    });
+
+    test("nullish optional fields are removed, nullish variant keys are kept as null", () => {
+        const out = typeboxValidate(eventsResponse(1), CommunityEventsResponse) as {
+            Success: Record<string, unknown>;
+        };
+        expect("unauthorized" in out.Success).toBe(false);
+        const err = typeboxValidate({ Error: [1, null] }, CommunityEventsResponse);
+        expect(err).toEqual({ Error: [1, null] });
+    });
+
+    test("OptionUpdate defaults are applied exactly as Value.Default applies them", () => {
+        // Value.Default only commits defaults inside a union variant when that variant
+        // already checks (pre-Convert), so they apply when the payload's bigints are real
+        // bigints and do not when they still need converting. Both are pinned here.
+        type Out = {
+            Success: {
+                display_name?: unknown;
+                direct_chats: { updated: Record<string, unknown>[] };
+            };
+        };
+        const applied = typeboxValidate(updatesWithChats(true), UserUpdatesResponse) as Out;
+        expect(applied.Success.display_name).toBe("NoChange");
+        expect(applied.Success.direct_chats.updated[1].events_ttl).toBe("NoChange");
+        expect(applied.Success.direct_chats.updated[0].events_ttl).toEqual({
+            SetToSome: BigInt(9),
+        });
+        expect(applied).toEqual(reference(updatesWithChats(true), UserUpdatesResponse));
+
+        const notApplied = typeboxValidate(updatesWithChats(false), UserUpdatesResponse) as Out;
+        expect("display_name" in notApplied.Success).toBe(false);
+        expect("events_ttl" in notApplied.Success.direct_chats.updated[1]).toBe(false);
+        expect(notApplied).toEqual(reference(updatesWithChats(false), UserUpdatesResponse));
+    });
+
+    test("returns a converted copy, not the input instance", () => {
+        const input = eventsResponse(1);
+        const out = typeboxValidate(input, CommunityEventsResponse);
+        expect(out).not.toBe(input);
+        expect(out).toEqual(reference(eventsResponse(1), CommunityEventsResponse));
+    });
+});
+
+describe("typeboxValidate rejects malformed payloads", () => {
+    const bad: [string, TSchema, () => unknown][] = [
+        [
+            "wrong type for bigint",
+            CommunityEventsResponse,
+            () => ({
+                Success: { ...eventsResponse(1).Success, chat_last_updated: "not-a-number" },
+            }),
+        ],
+        [
+            "missing required field",
+            CommunityEventsResponse,
+            () => ({ Success: { events: [], chat_last_updated: 1 } }),
+        ],
+        ["unknown union variant", CommunityEventsResponse, () => ({ Bogus: {} })],
+        [
+            "wrong nested content type",
+            CommunityEventsResponse,
+            () => ({
+                Success: {
+                    ...eventsResponse(0).Success,
+                    events: [message(1, { content: { Text: { text: { nested: true } } } })],
+                },
+            }),
+        ],
+        ["null where object required", UserUpdatesResponse, () => ({ Success: null })],
+        ["wrong literal", UserUpdatesResponse, () => "SuccessNoUpdatez"],
+        ["array instead of object", UserIndexUsersResponse, () => [1, 2, 3]],
+        ["undefined payload", UserIndexUsersResponse, () => undefined],
+        [
+            "request arg with wrong type",
+            UserIndexUsersArgs,
+            () => ({ user_groups: [{ users: ["u1"], updated_since: {} }] }),
+        ],
+        ["OCError tuple too long", CommunityEventsResponse, () => ({ Error: [1, "x", 3] })],
+    ];
+
+    test.each(bad)("%s", (_name, schema, input) => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            expect(() => reference(input(), schema)).toThrow();
+            let thrown: unknown;
+            try {
+                typeboxValidate(input(), schema);
+            } catch (e) {
+                thrown = e;
+            }
+            expect(thrown).toBeInstanceOf(TypeboxValidationError);
+            expect((thrown as Error).name).toBe("TypeboxValidationError");
+            expect((thrown as Error).message.length).toBeGreaterThan(0);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    test("error message matches the reference error message", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const input = { Success: { events: [], chat_last_updated: 1 } };
+            let refMsg = "";
+            try {
+                reference(input, CommunityEventsResponse);
+            } catch (e) {
+                refMsg = (e as Error).message;
+            }
+            let msg = "";
+            try {
+                typeboxValidate(input, CommunityEventsResponse);
+            } catch (e) {
+                msg = (e as Error).message;
+            }
+            expect(refMsg.length).toBeGreaterThan(0);
+            expect(msg).toBe(refMsg);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});

--- a/frontend/openchat-agent/src/utils/typebox.ts
+++ b/frontend/openchat-agent/src/utils/typebox.ts
@@ -1,11 +1,152 @@
-import { Value } from "@sinclair/typebox/value";
-import type { Static, TSchema } from "@sinclair/typebox";
+import { AssertError, Value } from "@sinclair/typebox/value";
+import { TypeCompiler, type TypeCheck } from "@sinclair/typebox/compiler";
+import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import { deepRemoveNullishFields } from "./nullish";
 import { TypeboxValidationError } from "@shared";
 
+// Compiled checkers are cached per schema object (root schemas and any union members
+// visited by applyDefaults). Compilation is a one-off few ms per schema.
+const compiled = new WeakMap<TSchema, TypeCheck<TSchema>>();
+
+function checkerFor<T extends TSchema>(schema: T): TypeCheck<T> {
+    let check = compiled.get(schema);
+    if (check === undefined) {
+        check = TypeCompiler.Compile(schema);
+        compiled.set(schema, check);
+    }
+    return check as TypeCheck<T>;
+}
+
+// Whether a schema or anything beneath it carries a `default` annotation. Value.Default is
+// deep-identity on a subtree with no defaults, so such subtrees can be skipped entirely.
+const hasDefaultsCache = new WeakMap<TSchema, boolean>();
+
+function hasDefaults(schema: TSchema): boolean {
+    const cached = hasDefaultsCache.get(schema);
+    if (cached !== undefined) return cached;
+    hasDefaultsCache.set(schema, true); // guard against cycles; overwritten below
+    let result = "default" in schema;
+    if (!result) {
+        switch (schema[Kind]) {
+            case "Object":
+                result = Object.values(schema.properties as Record<string, TSchema>).some(
+                    hasDefaults,
+                );
+                break;
+            case "Array":
+                result = hasDefaults(schema.items);
+                break;
+            case "Tuple":
+                result = ((schema.items ?? []) as TSchema[]).some(hasDefaults);
+                break;
+            case "Union":
+                result = (schema.anyOf as TSchema[]).some(hasDefaults);
+                break;
+            case "Record":
+                result =
+                    Object.values(schema.patternProperties as Record<string, TSchema>).some(
+                        hasDefaults,
+                    ) ||
+                    (typeof schema.additionalProperties === "object" &&
+                        hasDefaults(schema.additionalProperties));
+                break;
+            default:
+                // Literal, String, Number, BigInt, Boolean, Null, Uint8Array, Never: leaves
+                result = false;
+        }
+    }
+    hasDefaultsCache.set(schema, result);
+    return result;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object";
+}
+
+function isArray(value: unknown): value is unknown[] {
+    return Array.isArray(value) && !ArrayBuffer.isView(value);
+}
+
+// Mirrors typebox's internal ValueOrDefault.
+function valueOrDefault(schema: TSchema, value: unknown): unknown {
+    const defaultValue = "default" in schema ? schema.default : undefined;
+    const clone = typeof defaultValue === "function" ? defaultValue() : Value.Clone(defaultValue);
+    return value === undefined
+        ? clone
+        : isObject(value) && isObject(clone)
+          ? Object.assign(clone, value)
+          : value;
+}
+
+// Same result as Value.Default(schema, value), but subtrees without any `default`
+// annotation are returned as-is instead of being cloned and re-checked per union
+// variant (which is where Value.Default spends almost all of its time on large event
+// pages). Kinds not handled here fall through to Value.Default itself.
+function applyDefaults(schema: TSchema, value: unknown): unknown {
+    if (!hasDefaults(schema)) return value;
+    switch (schema[Kind]) {
+        case "Object": {
+            if (typeof schema.additionalProperties === "object") {
+                return Value.Default(schema, value);
+            }
+            const defaulted = valueOrDefault(schema, value);
+            if (!isObject(defaulted)) return defaulted;
+            const properties = schema.properties as Record<string, TSchema>;
+            for (const key of Object.getOwnPropertyNames(properties)) {
+                const propertyValue = applyDefaults(properties[key], defaulted[key]);
+                if (propertyValue === undefined) continue;
+                defaulted[key] = propertyValue;
+            }
+            return defaulted;
+        }
+        case "Array": {
+            const defaulted = isArray(value) ? value : valueOrDefault(schema, value);
+            if (!isArray(defaulted)) return defaulted;
+            for (let i = 0; i < defaulted.length; i++) {
+                defaulted[i] = applyDefaults(schema.items, defaulted[i]);
+            }
+            return defaulted;
+        }
+        case "Tuple": {
+            const defaulted = valueOrDefault(schema, value);
+            if (!isArray(defaulted) || schema.items === undefined) return defaulted;
+            const items = schema.items as TSchema[];
+            for (let i = 0; i < items.length; i++) {
+                defaulted[i] = applyDefaults(items[i], defaulted[i]);
+            }
+            return defaulted;
+        }
+        case "Union": {
+            const defaulted = valueOrDefault(schema, value);
+            for (const inner of schema.anyOf as TSchema[]) {
+                // Value.Default clones, defaults and checks every variant; when the variant
+                // has no defaults the clone would be unchanged, so check the value directly.
+                const result = hasDefaults(inner)
+                    ? applyDefaults(inner, Value.Clone(defaulted))
+                    : defaulted;
+                if (checkerFor(inner).Check(result)) return result;
+            }
+            return defaulted;
+        }
+        default:
+            return Value.Default(schema, value);
+    }
+}
+
+// Equivalent to Value.Parse(["Default", "Convert", "Assert"], schema, value): Default and
+// Convert are the transforms (Convert is what turns msgpack numbers/strings into bigints),
+// Assert is performed by the compiled checker.
 export function typeboxValidate<T extends TSchema>(value: unknown, validator: T): Static<T> {
     try {
-        return Value.Parse(["Default", "Convert", "Assert"], validator, deepRemoveNullishFields(value));
+        const check = checkerFor(validator);
+        const converted = Value.Convert(
+            validator,
+            applyDefaults(validator, deepRemoveNullishFields(value)),
+        );
+        if (!check.Check(converted)) {
+            throw new AssertError(check.Errors(converted));
+        }
+        return converted as Static<T>;
     } catch (err) {
         console.error("Typebox validation failed: ", value, err);
         throw new TypeboxValidationError(err instanceof Error ? err : undefined);

--- a/frontend/openchat-agent/src/utils/typebox.ts
+++ b/frontend/openchat-agent/src/utils/typebox.ts
@@ -1,21 +1,7 @@
-import { AssertError, Value } from "@sinclair/typebox/value";
-import { TypeCompiler, type TypeCheck } from "@sinclair/typebox/compiler";
+import { Value } from "@sinclair/typebox/value";
 import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import { deepRemoveNullishFields } from "./nullish";
 import { TypeboxValidationError } from "@shared";
-
-// Compiled checkers are cached per schema object (root schemas and any union members
-// visited by applyDefaults). Compilation is a one-off few ms per schema.
-const compiled = new WeakMap<TSchema, TypeCheck<TSchema>>();
-
-function checkerFor<T extends TSchema>(schema: T): TypeCheck<T> {
-    let check = compiled.get(schema);
-    if (check === undefined) {
-        check = TypeCompiler.Compile(schema);
-        compiled.set(schema, check);
-    }
-    return check as TypeCheck<T>;
-}
 
 // Whether a schema or anything beneath it carries a `default` annotation. Value.Default is
 // deep-identity on a subtree with no defaults, so such subtrees can be skipped entirely.
@@ -124,7 +110,7 @@ function applyDefaults(schema: TSchema, value: unknown): unknown {
                 const result = hasDefaults(inner)
                     ? applyDefaults(inner, Value.Clone(defaulted))
                     : defaulted;
-                if (checkerFor(inner).Check(result)) return result;
+                if (Value.Check(inner, result)) return result;
             }
             return defaulted;
         }
@@ -133,19 +119,16 @@ function applyDefaults(schema: TSchema, value: unknown): unknown {
     }
 }
 
-// Equivalent to Value.Parse(["Default", "Convert", "Assert"], schema, value): Default and
-// Convert are the transforms (Convert is what turns msgpack numbers/strings into bigints),
-// Assert is performed by the compiled checker.
+// Equivalent to Value.Parse(["Default", "Convert", "Assert"], schema, value), with the
+// Default step replaced by applyDefaults above. Convert is kept as-is (it is what turns
+// msgpack numbers/strings into bigints) and Value.Assert is the Parse "Assert" step.
 export function typeboxValidate<T extends TSchema>(value: unknown, validator: T): Static<T> {
     try {
-        const check = checkerFor(validator);
         const converted = Value.Convert(
             validator,
             applyDefaults(validator, deepRemoveNullishFields(value)),
         );
-        if (!check.Check(converted)) {
-            throw new AssertError(check.Errors(converted));
-        }
+        Value.Assert(validator, converted);
         return converted as Static<T>;
     } catch (err) {
         console.error("Typebox validation failed: ", value, err);


### PR DESCRIPTION
Closes #9189. Part of #9179. **Security-sensitive (canister payload validation) — independently reviewed with a differential test, see below.**

**What was actually slow.** The issue assumed uncompiled `Assert` was the cost. Profiling a 200-message events page through `typeboxValidate`: `Value.Default` **173 ms** of 176; `Convert` 3.7 ms; dynamic `Assert` 0.6 ms; a `TypeCompiler`-compiled check 0.7 ms. `Value.Default` clones and dynamically re-checks every union variant (`ChatEvent` has ~60) for every nested value, and our schemas do carry `default: "NoChange"` on the 15 `OptionUpdate` unions, so it cannot simply be dropped.

**Change.** `applyDefaults` is a port of `Value.Default`'s visitor that returns subtrees unchanged when the schema subtree carries no `default` annotation anywhere (scan memoised per schema object, conservative cycle guard), applies the identical algorithm where defaults exist, and delegates unhandled kinds to `Value.Default`. Then `Value.Convert` (still required — msgpackr yields numbers/strings for `BigInt` fields) and `Value.Assert` — exactly what `Value.Parse` calls — on every request arg and every response, unconditionally. `TypeCompiler` was implemented, measured at ~6% on the full path, and removed: it uses `new Function` inside the validator that guards every payload and the gain did not justify it.

Also: `deserializeResponse` takes `Uint8Array` and the three `resp.reply.arg.slice().buffer` copies are gone (`@dfinity/cbor` already returns an exact-length copy); and msgpackr now runs with `copyBuffers: true` so decoded bytes fields are copies rather than views into the whole reply buffer (previously masked by `Value.Default`'s union clone; without it a 32-byte principal retained in state or `postMessage`d would pin/serialise the entire reply).

**Independent review:** `Value.Assert` on every path; `applyDefaults` value-equivalent to `Value.Default` for every schema kind used in `typebox.ts` (Object, Union, Array, Tuple, Record, Optional, literals, BigInt, Uint8Array, Never; no Ref/Recursive/Intersect); a throwaway differential test ran master's `Value.Parse` vs this branch over **all 1,013 exported schemas × 6 generated values each, valid and mutated** (dropped keys, wrong types, extra keys, `__proto__`, bigint, null): identical output and identical throw-vs-pass on every case. No new acceptance path; everything new runs inside the existing try so failures remain `TypeboxValidationError`.

**Measured (unit benchmark, ×200):**

| | before | after |
|---|---|---|
| `typeboxValidate` of a 200-message events page | **176 ms** | **3.7 ms** (~48×) |
| same incl. msgpack decode with `copyBuffers` | — | 3.8 ms |
| getUpdates-shaped (20 chat updates) | 0.07–0.13 ms | 0.16 ms (noise) |

At app scale this was ~100–200 ms of worker time per scroll-back page and per large `getUpdates`, now single-digit ms. Pinned quirk preserved: `Value.Default` only commits a union variant's defaults if that variant already checks *pre-Convert*; tested both ways.

Tests: new `typebox.spec.ts` (25, run green against the old implementation first), `utils/msgpack.spec.ts` (3), `canisterAgent/msgpack.spec.ts` (2; 5 malformed-payload cases); full suite 485 passing; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e