### PR TITLE
Incremental unread counts; batch observer-driven mark-read calls

### DIFF
--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -129,6 +129,14 @@
     let loadPrevCooldownUntil = 0;
     let loadNewCooldownUntil = 0;
     let messageReadTimers: Record<number, number> = {};
+    // Rows whose MESSAGE_READ_THRESHOLD has elapsed, waiting to be marked read in one batch
+    let pendingReads: {
+        context: MessageContext;
+        idx: number;
+        id: bigint | undefined;
+        target: Element;
+    }[] = [];
+    let pendingReadsTimer: number | undefined;
 
     let threadSummary = $derived(threadRootEvent?.event.thread);
     let messageContext = $derived.by(
@@ -414,8 +422,10 @@
                                 entry.target.isConnected &&
                                 messageContextsEqual(context, messageContext)
                             ) {
-                                client.markMessageRead(messageContext, idx, id);
-                                messageObserver?.unobserve(entry.target);
+                                pendingReads.push({ context, idx, id, target: entry.target });
+                                // Timers for rows that came into view together are due at
+                                // the same time; flush them all with a single publish
+                                pendingReadsTimer ??= window.setTimeout(flushPendingReads, 0);
                             }
                             delete messageReadTimers[idx];
                         }, MESSAGE_READ_THRESHOLD);
@@ -453,9 +463,27 @@
                 window.clearTimeout(timer);
             }
             messageReadTimers = {};
+            window.clearTimeout(pendingReadsTimer);
+            pendingReadsTimer = undefined;
+            pendingReads = [];
             clearTimeout(scrollTimeout);
         };
     });
+
+    function flushPendingReads() {
+        pendingReadsTimer = undefined;
+        const reads = pendingReads.filter(
+            (r) => r.target.isConnected && messageContextsEqual(r.context, messageContext),
+        );
+        pendingReads = [];
+        client.markMessagesRead(
+            messageContext,
+            reads.map(({ idx, id }) => ({ messageIndex: idx, messageId: id })),
+        );
+        for (const { target } of reads) {
+            messageObserver?.unobserve(target);
+        }
+    }
 
     function chatsUpdated(ctx: MessageContext) {
         // Never start a background new-message load while a message navigation

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1298,6 +1298,18 @@ export class OpenChat {
         }
     }
 
+    // Marks several messages read with a single publish of the messagesRead store
+    markMessagesRead(
+        context: MessageContext,
+        messages: { messageIndex: number; messageId: bigint | undefined }[],
+    ): void {
+        withPausedStores(() => {
+            for (const { messageIndex, messageId } of messages) {
+                this.markMessageRead(context, messageIndex, messageId);
+            }
+        });
+    }
+
     markPinnedMessagesRead(chatId: ChatIdentifier, dateLastPinned: bigint): void {
         messagesRead.markPinnedMessagesRead(chatId, dateLastPinned);
     }

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -987,8 +987,14 @@ describe("unread count stores", () => {
 
         const after = get(globalUnreadCountStore);
         expect(after.chats).toEqual({ muted: 0, unmuted: 1100, mentions: false });
+        // only the changed chat is re-evaluated per publish (was 50 x 1100 before the per-chat cache)
+        expect(evaluations).toEqual(50);
         messagesRead.markMessageRead({ chatId: target.id }, 100, undefined);
-        expect(get(globalUnreadCountStore).chats).toEqual({ muted: 0, unmuted: 1099, mentions: false });
+        expect(get(globalUnreadCountStore).chats).toEqual({
+            muted: 0,
+            unmuted: 1099,
+            mentions: false,
+        });
         unsub();
         console.log(
             `appStores.spec: 50 marks over 1100 chats: ${evaluations} per-chat evaluations, ${publishes} publishes, ${ms.toFixed(1)}ms`,

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -975,13 +975,11 @@ describe("unread count stores", () => {
 
         const spy = vi.spyOn(messagesRead, "unreadMessageCount");
         const target = all[7];
-        const start = performance.now();
         for (let i = 1; i <= 50; i++) {
             if (!messagesRead.isRead({ chatId: target.id }, i, undefined)) {
                 messagesRead.markMessageRead({ chatId: target.id }, i, undefined);
             }
         }
-        const ms = performance.now() - start;
         const evaluations = spy.mock.calls.length;
         spy.mockRestore();
 
@@ -996,8 +994,7 @@ describe("unread count stores", () => {
             mentions: false,
         });
         unsub();
-        console.log(
-            `appStores.spec: 50 marks over 1100 chats: ${evaluations} per-chat evaluations, ${publishes} publishes, ${ms.toFixed(1)}ms`,
-        );
+        // initial subscription + 50 marks + the final mark
+        expect(publishes).toEqual(52);
     });
 });

--- a/frontend/openchat-client/src/state/app/appStores.spec.ts
+++ b/frontend/openchat-client/src/state/app/appStores.spec.ts
@@ -1,5 +1,6 @@
 import DRange from "drange";
 import {
+    ChatMap,
     CommunityMap,
     emptyChatMetrics,
     emptyRules,
@@ -9,6 +10,7 @@ import {
     ROLE_MODERATOR,
     ROLE_NONE,
     ROLE_OWNER,
+    type ChannelSummary,
     type ChatIdentifier,
     type CommunityIdentifier,
     type CommunityPermissions,
@@ -28,6 +30,8 @@ import { ChatDetailsState } from "../chat/serverDetails";
 import { communityLocalUpdates } from "../community/detailUpdates";
 import { CommunityDetailsState } from "../community/server";
 import { localUpdates } from "../localUpdates";
+import { messagesRead } from "../unread/markRead";
+import { withPausedStores } from "../../utils/stores";
 import {
     notFoundStore,
     pathContextStore,
@@ -46,6 +50,7 @@ import {
     communitiesStore,
     directChatBotsStore,
     eventsStore,
+    globalUnreadCountStore,
     expiredServerEventRanges,
     messageFiltersStore,
     pinnedChatsStore,
@@ -60,6 +65,7 @@ import {
     selectedServerCommunityStore,
     serverCommunitiesStore,
     serverEventsStore,
+    serverGroupChatsStore,
     serverPinnedChatsStore,
     translationsStore,
 } from "./stores";
@@ -916,5 +922,76 @@ describe("cryptoBalanceStore", () => {
         expect(cryptoBalanceStore.value.get("ledger1")).toBe(200n);
         expect(cryptoBalanceStore.valueIfUpdatedRecently("ledger1")).toBe(200n);
         unsub();
+    });
+});
+
+describe("unread count stores", () => {
+    const msg = chatMessage();
+    msg.event.messageIndex = 100;
+    function channel(communityId: string, channelId: string): ChannelSummary {
+        return {
+            ...groupChat(channelId, msg),
+            kind: "channel",
+            id: { kind: "channel", communityId, channelId },
+        } as unknown as ChannelSummary;
+    }
+
+    test("marking messages read in one chat only re-evaluates that chat", () => {
+        const groups: GroupChatSummary[] = [];
+        for (let i = 0; i < 300; i++) {
+            groups.push(groupChat(`g${i}`, msg));
+        }
+        const communities: CommunitySummary[] = [];
+        for (let c = 0; c < 20; c++) {
+            const community = createCommunitySummary(`c${c}`, c);
+            for (let ch = 0; ch < 40; ch++) {
+                community.channels.push(channel(`c${c}`, `${c}_${ch}`));
+            }
+            communities.push(community);
+        }
+        const all: (GroupChatSummary | ChannelSummary)[] = [
+            ...groups,
+            ...communities.flatMap((c) => c.channels),
+        ];
+        withPausedStores(() => {
+            for (const c of all) {
+                messagesRead.syncWithServer(c.id, 0, [], undefined);
+            }
+            serverGroupChatsStore.set(ChatMap.fromList(all.slice(0, 300) as GroupChatSummary[]));
+            serverCommunitiesStore.set(
+                CommunityMap.fromList(
+                    communities.map((c, i) => ({
+                        ...c,
+                        channels: all.slice(300 + i * 40, 340 + i * 40) as ChannelSummary[],
+                    })),
+                ),
+            );
+        });
+
+        let publishes = 0;
+        const unsub = globalUnreadCountStore.subscribe(() => publishes++);
+        const before = get(globalUnreadCountStore);
+        expect(before.chats).toEqual({ muted: 0, unmuted: 1100, mentions: false });
+
+        const spy = vi.spyOn(messagesRead, "unreadMessageCount");
+        const target = all[7];
+        const start = performance.now();
+        for (let i = 1; i <= 50; i++) {
+            if (!messagesRead.isRead({ chatId: target.id }, i, undefined)) {
+                messagesRead.markMessageRead({ chatId: target.id }, i, undefined);
+            }
+        }
+        const ms = performance.now() - start;
+        const evaluations = spy.mock.calls.length;
+        spy.mockRestore();
+
+        const after = get(globalUnreadCountStore);
+        expect(after.chats).toEqual({ muted: 0, unmuted: 1100, mentions: false });
+        messagesRead.markMessageRead({ chatId: target.id }, 100, undefined);
+        expect(get(globalUnreadCountStore).chats).toEqual({ muted: 0, unmuted: 1099, mentions: false });
+        unsub();
+        console.log(
+            `appStores.spec: 50 marks over 1100 chats: ${evaluations} per-chat evaluations, ${publishes} publishes, ${ms.toFixed(1)}ms`,
+        );
     });
 });

--- a/frontend/openchat-client/src/state/unread/markRead.spec.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.spec.ts
@@ -363,9 +363,19 @@ describe("mark messages read", () => {
                 unmuted: 4,
                 mentions: false,
             });
-            // unconfirmed message read then removed
-            tracker.removeUnconfirmedMessage({ chatId: chats[4].id }, BigInt(1));
+            // reading an unconfirmed message counts it as read until it is removed
+            const unconfirmed = vi
+                .spyOn(localUpdates, "isUnconfirmed")
+                .mockImplementation((_ctx, messageId) => messageId === BigInt(1));
+            const ctx = { chatId: chats[4].id };
+            tracker.syncWithServer(ctx.chatId, 49, [], undefined);
             expect(tracker.combinedUnreadCountForChats(chats).chats.unmuted).toEqual(4);
+            tracker.markMessageRead(ctx, 50, BigInt(1));
+            expect(tracker.value.waiting.get(ctx)?.has(BigInt(1))).toBe(true);
+            expect(tracker.combinedUnreadCountForChats(chats).chats.unmuted).toEqual(3);
+            expect(tracker.removeUnconfirmedMessage(ctx, BigInt(1))).toBe(true);
+            expect(tracker.combinedUnreadCountForChats(chats).chats.unmuted).toEqual(4);
+            unconfirmed.mockRestore();
         });
     });
 

--- a/frontend/openchat-client/src/state/unread/markRead.spec.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared";
 import { SvelteMap } from "svelte/reactivity";
 import { vi } from "vitest";
+import { withPausedStores } from "../../utils/stores";
 import { localUpdates } from "../localUpdates";
 import { MessageReadTracker, MessagesRead } from "./markRead";
 
@@ -288,6 +289,96 @@ describe("mark messages read", () => {
             const counts = markRead.combinedUnreadCountForChats(chats);
             expect(counts.chats).toEqual({ muted: 1, unmuted: 1, mentions: false });
             expect(counts.threads).toEqual({ muted: 0, unmuted: 0, mentions: false });
+        });
+    });
+
+    describe("incremental unread counts", () => {
+        function chat(
+            groupId: string,
+            latestMessageIndex: number,
+            notificationsMuted: boolean,
+        ): ChatSummary {
+            return {
+                kind: "group_chat",
+                id: { kind: "group_chat", groupId },
+                latestMessage: { event: { messageIndex: latestMessageIndex } },
+                membership: { notificationsMuted, mentions: [], latestThreads: [] },
+            } as unknown as ChatSummary;
+        }
+
+        function setup(n: number) {
+            const tracker = new MessageReadTracker();
+            const chats: ChatSummary[] = [];
+            for (let i = 0; i < n; i++) {
+                const c = chat(`g${i}`, 50, i % 3 === 0);
+                chats.push(c);
+                tracker.syncWithServer(c.id, i % 5 === 0 ? 50 : 10, [], undefined);
+            }
+            return { tracker, chats };
+        }
+
+        test("marking one message read gives the same counts as a full recompute", () => {
+            const { tracker, chats } = setup(300);
+            const before = tracker.combinedUnreadCountForChats(chats);
+            expect(before.chats).toEqual({ muted: 80, unmuted: 160, mentions: false });
+
+            const spy = vi.spyOn(tracker, "unreadMessageCount");
+            for (let i = 11; i <= 60; i++) {
+                tracker.markMessageRead({ chatId: chats[1].id }, i, undefined);
+                tracker.combinedUnreadCountForChats(chats);
+            }
+            tracker.markMessageRead({ chatId: chats[2].id }, 50, undefined);
+            const after = tracker.combinedUnreadCountForChats(chats);
+            const evaluations = spy.mock.calls.length;
+            spy.mockRestore();
+
+            // independent full computation with a fresh tracker
+            const fresh = setup(300);
+            fresh.tracker.markReadUpTo({ chatId: fresh.chats[1].id }, 60);
+            fresh.tracker.markReadUpTo({ chatId: fresh.chats[2].id }, 50);
+            expect(after).toEqual(fresh.tracker.combinedUnreadCountForChats(fresh.chats));
+            expect(after.chats).toEqual({ muted: 80, unmuted: 158, mentions: false });
+            console.log(`markRead.spec: per-chat evaluations for 51 marks over 300 chats: ${evaluations}`);
+        });
+
+        test("a new chat object or a server sync is re-evaluated", () => {
+            const { tracker, chats } = setup(10);
+            expect(tracker.combinedUnreadCountForChats(chats).chats.unmuted).toEqual(5);
+            // muting a chat by replacing its object
+            const replaced = chats.slice();
+            replaced[1] = chat("g1", 50, true);
+            expect(tracker.combinedUnreadCountForChats(replaced).chats).toEqual({
+                muted: 4,
+                unmuted: 4,
+                mentions: false,
+            });
+            // server sync marks g2 as fully read
+            tracker.syncWithServer(chats[2].id, 50, [], undefined);
+            expect(tracker.combinedUnreadCountForChats(chats).chats).toEqual({
+                muted: 3,
+                unmuted: 4,
+                mentions: false,
+            });
+            // unconfirmed message read then removed
+            tracker.removeUnconfirmedMessage({ chatId: chats[4].id }, BigInt(1));
+            expect(tracker.combinedUnreadCountForChats(chats).chats.unmuted).toEqual(4);
+        });
+    });
+
+    describe("batched marks", () => {
+        test("marks inside withPausedStores publish once", () => {
+            const tracker = new MessageReadTracker();
+            let publishes = 0;
+            const unsub = tracker.subscribe(() => publishes++);
+            publishes = 0;
+            withPausedStores(() => {
+                for (let i = 1; i <= 10; i++) {
+                    tracker.markMessageRead({ chatId: abcId }, i, undefined);
+                }
+            });
+            expect(publishes).toEqual(1);
+            expect(tracker.value.state.get(abcId)?.readUpTo).toEqual(10);
+            unsub();
         });
     });
 

--- a/frontend/openchat-client/src/state/unread/markRead.spec.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.spec.ts
@@ -338,7 +338,11 @@ describe("mark messages read", () => {
             fresh.tracker.markReadUpTo({ chatId: fresh.chats[2].id }, 50);
             expect(after).toEqual(fresh.tracker.combinedUnreadCountForChats(fresh.chats));
             expect(after.chats).toEqual({ muted: 80, unmuted: 158, mentions: false });
-            console.log(`markRead.spec: per-chat evaluations for 51 marks over 300 chats: ${evaluations}`);
+            // one evaluation per changed chat per recompute (was 51 x 300 before the per-chat cache)
+            expect(evaluations).toEqual(51);
+            console.log(
+                `markRead.spec: per-chat evaluations for 51 marks over 300 chats: ${evaluations}`,
+            );
         });
 
         test("a new chat object or a server sync is re-evaluated", () => {

--- a/frontend/openchat-client/src/state/unread/markRead.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.ts
@@ -510,6 +510,9 @@ export class MessageReadTracker {
         return contribution;
     }
 
+    // Assumes mentions from the server always carry confirmed message ids: isRead also consults
+    // localUpdates.isUnconfirmed/isEphemeral, which are not versioned inputs of the contribution
+    // cache. A feature that produces local (unconfirmed) mentions must bump the chat's version.
     #hasUnreadMentions(chat: ChatSummary): boolean {
         if (chat.kind === "direct_chat") return false;
         return (

--- a/frontend/openchat-client/src/state/unread/markRead.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.ts
@@ -3,6 +3,7 @@ import {
     ChatMap,
     MessageContextMap,
     bigIntMax,
+    chatIdentifierToString,
     emptyUnreadCounts,
     mergeUnreadCounts,
     type ChatIdentifier,
@@ -79,6 +80,17 @@ export type MessageReadState = {
     state: MessagesReadByChat;
 };
 
+// The unread contribution of one chat, valid while the chat object and the
+// read state version of the chat are unchanged
+type UnreadContribution = {
+    chat: ChatSummary;
+    version: number;
+    unreadMessages: number;
+    muted: boolean;
+    mentions: boolean;
+    unreadThreads: number;
+};
+
 /**
  * Let's try to leave this logic alone as much as we can
  * and just focus on converting the actual underlying state to svelte 5 runes
@@ -86,6 +98,9 @@ export type MessageReadState = {
 export class MessageReadTracker {
     #timeout: number | undefined;
     #stopped: boolean = false;
+    // Bumped whenever the read state of a chat changes, keyed by chat id string
+    #versions = new Map<string, number>();
+    #contributions = new Map<string, UnreadContribution>();
 
     #store = writable<MessageReadState>(
         {
@@ -159,6 +174,11 @@ export class MessageReadTracker {
         }
     }
 
+    #touch(chatId: ChatIdentifier): void {
+        const key = chatIdentifierToString(chatId);
+        this.#versions.set(key, (this.#versions.get(key) ?? 0) + 1);
+    }
+
     #stateForId(chatId: ChatIdentifier, state: MessagesReadByChat): MessagesRead {
         if (!state.has(chatId)) {
             state.set(chatId, new MessagesRead());
@@ -173,6 +193,7 @@ export class MessageReadTracker {
     ): void {
         const { state, waiting } = this.value;
         withPausedStores(() => {
+            this.#touch(context.chatId);
             const chatState = this.#stateForId(context.chatId, state);
             if (messageId !== undefined && localUpdates.isUnconfirmed(context, messageId)) {
                 // if a message is unconfirmed we will just tuck it away until we are told it has been confirmed
@@ -192,6 +213,7 @@ export class MessageReadTracker {
 
     markReadUpTo(context: MessageContext, index: number): void {
         const { state } = this.value;
+        this.#touch(context.chatId);
         const chatState = this.#stateForId(context.chatId, state);
         if (context.threadRootMessageIndex !== undefined) {
             chatState.updateThread(context.threadRootMessageIndex, index);
@@ -203,6 +225,7 @@ export class MessageReadTracker {
 
     markPinnedMessagesRead(chatId: ChatIdentifier, dateLastPinned: bigint): void {
         const { state } = this.value;
+        this.#touch(chatId);
         this.#stateForId(chatId, state).markReadPinned(dateLastPinned);
         this.#store.update((s) => ({ ...s, state }));
     }
@@ -224,6 +247,7 @@ export class MessageReadTracker {
         const { waiting } = this.value;
         const deleted = waiting.get(context)?.delete(messageId) ?? false;
         if (deleted) {
+            this.#touch(context.chatId);
             this.#store.update((s) => ({ ...s, waiting }));
         }
         return deleted;
@@ -355,6 +379,7 @@ export class MessageReadTracker {
         dateReadPinned: bigint | undefined,
     ): void {
         const { state } = this.value;
+        this.#touch(chatId);
         const serverState = new MessagesRead();
         serverState.readUpTo = readUpTo;
         serverState.setThreads(threads);
@@ -442,16 +467,8 @@ export class MessageReadTracker {
         for (const chat of chats) {
             if (chat === undefined) continue;
 
-            const muted = chat.membership.notificationsMuted;
-            const unreadMessages = this.unreadMessageCount(
-                chat.id,
-                chat.latestMessage?.event.messageIndex,
-            );
-            const mentions = unreadMessages > 0 && this.#hasUnreadMentions(chat);
-            const unreadThreads = this.staleThreadCountForChat(
-                chat.id,
-                chat.membership.latestThreads,
-            );
+            const { unreadMessages, muted, mentions, unreadThreads } =
+                this.#unreadContribution(chat);
             counts = {
                 chats: mergeUnreadCounts(unreadMessages, muted, mentions, counts.chats),
                 threads: mergeUnreadCounts(
@@ -464,6 +481,33 @@ export class MessageReadTracker {
             };
         }
         return counts;
+    }
+
+    // Per-chat unread work is only redone when the chat object or its read state has changed
+    #unreadContribution(chat: ChatSummary): UnreadContribution {
+        const key = chatIdentifierToString(chat.id);
+        const version = this.#versions.get(key) ?? 0;
+        let contribution = this.#contributions.get(key);
+        if (
+            contribution === undefined ||
+            contribution.chat !== chat ||
+            contribution.version !== version
+        ) {
+            const unreadMessages = this.unreadMessageCount(
+                chat.id,
+                chat.latestMessage?.event.messageIndex,
+            );
+            contribution = {
+                chat,
+                version,
+                unreadMessages,
+                muted: chat.membership.notificationsMuted,
+                mentions: unreadMessages > 0 && this.#hasUnreadMentions(chat),
+                unreadThreads: this.staleThreadCountForChat(chat.id, chat.membership.latestThreads),
+            };
+            this.#contributions.set(key, contribution);
+        }
+        return contribution;
     }
 
     #hasUnreadMentions(chat: ChatSummary): boolean {


### PR DESCRIPTION
Closes #9182. Part of #9179. Supersedes #9233 (auto-closed by GitHub when its original base branch was deleted after #9227 squash-merged; branch rebased onto master, 4 commits).

- `ChatEventList`'s intersection observer fired one `markMessageRead` per message as rows crossed the read threshold, each publishing the `messagesRead` store on its own. The per-row `MESSAGE_READ_THRESHOLD` timer is unchanged, but marks are now queued and flushed in one `OpenChat.markMessagesRead(context, [...])` call inside `withPausedStores` — one publish per flush. Context is captured per entry and re-checked at flush; unmount cancels both row timers and the flush.
- `MessageReadTracker` keeps a per-chat version (bumped by every mutating method) and caches each chat's unread contribution keyed on chat object identity + version. `combinedUnreadCountForChats` reuses contributions for untouched chats, so all four sweep stores become incremental without changing their outputs. Independent review verified server stores always replace chat objects; the one non-versioned input (`localUpdates.isUnconfirmed/isEphemeral` inside `isRead`) is documented.

**Measured (300 group chats + 20 communities × 40 channels, 50 messages marked read in one chat):** per-chat unread evaluations **55,000 → 50**; wall time ~50–55 ms → ~16 ms; outputs identical to a full recompute.

Tests: `markRead.spec.ts` + `appStores.spec.ts` 74 passing; state specs 128; svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjRnHaDJUTCpbH9HLsmt2e