### PR TITLE
Serve apple-app-site-association for iOS passkeys

### DIFF
--- a/frontend/app/.ic-assets.json5
+++ b/frontend/app/.ic-assets.json5
@@ -30,7 +30,7 @@
         ignore: false,
     },
     {
-        match: ".well-known/{ii-alternative-origins,webauthn}",
+        match: ".well-known/{ii-alternative-origins,webauthn,apple-app-site-association}",
         headers: {
             "Content-Type": "application/json",
         },

--- a/frontend/app/apple-app-site-association
+++ b/frontend/app/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+    "webcredentials": {
+        "apps": ["A468T66XSK.com.oc.app"]
+    }
+}

--- a/frontend/app/rollup.config.mjs
+++ b/frontend/app/rollup.config.mjs
@@ -59,6 +59,8 @@ function clean() {
             }
             copyFile(".", "build", ".ic-assets.json5");
             copyFile(".", "build/.well-known", "assetlinks.json");
+            // iOS counterpart of assetlinks.json, required for native passkeys.
+            copyFile(".", "build/.well-known", "apple-app-site-association");
         },
     };
 }


### PR DESCRIPTION
Ships `https://oc.app/.well-known/apple-app-site-association` (`webcredentials` only — no universal links yet), the iOS counterpart of the existing `assetlinks.json`, so the native iOS app can use passkeys with RP id `oc.app`.

- `frontend/app/apple-app-site-association` — lists the interim development team's app id (`A468T66XSK.com.oc.app`). To be swapped (or dual-listed) once the production Apple Developer account exists.
- `rollup.config.mjs` — copies it into `build/.well-known/`, same as `assetlinks.json`
- `.ic-assets.json5` — serves it with `Content-Type: application/json`

Why now: iOS passkey requests fail even in associated-domains developer mode without this file — the SPA fallback answers the well-known path with 200 + HTML, which the association daemon rejects (`SWCErrorDomain 104` → `ASAuthorizationError 1004`). Web, Android and existing browser WebAuthn are unaffected; the file only governs which *native apps* may use oc.app credentials.

Split out from the iOS port branch so a website release can pick it up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)