### PR TITLE
Add interim iOS dev bundle id to apple-app-site-association

### DIFF
--- a/frontend/app/apple-app-site-association
+++ b/frontend/app/apple-app-site-association
@@ -1,5 +1,5 @@
 {
     "webcredentials": {
-        "apps": ["A468T66XSK.com.oc.app"]
+        "apps": ["A468T66XSK.com.oc.app", "A468T66XSK.com.computism.openchat"]
     }
 }

--- a/frontend/app/apple-app-site-association
+++ b/frontend/app/apple-app-site-association
@@ -1,5 +1,5 @@
 {
     "webcredentials": {
-        "apps": ["A468T66XSK.com.oc.app", "A468T66XSK.com.computism.openchat"]
+        "apps": ["A468T66XSK.com.computism.openchat"]
     }
 }

--- a/frontend/app/apple-app-site-association
+++ b/frontend/app/apple-app-site-association
@@ -1,5 +1,5 @@
 {
     "webcredentials": {
-        "apps": ["A468T66XSK.com.computism.openchat"]
+        "apps": ["A468T66XSK.com.oclabs.openchat.dev"]
     }
 }


### PR DESCRIPTION
Follow-up to #9241. It turns out `com.oc.app` is currently registered to some other Apple developer team (holder unknown — possibly historic; to be investigated before the production account is set up), so it cannot be used for iOS development signing. The interim iOS dev builds therefore use `com.oclabs.openchat.dev` — company.product convention, clearly interim, and deliberately NOT `com.oclabs.openchat` so the production OC Labs account can register that name first, fresh.

Native passkeys require the exact app id in the AASA file, so this replaces the unusable `A468T66XSK.com.oc.app` entry (that app id can never exist) with `A468T66XSK.com.oclabs.openchat.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)