### PR TITLE
perf: memoise timeline grouping so cosmetic updates don't regroup

### DIFF
--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -11,6 +11,7 @@
         type OpenChat,
         type ReadonlySet,
         FilteredProposals,
+        TimelineGrouper,
         allUsersStore,
         chatIdentifiersEqual,
         chatListScopeStore,
@@ -39,7 +40,7 @@
     import Witch from "@shared_components/Witch.svelte";
     import {
         chatStartItem,
-        flattenTimeline,
+        TimelineFlattener,
         type FlatChatItem,
     } from "@shared_components/flatChatItems";
     import ChatEvent from "./ChatEvent.svelte";
@@ -236,18 +237,23 @@
     let showAvatar = $derived(initialised && shouldShowAvatar(chat, $eventsStore[0]?.index));
     let messageContext = $derived({ chatId: chat?.id, threadRootMessageIndex: undefined });
     let editingEvent = $derived($selectedChatDraftMessageStore?.editingEvent);
+    const grouper = new TimelineGrouper();
+    const flattener = new TimelineFlattener();
+    // Derived (not inline) so its identity only changes with filteredProposals,
+    // which is what the grouper's memo keys on.
+    let groupInnerFn = $derived(groupInner(filteredProposals));
     let timeline = $derived(
-        client.groupEvents(
+        grouper.group(
             $eventsStore,
             $currentUserIdStore,
             chat.kind === "channel" && chat.public,
             $selectedChatExpandedDeletedMessageStore,
-            groupInner(filteredProposals),
+            groupInnerFn,
             true,
         ),
     );
     let items = $derived.by<FlatChatItem[]>(() => {
-        const flat: FlatChatItem[] = flattenTimeline(timeline);
+        const flat: FlatChatItem[] = flattener.flatten(timeline);
         if (showAvatar) {
             // rendered at the oldest end of the list (the visual top)
             flat.push(chatStartItem(chatIdentifierToString(chat.id)));

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -29,6 +29,7 @@
         subscribe,
         threadEventsStore,
         threadsFollowedByMeStore,
+        TimelineGrouper,
         unconfirmedStore,
     } from "@client";
     import { getContext, onMount } from "svelte";
@@ -37,7 +38,7 @@
     import { randomSentence } from "../../../utils/randomMsg";
     import AreYouSure from "../../AreYouSure.svelte";
     import Loading from "@shared_components/Loading.svelte";
-    import { flattenTimeline } from "@shared_components/flatChatItems";
+    import { TimelineFlattener } from "@shared_components/flatChatItems";
     import ChatEvent from "../ChatEvent.svelte";
     import ChatEventList from "../ChatEventList.svelte";
     import CryptoTransferBuilder from "../CryptoTransferBuilder.svelte";
@@ -96,8 +97,10 @@
     let events = $derived(
         atRoot && rootEvent !== undefined ? [rootEvent, ...$threadEventsStore] : $threadEventsStore,
     );
+    const grouper = new TimelineGrouper();
+    const flattener = new TimelineFlattener<Message>();
     let timeline = $derived(
-        client.groupEvents(
+        grouper.group(
             events,
             $currentUserIdStore,
             chat.kind === "channel" && chat.public,
@@ -106,7 +109,7 @@
             true,
         ) as TimelineItem<Message>[],
     );
-    let items = $derived(flattenTimeline(timeline));
+    let items = $derived(flattener.flatten(timeline));
     let readonly = $derived(client.isChatReadOnly(chat.id));
     let thread = $derived(rootEvent?.event.thread);
     let loading = $derived(!initialised && $threadEventsStore.length === 0 && thread !== undefined);

--- a/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
@@ -18,6 +18,7 @@
         eventsStore,
         failedMessagesStore,
         FilteredProposals,
+        TimelineGrouper,
         localUpdates,
         messageIndexStore,
         messagesRead,
@@ -43,7 +44,7 @@
     import Witch from "@shared_components/Witch.svelte";
     import {
         chatStartItem,
-        flattenTimeline,
+        TimelineFlattener,
         type FlatChatItem,
     } from "@shared_components/flatChatItems";
     import ChatEvent from "./ChatEvent.svelte";
@@ -273,18 +274,23 @@
     });
     let showAvatar = $derived(initialised && shouldShowAvatar(chat, $eventsStore[0]?.index));
     let messageContext = $derived({ chatId: chat?.id, threadRootMessageIndex: undefined });
+    const grouper = new TimelineGrouper();
+    const flattener = new TimelineFlattener();
+    // Derived (not inline) so its identity only changes with filteredProposals,
+    // which is what the grouper's memo keys on.
+    let groupInnerFn = $derived(groupInner(filteredProposals));
     let timeline = $derived(
-        client.groupEvents(
+        grouper.group(
             $eventsStore,
             $currentUserIdStore,
             chat.kind === "channel" && chat.public,
             $selectedChatExpandedDeletedMessageStore,
-            groupInner(filteredProposals),
+            groupInnerFn,
             true,
         ),
     );
     let items = $derived.by<FlatChatItem[]>(() => {
-        const flat: FlatChatItem[] = flattenTimeline(timeline);
+        const flat: FlatChatItem[] = flattener.flatten(timeline);
         if (showAvatar) {
             // rendered at the oldest end of the list (the visual top)
             flat.push(chatStartItem(chatIdentifierToString(chat.id)));

--- a/frontend/app/src/components_mobile/home/thread/Thread.svelte
+++ b/frontend/app/src/components_mobile/home/thread/Thread.svelte
@@ -30,6 +30,7 @@
         subscribe,
         threadEventsStore,
         threadsFollowedByMeStore,
+        TimelineGrouper,
         unconfirmedStore,
     } from "@client";
     import { getContext, onMount } from "svelte";
@@ -38,7 +39,7 @@
     import { randomSentence } from "../../../utils/randomMsg";
     import AreYouSure from "../../AreYouSure.svelte";
     import Loading from "@shared_components/Loading.svelte";
-    import { flattenTimeline } from "@shared_components/flatChatItems";
+    import { TimelineFlattener } from "@shared_components/flatChatItems";
     import ChatEvent from "../ChatEvent.svelte";
     import ChatEventList from "../ChatEventList.svelte";
     import CryptoTransferBuilder from "../CryptoTransferBuilder.svelte";
@@ -82,8 +83,10 @@
     let canReact = $derived(client.canReactToMessages(chat.id));
     let atRoot = $derived($threadEventsStore.length === 0 || $threadEventsStore[0]?.index === 0);
     let events = $derived(atRoot ? [rootEvent, ...$threadEventsStore] : $threadEventsStore);
+    const grouper = new TimelineGrouper();
+    const flattener = new TimelineFlattener<Message>();
     let timeline = $derived(
-        client.groupEvents(
+        grouper.group(
             events,
             $currentUserIdStore,
             chat.kind === "channel" && chat.public,
@@ -92,7 +95,7 @@
             true,
         ) as TimelineItem<Message>[],
     );
-    let items = $derived(flattenTimeline(timeline));
+    let items = $derived(flattener.flatten(timeline));
     let readonly = $derived(client.isChatReadOnly(chat.id));
     let thread = $derived(rootEvent.event.thread);
     let loading = $derived(!initialised && $threadEventsStore.length === 0 && thread !== undefined);

--- a/frontend/app/src/components_shared/flatChatItems.spec.ts
+++ b/frontend/app/src/components_shared/flatChatItems.spec.ts
@@ -1,0 +1,103 @@
+import type { ChatEvent, EventWrapper, Message, TimelineItem } from "@client";
+import { describe, expect, test } from "vitest";
+import { flattenTimeline, TimelineFlattener } from "./flatChatItems";
+
+const BASE = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+function msgEv(index: number, sender = "u1", ts = BASE + index * 1000): EventWrapper<Message> {
+    return {
+        index,
+        timestamp: BigInt(ts),
+        event: {
+            kind: "message",
+            messageId: BigInt(index),
+            messageIndex: index,
+            sender,
+            content: { kind: "text_content", text: `m${index}` },
+            reactions: [],
+            tips: {},
+            edited: false,
+            forwarded: false,
+            deleted: false,
+            blockLevelMarkdown: false,
+            ogPreviews: [],
+            messagePreviews: [],
+        },
+    };
+}
+
+function timelineOf(...groups: EventWrapper<ChatEvent>[][][]): TimelineItem<ChatEvent>[] {
+    const out: TimelineItem<ChatEvent>[] = [];
+    for (const dayGroup of groups) {
+        out.push(
+            { kind: "timeline_event_group", group: dayGroup },
+            { kind: "timeline_date", timestamp: dayGroup[0][0].timestamp },
+        );
+    }
+    return out;
+}
+
+describe("TimelineFlattener", () => {
+    const e1 = msgEv(1, "u1", BASE + DAY);
+    const e2 = msgEv(2, "u1", BASE + DAY + 1);
+    const e3 = msgEv(3, "u2", BASE + DAY + 2);
+    const e4 = msgEv(4, "u1", BASE);
+
+    test("matches flattenTimeline and always returns a new array", () => {
+        const f = new TimelineFlattener();
+        const tl = timelineOf([[e3], [e2, e1]], [[e4]]);
+        const a = f.flatten(tl);
+        expect(a).toEqual(flattenTimeline(tl));
+        const b = f.flatten(tl);
+        expect(b).toEqual(a);
+        expect(b).not.toBe(a);
+        b.forEach((item, i) => expect(item).toBe(a[i]));
+    });
+
+    test("reuses rows for untouched items and for unchanged wrappers in a patched group", () => {
+        const f = new TimelineFlattener();
+        const before = f.flatten(timelineOf([[e3], [e2, e1]], [[e4]]));
+        const e2b = { ...e2 };
+        const tl2 = timelineOf([[e3], [e2b, e1]], [[e4]]);
+        const after = f.flatten(tl2);
+        expect(after).toEqual(flattenTimeline(tl2));
+        expect(after[0]).toBe(before[0]); // e3 row unchanged
+        expect(after[1]).not.toBe(before[1]); // e2 replaced
+        expect(after[1].kind === "event" && after[1].event).toBe(e2b);
+        expect(after[2]).toBe(before[2]); // e1 unchanged
+        expect(after[3]).not.toBe(before[3]); // date: new object in tl2 (same key/timestamp)
+        expect(after[4]).toBe(before[4]); // e4 group is a new object of same shape → row reused
+    });
+
+    test("identical timeline items copy their rows through", () => {
+        const f = new TimelineFlattener();
+        const tl = timelineOf([[e3], [e2, e1]], [[e4]]);
+        const before = f.flatten(tl);
+        const tl2 = [...tl];
+        const after = f.flatten(tl2);
+        after.forEach((item, i) => expect(item).toBe(before[i]));
+    });
+
+    test("shape changes rebuild rows correctly", () => {
+        const f = new TimelineFlattener();
+        f.flatten(timelineOf([[e3], [e2, e1]], [[e4]]));
+        const e0 = msgEv(0, "u2", BASE + DAY + 3);
+        const cases = [
+            timelineOf(
+                [
+                    [e0, e3],
+                    [e2, e1],
+                ],
+                [[e4]],
+            ),
+            timelineOf([[e2, e1]], [[e4]]),
+            timelineOf([[e3, e2, e1]], [[e4]]),
+            timelineOf([[e4]]),
+            [],
+        ];
+        for (const tl of cases) {
+            expect(f.flatten(tl)).toEqual(flattenTimeline(tl));
+        }
+    });
+});

--- a/frontend/app/src/components_shared/flatChatItems.ts
+++ b/frontend/app/src/components_shared/flatChatItems.ts
@@ -64,24 +64,92 @@ export function flattenTimeline<T extends ChatEvent>(
     const result: FlatChatItem<T>[] = [];
     for (const item of timeline) {
         if (item.kind === "timeline_date") {
-            result.push({
-                kind: "timeline_date",
-                key: dateKey(item.timestamp),
-                timestamp: item.timestamp,
-            });
+            result.push(dateItem(item.timestamp));
         } else {
-            for (const group of item.group) {
-                for (let i = 0; i < group.length; i++) {
-                    result.push({
-                        kind: "event",
-                        key: eventKey(group[i]),
-                        event: group[i],
-                        first: i + 1 === group.length,
-                        last: i === 0,
-                    });
-                }
-            }
+            pushGroup(result, item.group);
         }
     }
     return result;
+}
+
+function dateItem<T extends ChatEvent>(timestamp: bigint): FlatChatItem<T> {
+    return { kind: "timeline_date", key: dateKey(timestamp), timestamp };
+}
+
+function eventItem<T extends ChatEvent>(
+    event: EventWrapper<T>,
+    first: boolean,
+    last: boolean,
+): FlatChatEvent<T> {
+    return { kind: "event", key: eventKey(event), event, first, last };
+}
+
+function pushGroup<T extends ChatEvent>(result: FlatChatItem<T>[], groups: EventWrapper<T>[][]) {
+    for (const group of groups) {
+        for (let i = 0; i < group.length; i++) {
+            result.push(eventItem(group[i], i + 1 === group.length, i === 0));
+        }
+    }
+}
+
+// Memoising wrapper around `flattenTimeline`. One instance per list.
+//
+// Paired with TimelineGrouper: after a cosmetic update the new timeline shares
+// every untouched item/group with the previous one, so the flat rows for those
+// can be reused as-is. Rows whose identity is preserved are not re-rendered by
+// the keyed {#each} downstream. Always returns a new array.
+export class TimelineFlattener<T extends ChatEvent = ChatEvent> {
+    #prevTimeline: TimelineItem<T>[] = [];
+    #prevFlat: FlatChatItem<T>[] = [];
+
+    flatten(timeline: TimelineItem<T>[]): FlatChatItem<T>[] {
+        const prevTimeline = this.#prevTimeline;
+        const prevFlat = this.#prevFlat;
+        const result: FlatChatItem<T>[] = [];
+        // Walk both timelines in lockstep; `offset` tracks where the previous
+        // item's rows start in prevFlat.
+        let offset = 0;
+        for (let t = 0; t < timeline.length; t++) {
+            const item = timeline[t];
+            const prevItem = t < prevTimeline.length ? prevTimeline[t] : undefined;
+            const prevLen = prevItem === undefined ? 0 : flatLength(prevItem);
+            if (item === prevItem) {
+                for (let i = 0; i < prevLen; i++) result.push(prevFlat[offset + i]);
+            } else if (item.kind === "timeline_date") {
+                result.push(dateItem(item.timestamp));
+            } else if (prevItem?.kind === "timeline_event_group" && prevLen === flatLength(item)) {
+                // Same shape (the grouper patched wrappers in place): reuse
+                // rows whose wrapper and flags are unchanged.
+                let i = 0;
+                for (const group of item.group) {
+                    for (let g = 0; g < group.length; g++, i++) {
+                        const first = g + 1 === group.length;
+                        const last = g === 0;
+                        const prev = prevFlat[offset + i];
+                        result.push(
+                            prev.kind === "event" &&
+                                prev.event === group[g] &&
+                                prev.first === first &&
+                                prev.last === last
+                                ? prev
+                                : eventItem(group[g], first, last),
+                        );
+                    }
+                }
+            } else {
+                pushGroup(result, item.group);
+            }
+            offset += prevLen;
+        }
+        this.#prevTimeline = timeline;
+        this.#prevFlat = result;
+        return result;
+    }
+}
+
+function flatLength<T extends ChatEvent>(item: TimelineItem<T>): number {
+    if (item.kind === "timeline_date") return 1;
+    let n = 0;
+    for (const group of item.group) n += group.length;
+    return n;
 }

--- a/frontend/openchat-client/src/index.ts
+++ b/frontend/openchat-client/src/index.ts
@@ -11,7 +11,12 @@ export { createSetStore } from "./stores/setStore";
 export type { TypersByKey } from "./stores/typing";
 export { builtinBot } from "./utils/builtinBotCommands";
 export * from "./utils/restrictedContent";
-export { buildCryptoTransferText, buildTransactionUrl, subrangesCover } from "./utils/chat";
+export {
+    buildCryptoTransferText,
+    buildTransactionUrl,
+    subrangesCover,
+    TimelineGrouper,
+} from "./utils/chat";
 export * from "./utils/cryptoFormatter";
 export type { TrackingCategory } from "./utils/ga";
 export { toRecord } from "./utils/list";

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -4904,10 +4904,10 @@ export class OpenChat {
     }
 
     expandDeletedMessages(messageIndexes: Set<number>): void {
-        selectedChatExpandedDeletedMessageStore.update((set) => {
-            messageIndexes.forEach((i) => set.add(i));
-            return set;
-        });
+        // A new set each time: consumers (TimelineGrouper) memoise by identity
+        selectedChatExpandedDeletedMessageStore.update(
+            (set) => new Set([...set, ...messageIndexes]),
+        );
     }
 
     remoteUserToggledReaction(

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -574,6 +574,174 @@ export function groupEvents(
     );
 }
 
+type GroupEventsInner = (events: EventWrapper<ChatEvent>[]) => EventWrapper<ChatEvent>[][];
+
+// Memoising wrapper around `groupEvents`. One instance per timeline consumer.
+//
+// Most publishes of the events store are cosmetic: a reaction, read receipt,
+// edit or translation replaces ONE message's wrapper and leaves every other
+// wrapper identical (see the fast path in mergeEventsAndLocalUpdates). None
+// of that affects grouping, so instead of re-running filter → sameDate →
+// reduceJoinedOrLeft → groupBySender over the whole list, the previous
+// timeline is patched: replaced wrappers are swapped in, and every untouched
+// group / timeline item keeps its identity (which lets the flattened rows
+// keep theirs too, so unchanged rows are not re-rendered).
+//
+// A full regroup happens whenever anything structural changes: a different
+// number of events, any non-message event replaced, or a message whose
+// grouping inputs (index, timestamp, sender, hidden-ness, proposal content)
+// differ. All other arguments are compared by identity, so callers must pass
+// a NEW `expandedDeletedMessages` set / `groupInner` function when their
+// contents change.
+export class TimelineGrouper {
+    #prev:
+        | {
+              events: EventWrapper<ChatEvent>[];
+              myUserId: string;
+              isPublicChannel: boolean;
+              expandedDeletedMessages: ReadonlySet<number>;
+              groupInner: GroupEventsInner | undefined;
+              iterateBackwards: boolean;
+              timeline: TimelineItem<ChatEvent>[];
+          }
+        | undefined;
+
+    group(
+        events: EventWrapper<ChatEvent>[],
+        myUserId: string,
+        isPublicChannel: boolean,
+        expandedDeletedMessages: ReadonlySet<number>,
+        groupInner?: GroupEventsInner,
+        iterateBackwards = false,
+    ): TimelineItem<ChatEvent>[] {
+        const prev = this.#prev;
+        let timeline: TimelineItem<ChatEvent>[] | undefined;
+        if (
+            prev !== undefined &&
+            prev.myUserId === myUserId &&
+            prev.isPublicChannel === isPublicChannel &&
+            prev.expandedDeletedMessages === expandedDeletedMessages &&
+            prev.groupInner === groupInner &&
+            prev.iterateBackwards === iterateBackwards
+        ) {
+            timeline =
+                prev.events === events
+                    ? prev.timeline
+                    : patchTimeline(
+                          prev.events,
+                          events,
+                          prev.timeline,
+                          myUserId,
+                          expandedDeletedMessages,
+                      );
+        }
+        timeline ??= groupEvents(
+            events,
+            myUserId,
+            isPublicChannel,
+            expandedDeletedMessages,
+            groupInner,
+            iterateBackwards,
+        );
+        this.#prev = {
+            events,
+            myUserId,
+            isPublicChannel,
+            expandedDeletedMessages,
+            groupInner,
+            iterateBackwards,
+            timeline,
+        };
+        return timeline;
+    }
+}
+
+// Returns `prevTimeline` with replaced wrappers swapped in, or undefined if
+// the new events cannot share the previous grouping structure.
+function patchTimeline(
+    prevEvents: EventWrapper<ChatEvent>[],
+    events: EventWrapper<ChatEvent>[],
+    prevTimeline: TimelineItem<ChatEvent>[],
+    myUserId: string,
+    expandedDeletedMessages: ReadonlySet<number>,
+): TimelineItem<ChatEvent>[] | undefined {
+    if (prevEvents.length !== events.length) return undefined;
+    let replaced: Map<EventWrapper<ChatEvent>, EventWrapper<ChatEvent>> | undefined;
+    for (let i = 0; i < events.length; i++) {
+        const a = prevEvents[i];
+        const b = events[i];
+        if (a === b) continue;
+        if (!groupingEquivalent(a, b, myUserId, expandedDeletedMessages)) return undefined;
+        (replaced ??= new Map()).set(a, b);
+    }
+    if (replaced === undefined) return prevTimeline;
+
+    // Hidden (aggregated) messages never appear in the timeline as themselves,
+    // so their replacements simply never match and the aggregate is kept.
+    let timeline: TimelineItem<ChatEvent>[] | undefined;
+    for (let t = 0; t < prevTimeline.length; t++) {
+        const item = prevTimeline[t];
+        if (item.kind !== "timeline_event_group") continue;
+        let groups: EventWrapper<ChatEvent>[][] | undefined;
+        for (let g = 0; g < item.group.length; g++) {
+            const group = item.group[g];
+            let copy: EventWrapper<ChatEvent>[] | undefined;
+            for (let i = 0; i < group.length; i++) {
+                const r = replaced.get(group[i]);
+                if (r !== undefined) {
+                    copy ??= [...group];
+                    copy[i] = r;
+                }
+            }
+            if (copy !== undefined) {
+                groups ??= [...item.group];
+                groups[g] = copy;
+            }
+        }
+        if (groups !== undefined) {
+            timeline ??= [...prevTimeline];
+            timeline[t] = { kind: "timeline_event_group", group: groups };
+        }
+    }
+    return timeline ?? prevTimeline;
+}
+
+// Two different wrappers at the same position may share grouping structure
+// only if every input to isEventKindHidden / sameDate / reduceJoinedOrLeft /
+// groupBySender is unchanged. Only messages are ever replaced in place by
+// local updates; any other kind of change forces a full regroup. Proposal
+// messages are grouped by their collapse state (CurrentChatMessages'
+// groupInner), which depends on the proposal itself, so those require
+// identical content.
+function groupingEquivalent(
+    a: EventWrapper<ChatEvent>,
+    b: EventWrapper<ChatEvent>,
+    myUserId: string,
+    expandedDeletedMessages: ReadonlySet<number>,
+): boolean {
+    if (a.index !== b.index || a.timestamp !== b.timestamp) return false;
+    if (a.event.kind !== "message" || b.event.kind !== "message") return false;
+    const am = a.event;
+    const bm = b.event;
+    if (
+        am.messageId !== bm.messageId ||
+        am.messageIndex !== bm.messageIndex ||
+        am.sender !== bm.sender
+    ) {
+        return false;
+    }
+    if (
+        (am.content.kind === "proposal_content" || bm.content.kind === "proposal_content") &&
+        am.content !== bm.content
+    ) {
+        return false;
+    }
+    return (
+        messageIsHidden(am, myUserId, expandedDeletedMessages) ===
+        messageIsHidden(bm, myUserId, expandedDeletedMessages)
+    );
+}
+
 export function flattenTimeline(grouped: EventWrapper<ChatEvent>[][][]): TimelineItem<ChatEvent>[] {
     const timeline: TimelineItem<ChatEvent>[] = [];
     grouped.forEach((dayGroup) => {

--- a/frontend/openchat-client/src/utils/chatMerge.baseline.spec.ts
+++ b/frontend/openchat-client/src/utils/chatMerge.baseline.spec.ts
@@ -13,6 +13,7 @@ import DRange from "drange";
 import { MessageLocalUpdates } from "../state/message/localUpdates";
 import {
     groupEvents,
+    TimelineGrouper,
     mergeEventsAndLocalUpdates,
     mergeEventsAndLocalUpdatesWithRange,
     mergeServerEvents,
@@ -54,7 +55,11 @@ function msg(
     };
 }
 
-function ev<T extends ChatEvent>(index: number, event: T, timestamp = BASE + index * 1000): EventWrapper<T> {
+function ev<T extends ChatEvent>(
+    index: number,
+    event: T,
+    timestamp = BASE + index * 1000,
+): EventWrapper<T> {
     return { index, event, timestamp: BigInt(timestamp) };
 }
 
@@ -72,7 +77,10 @@ describe("mergeServerEvents", () => {
         const incoming = [ev(2, msg(2, "u1", "edited 2")), msgEv(4)];
         const merged = mergeServerEvents(existing, incoming, ctx);
         expect(indexes(merged)).toEqual([1, 2, 3, 4]);
-        expect((merged[1].event as Message).content).toEqual({ kind: "text_content", text: "edited 2" });
+        expect((merged[1].event as Message).content).toEqual({
+            kind: "text_content",
+            text: "edited 2",
+        });
     });
 
     test("sorts by timestamp before index", () => {
@@ -162,8 +170,14 @@ describe("updateExistingMessages", () => {
         ];
         const out = updateExistingMessages(events, [ev(3, msg(3, "u1", "updated 3"))]);
         expect(out).toBe(events);
-        expect((events[2].event as Message).content).toEqual({ kind: "text_content", text: "updated 3" });
-        expect((events[0].event as Message).content).toEqual({ kind: "text_content", text: "msg 1" });
+        expect((events[2].event as Message).content).toEqual({
+            kind: "text_content",
+            text: "updated 3",
+        });
+        expect((events[0].event as Message).content).toEqual({
+            kind: "text_content",
+            text: "msg 1",
+        });
         expect(events[1].event.kind).toBe("member_joined");
     });
 });
@@ -208,7 +222,10 @@ describe("mergeEventsAndLocalUpdates", () => {
         const out = run(events, [], updates);
         expect(out[0]).not.toBe(events[0]);
         expect((out[0].event as Message).content).toEqual({ kind: "text_content", text: "edited" });
-        expect((events[0].event as Message).content).toEqual({ kind: "text_content", text: "msg 1" });
+        expect((events[0].event as Message).content).toEqual({
+            kind: "text_content",
+            text: "msg 1",
+        });
     });
 
     test("applies local delete", () => {
@@ -230,7 +247,10 @@ describe("mergeEventsAndLocalUpdates", () => {
             undefined,
             new MessageMap([[1n, "bonjour"]]),
         );
-        expect((out[0].event as Message).content).toMatchObject({ kind: "text_content", text: "bonjour" });
+        expect((out[0].event as Message).content).toMatchObject({
+            kind: "text_content",
+            text: "bonjour",
+        });
     });
 
     test("hides messages from blocked senders", () => {
@@ -428,7 +448,10 @@ describe("mergeEventsAndLocalUpdates fast path", () => {
     });
 
     test("fast path still tracks confirmed ids and contiguity for unconfirmed messages", () => {
-        const out = run([msgEv(1), msgEv(2)], [ev(2, msg(2, "me")), msgEv(3, "me"), msgEv(9, "me")]);
+        const out = run(
+            [msgEv(1), msgEv(2)],
+            [ev(2, msg(2, "me")), msgEv(3, "me"), msgEv(9, "me")],
+        );
         expect(indexes(out)).toEqual([1, 2, 3]);
     });
 });
@@ -515,5 +538,191 @@ describe("mergeEventsAndLocalUpdatesWithRange", () => {
     test("range excludes unconfirmed messages that were dropped", () => {
         const { range } = run([msgEv(1)], [msgEv(10, "me")]);
         expect(range.subranges()).toEqual([{ low: 1, high: 1, length: 1 }]);
+    });
+});
+
+describe("TimelineGrouper", () => {
+    function base(): EventWrapper<ChatEvent>[] {
+        return [
+            msgEv(1, "u1", BASE),
+            ev(2, { kind: "member_joined", userId: "a" }, BASE + 1),
+            msgEv(3, "u1", BASE + 2000),
+            msgEv(4, "u2", BASE + 3000),
+            ev(
+                5,
+                msg(5, "u3", "gone", {
+                    content: { kind: "deleted_content", deletedBy: "u3", timestamp: 0n },
+                }),
+                BASE + 4000,
+            ),
+            msgEv(6, "u2", BASE + DAY),
+            msgEv(7, "u1", BASE + DAY + 1000),
+        ];
+    }
+
+    function groupsOf(timeline: ReturnType<typeof groupEvents>) {
+        return timeline.map((t) => (t.kind === "timeline_event_group" ? t.group : t.kind));
+    }
+
+    test("first call matches groupEvents exactly", () => {
+        const events = base();
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        for (const backwards of [false, true]) {
+            expect(g.group(events, "me", false, expanded, undefined, backwards)).toEqual(
+                groupEvents(events, "me", false, expanded, undefined, backwards),
+            );
+        }
+    });
+
+    test("same array returns the same timeline instance", () => {
+        const events = base();
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        const a = g.group(events, "me", false, expanded, undefined, true);
+        expect(g.group(events, "me", false, expanded, undefined, true)).toBe(a);
+    });
+
+    test("cosmetic replacement of one message patches the timeline, keeping untouched groups", () => {
+        const events = base();
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        const before = g.group(events, "me", false, expanded, undefined, true);
+
+        const reacted = {
+            ...events[3],
+            event: {
+                ...(events[3].event as Message),
+                reactions: [{ reaction: "x", userIds: new Set(["me"]) }],
+            },
+        };
+        const next = [...events];
+        next[3] = reacted;
+        const after = g.group(next, "me", false, expanded, undefined, true);
+
+        expect(after).toEqual(groupEvents(next, "me", false, expanded, undefined, true));
+        expect(after).not.toBe(before);
+        // Day 2 (timeline[0]/[1] in backwards order) is untouched: identity kept.
+        expect(after[0]).toBe(before[0]);
+        expect(after[1]).toBe(before[1]);
+        // Day 1's item is new, but only the group holding index 4 was copied.
+        expect(after[2]).not.toBe(before[2]);
+        const g2a = groupsOf(after)[2] as EventWrapper<ChatEvent>[][];
+        const g2b = groupsOf(before)[2] as EventWrapper<ChatEvent>[][];
+        expect(g2a.length).toBe(g2b.length);
+        for (let i = 0; i < g2a.length; i++) {
+            const holdsReacted = g2a[i].some((e) => e === reacted);
+            if (holdsReacted) expect(g2a[i]).not.toBe(g2b[i]);
+            else expect(g2a[i]).toBe(g2b[i]);
+        }
+    });
+
+    test("replacing a hidden (aggregated) message keeps the whole timeline", () => {
+        const events = base();
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        const before = g.group(events, "me", false, expanded, undefined, true);
+        const next = [...events];
+        next[4] = { ...events[4], event: { ...(events[4].event as Message) } };
+        const after = g.group(next, "me", false, expanded, undefined, true);
+        expect(after).toBe(before);
+        expect(after).toEqual(groupEvents(next, "me", false, expanded, undefined, true));
+    });
+
+    test("structural changes fall back to a full regroup", () => {
+        const events = base();
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        g.group(events, "me", false, expanded, undefined, true);
+
+        const cases: [string, EventWrapper<ChatEvent>[], ReadonlySet<number>, string][] = [
+            ["appended", [...events, msgEv(8, "u1", BASE + DAY + 2000)], expanded, "me"],
+            ["removed", events.slice(1), expanded, "me"],
+            [
+                "sender changed",
+                events.map((e, i) => (i === 3 ? msgEv(4, "u1", BASE + 3000) : e)),
+                expanded,
+                "me",
+            ],
+            [
+                "timestamp changed",
+                events.map((e, i) => (i === 3 ? msgEv(4, "u2", BASE + DAY) : e)),
+                expanded,
+                "me",
+            ],
+            [
+                "message deleted",
+                events.map((e, i) =>
+                    i === 3
+                        ? ev(
+                              4,
+                              msg(4, "u2", "", {
+                                  content: {
+                                      kind: "deleted_content",
+                                      deletedBy: "u2",
+                                      timestamp: 0n,
+                                  },
+                              }),
+                              BASE + 3000,
+                          )
+                        : e,
+                ),
+                expanded,
+                "me",
+            ],
+            [
+                "non-message replaced",
+                events.map((e, i) =>
+                    i === 1 ? ev(2, { kind: "member_joined", userId: "b" }, BASE + 1) : e,
+                ),
+                expanded,
+                "me",
+            ],
+            ["deleted message expanded", events.map((e) => ({ ...e })), new Set([5]), "me"],
+            ["different user", events.map((e) => ({ ...e })), expanded, "u3"],
+        ];
+        for (const [name, next, exp, me] of cases) {
+            const actual = g.group(next, me, false, exp, undefined, true);
+            expect(actual, name).toEqual(groupEvents(next, me, false, exp, undefined, true));
+        }
+    });
+
+    test("a new groupInner forces a regroup", () => {
+        const events = [msgEv(1, "u1", BASE), msgEv(2, "u1", BASE + 1000)];
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        const one = (evs: EventWrapper<ChatEvent>[]) => evs.map((e) => [e]);
+        const a = g.group(events, "me", false, expanded, one, true);
+        expect(a).toEqual(groupEvents(events, "me", false, expanded, one, true));
+        const b = g.group([...events], "me", false, expanded, undefined, true);
+        expect(b).toEqual(groupEvents(events, "me", false, expanded, undefined, true));
+        expect(b).not.toEqual(a);
+    });
+
+    test("proposal messages require identical content", () => {
+        const proposal = { kind: "nns", id: 1n, topic: 3 };
+        const mk = (content: unknown) =>
+            ev(4, msg(4, "u2", "", { content: content as Message["content"] }), BASE + 3000);
+        const events = base();
+        events[3] = mk({
+            kind: "proposal_content",
+            governanceCanisterId: "x",
+            proposal,
+            myVote: undefined,
+        });
+        const expanded = new Set<number>();
+        const g = new TimelineGrouper();
+        const inner = (evs: EventWrapper<ChatEvent>[]) => evs.map((e) => [e]);
+        const before = g.group(events, "me", false, expanded, inner, true);
+        const next = [...events];
+        next[3] = mk({
+            kind: "proposal_content",
+            governanceCanisterId: "x",
+            proposal: { ...proposal },
+            myVote: undefined,
+        });
+        const after = g.group(next, "me", false, expanded, inner, true);
+        expect(after).toEqual(groupEvents(next, "me", false, expanded, inner, true));
+        expect(after).not.toBe(before);
     });
 });


### PR DESCRIPTION
Completes #9184 (part of #9179). Follow-up to #9225: the remaining cost was that a cosmetic update (reaction, read receipt, edit, translation) regrouped the whole timeline and rebuilt every flat row.

## Changes

- **`TimelineGrouper`** (`openchat-client/src/utils/chat.ts`): memoising wrapper around `groupEvents`, keyed on argument identity. When the new events array is pairwise identical or *grouping-equivalent* (message with same index/timestamp/messageId/messageIndex/sender/hidden-state; proposal messages need identical content) the previous timeline is patched via a replacement map — untouched groups and timeline items keep identity. Any structural change (length, non-message replaced, sender/timestamp/hidden-state differs, different user / expanded set / `groupInner`) falls back to a full `groupEvents`, which is unchanged.
- **`TimelineFlattener`** (`app/src/components_shared/flatChatItems.ts`): lockstep walk of new vs previous timeline; reuses `FlatChatItem`s whose wrapper and first/last flags are unchanged, so the keyed `{#each}` doesn't re-render those rows. `flattenTimeline` kept (refactored onto shared helpers).
- Wired into desktop + mobile `CurrentChatMessages` / `Thread`. `groupInner` is now `$derived` so its identity only changes with `filteredProposals` (the memo key).
- `expandDeletedMessages` emits a new `Set` rather than mutating in place (store is `notEq`, so no behaviour change; needed for identity memo).

## Measurements

Real app, reaction on a visible message, store publish → Svelte flush, 29 rows rendered, before/after interleaved on identical data (long history was synthetic events injected into `serverEventsStore`):

| loaded events | before | after |
|---|---|---|
| 533 | 3.2 ms | 1.2 ms |
| 2033 | 6.0 ms | 2.8 ms |

Grouping + flatten alone (node): 6.8× @500, 12.8× @2000, 19.5× @5000 events. The remaining after-cost scales with N and lives in merge/DRange/segmentation — outside this issue.

## Tests

- `chatMerge.baseline.spec.ts`: 7 new `TimelineGrouper` specs pinned against `groupEvents` (cosmetic patch keeps untouched group identity, hidden-message replacement keeps whole timeline, 8 structural fallbacks, `groupInner` change, proposal content).
- `flatChatItems.spec.ts`: `TimelineFlattener` pinned against `flattenTimeline` (row reuse, identical items, shape changes).
- `npm run typecheck && npm run typecheck:agent && npm run lint && npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
