### PR TITLE
perf: load the rich text editor as its own chunk, off the critical path

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -49,6 +49,7 @@
         recordError,
     } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
+    import { warmRichTextEditor } from "@shared_components/richTextEditorLoader";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
@@ -305,10 +306,12 @@
 
     if ($identityStateStore.kind === "logged_in") {
         setupNativeApp();
+        warmRichTextEditor();
     }
 
     function onUserLoggedIn(userId: string) {
         setupNativeApp();
+        warmRichTextEditor();
         broadcastLoggedInUser(userId);
     }
 

--- a/frontend/app/src/components/home/MessageEntry.svelte
+++ b/frontend/app/src/components/home/MessageEntry.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-    import RichTextEditor from "@shared_components/RichTextEditor.svelte";
+    import type RichTextEditor from "@shared_components/RichTextEditor.svelte";
+    import {
+        loadRichTextEditor,
+        richTextEditorIfLoaded,
+    } from "@shared_components/richTextEditorLoader";
     import { trackedEffect } from "@src/utils/effects.svelte";
     import { detectMarkdown } from "@src/utils/detectMarkdown";
     import type {
@@ -125,6 +129,22 @@
     const MARK_TYPING_STOPPED_INTERVAL_MS = 5000; // 5 seconds
 
     let editor = $state<RichTextEditor>();
+    // The editor is its own chunk (see richTextEditorLoader). Normally already
+    // warm; the placeholder is only visible on direct-to-chat entry while the
+    // chunk is in flight. A tap on the placeholder focuses the editor once it
+    // arrives.
+    const alreadyLoaded = richTextEditorIfLoaded();
+    let EditorComponent = $state(alreadyLoaded);
+    let focusWhenReady = false;
+    if (alreadyLoaded === undefined) {
+        loadRichTextEditor().then(
+            (c) => {
+                EditorComponent = c;
+                if (focusWhenReady) tick().then(() => editor?.focus());
+            },
+            (err) => console.error("Failed to load the rich text editor", err),
+        );
+    }
     let editorEmpty = $state(true);
 
     // let inp: HTMLDivElement | undefined = $state();
@@ -486,30 +506,37 @@
                     {/if}
 
                     <div class="textbox">
-                        <RichTextEditor
-                            bind:this={editor}
-                            bind:empty={editorEmpty}
-                            placeholder={interpolate($_, placeholder)}
-                            members={$selectedChatMembersStore}
-                            {onPaste}
-                            onKeydown={keyDown}
-                            oninput={onInput}>
-                            {#snippet mentionPicker(args)}
-                                <MentionPicker
-                                    supportsUserGroups
-                                    offset={messageEntryHeight}
-                                    onClose={args.onClose}
-                                    onMention={args.onMention}
-                                    prefix={args.query} />
-                            {/snippet}
-                            {#snippet emojiPicker(args)}
-                                <EmojiAutocompleter
-                                    offset={messageEntryHeight}
-                                    onClose={args.onClose}
-                                    onSelect={args.onSelect}
-                                    query={args.query} />
-                            {/snippet}
-                        </RichTextEditor>
+                        {#if EditorComponent}
+                            <EditorComponent
+                                bind:this={editor}
+                                bind:empty={editorEmpty}
+                                placeholder={interpolate($_, placeholder)}
+                                members={$selectedChatMembersStore}
+                                {onPaste}
+                                onKeydown={keyDown}
+                                oninput={onInput}>
+                                {#snippet mentionPicker(args)}
+                                    <MentionPicker
+                                        supportsUserGroups
+                                        offset={messageEntryHeight}
+                                        onClose={args.onClose}
+                                        onMention={args.onMention}
+                                        prefix={args.query} />
+                                {/snippet}
+                                {#snippet emojiPicker(args)}
+                                    <EmojiAutocompleter
+                                        offset={messageEntryHeight}
+                                        onClose={args.onClose}
+                                        onSelect={args.onSelect}
+                                        query={args.query} />
+                                {/snippet}
+                            </EditorComponent>
+                        {:else}
+                            <!-- svelte-ignore a11y_no_static_element_interactions -->
+                            <div class="editor-placeholder" onpointerdown={() => (focusWhenReady = true)}>
+                                {interpolate($_, placeholder)}
+                            </div>
+                        {/if}
                     </div>
                 </div>
             {/key}
@@ -602,6 +629,16 @@
         margin: 0 $sp3;
         flex: 1;
         position: relative;
+    }
+
+    // mirrors :global(.ProseMirror) + its empty-editor placeholder
+    .editor-placeholder {
+        width: 100%;
+        min-width: 0;
+        font-size: 1rem;
+        line-height: 1.3;
+        color: var(--txt-light, var(--chat-input-placeholder));
+        cursor: text;
     }
 
     .textbox {

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -42,6 +42,7 @@
         recordError,
     } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
+    import { warmRichTextEditor } from "@shared_components/richTextEditorLoader";
     import { onMount, setContext } from "svelte";
     import { overrideItemIdKeyNameBeforeInitialisingDndZones } from "svelte-dnd-action";
     import { _, isLoading } from "svelte-i18n";
@@ -285,10 +286,12 @@
 
     if ($identityStateStore.kind === "logged_in") {
         setupNativeApp();
+        warmRichTextEditor();
     }
 
     function onUserLoggedIn(userId: string) {
         setupNativeApp();
+        warmRichTextEditor();
         broadcastLoggedInUser(userId);
     }
 

--- a/frontend/app/src/components_mobile/home/MessageEntry.svelte
+++ b/frontend/app/src/components_mobile/home/MessageEntry.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-    import RichTextEditor from "@shared_components/RichTextEditor.svelte";
+    import type RichTextEditor from "@shared_components/RichTextEditor.svelte";
+    import {
+        loadRichTextEditor,
+        richTextEditorIfLoaded,
+    } from "@shared_components/richTextEditorLoader";
     import { keyboard } from "@src/stores/keyboard.svelte";
     import { isIosTauriApp } from "@shared";
     import { trackedEffect } from "@src/utils/effects.svelte";
@@ -135,6 +139,22 @@
     const MARK_TYPING_STOPPED_INTERVAL_MS = 5000; // 5 seconds
 
     let editor = $state<RichTextEditor>();
+    // The editor is its own chunk (see richTextEditorLoader). Normally already
+    // warm; the placeholder is only visible on direct-to-chat entry while the
+    // chunk is in flight. A tap on the placeholder focuses the editor once it
+    // arrives.
+    const alreadyLoaded = richTextEditorIfLoaded();
+    let EditorComponent = $state(alreadyLoaded);
+    let focusWhenReady = false;
+    if (alreadyLoaded === undefined) {
+        loadRichTextEditor().then(
+            (c) => {
+                EditorComponent = c;
+                if (focusWhenReady) tick().then(() => editor?.focus());
+            },
+            (err) => console.error("Failed to load the rich text editor", err),
+        );
+    }
     let editorEmpty = $state(true);
 
     let messageEntryElement = $state<HTMLElement>();
@@ -742,30 +762,37 @@
 
                         {#key textboxId}
                             <div class="textbox">
-                                <RichTextEditor
-                                    bind:this={editor}
-                                    bind:empty={editorEmpty}
-                                    placeholder={interpolate($_, placeholder)}
-                                    members={$selectedChatMembersStore}
-                                    {onPaste}
-                                    onfocus={keyboardFocus}
-                                    onKeydown={keyDown}
-                                    oninput={onInput}>
-                                    {#snippet mentionPicker(args)}
-                                        <MentionPicker
-                                            supportsUserGroups
-                                            offset={messageEntryHeight}
-                                            onMention={args.onMention}
-                                            prefix={args.query} />
-                                    {/snippet}
-                                    {#snippet emojiPicker(args)}
-                                        <EmojiAutocompleter
-                                            offset={messageEntryHeight}
-                                            onClose={args.onClose}
-                                            onSelect={args.onSelect}
-                                            query={args.query} />
-                                    {/snippet}
-                                </RichTextEditor>
+                                {#if EditorComponent}
+                                    <EditorComponent
+                                        bind:this={editor}
+                                        bind:empty={editorEmpty}
+                                        placeholder={interpolate($_, placeholder)}
+                                        members={$selectedChatMembersStore}
+                                        {onPaste}
+                                        onfocus={keyboardFocus}
+                                        onKeydown={keyDown}
+                                        oninput={onInput}>
+                                        {#snippet mentionPicker(args)}
+                                            <MentionPicker
+                                                supportsUserGroups
+                                                offset={messageEntryHeight}
+                                                onMention={args.onMention}
+                                                prefix={args.query} />
+                                        {/snippet}
+                                        {#snippet emojiPicker(args)}
+                                            <EmojiAutocompleter
+                                                offset={messageEntryHeight}
+                                                onClose={args.onClose}
+                                                onSelect={args.onSelect}
+                                                query={args.query} />
+                                        {/snippet}
+                                    </EditorComponent>
+                                {:else}
+                                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                                    <div class="editor-placeholder" onpointerdown={() => (focusWhenReady = true)}>
+                                        {interpolate($_, placeholder)}
+                                    </div>
+                                {/if}
                             </div>
                         {/key}
 
@@ -910,6 +937,16 @@
             transform: rotate(135deg);
         }
     }
+    // mirrors :global(.ProseMirror) + its empty-editor placeholder
+    .editor-placeholder {
+        width: 100%;
+        min-width: 0;
+        font-size: 1rem;
+        line-height: 1.3;
+        color: var(--txt-light, var(--chat-input-placeholder));
+        cursor: text;
+    }
+
     .textbox {
         outline: none;
         border: 0;

--- a/frontend/app/src/components_shared/richTextEditorLoader.spec.ts
+++ b/frontend/app/src/components_shared/richTextEditorLoader.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const fakeComponent = { name: "FakeRichTextEditor" };
+
+// Each test gets a fresh loader module and a fresh mock of the editor chunk.
+async function fresh(behaviour: () => Promise<{ default: unknown }>) {
+    vi.resetModules();
+    vi.doMock("./RichTextEditor.svelte", behaviour);
+    return import("./richTextEditorLoader");
+}
+
+describe("richTextEditorLoader", () => {
+    beforeEach(() => {
+        vi.doUnmock("./RichTextEditor.svelte");
+    });
+
+    test("nothing is loaded until asked; concurrent loads share one import", async () => {
+        let importCount = 0;
+        const loader = await fresh(async () => {
+            importCount++;
+            return { default: fakeComponent };
+        });
+        expect(loader.richTextEditorIfLoaded()).toBeUndefined();
+        const [a, b] = await Promise.all([
+            loader.loadRichTextEditor(),
+            loader.loadRichTextEditor(),
+        ]);
+        expect(a).toBe(fakeComponent);
+        expect(b).toBe(fakeComponent);
+        expect(importCount).toBe(1);
+        expect(loader.richTextEditorIfLoaded()).toBe(fakeComponent);
+        await loader.loadRichTextEditor();
+        expect(importCount).toBe(1);
+    });
+
+    test("a failed load is retried on the next request", async () => {
+        let attempts = 0;
+        const loader = await fresh(async () => {
+            attempts++;
+            if (attempts === 1) throw new Error("chunk failed");
+            return { default: fakeComponent };
+        });
+        await expect(loader.loadRichTextEditor()).rejects.toThrow();
+        expect(loader.richTextEditorIfLoaded()).toBeUndefined();
+        await expect(loader.loadRichTextEditor()).resolves.toBe(fakeComponent);
+        expect(attempts).toBe(2);
+    });
+
+    test("warm-up loads at idle and swallows failures", async () => {
+        vi.useFakeTimers();
+        try {
+            let attempts = 0;
+            const loader = await fresh(async () => {
+                attempts++;
+                if (attempts === 1) throw new Error("chunk failed");
+                return { default: fakeComponent };
+            });
+            loader.warmRichTextEditor();
+            await vi.runAllTimersAsync();
+            expect(loader.richTextEditorIfLoaded()).toBeUndefined();
+            loader.warmRichTextEditor();
+            await vi.runAllTimersAsync();
+            expect(loader.richTextEditorIfLoaded()).toBe(fakeComponent);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/app/src/components_shared/richTextEditorLoader.ts
+++ b/frontend/app/src/components_shared/richTextEditorLoader.ts
@@ -1,0 +1,46 @@
+import type RichTextEditor from "./RichTextEditor.svelte";
+
+// The rich text editor pulls in tiptap + ProseMirror + lowlight (~445 KB raw /
+// ~140 KB gz), roughly a quarter of the critical-path JS. Loading it through
+// this module (rather than a static import) makes it its own chunk, off the
+// critical path. It is NOT deferred to first use: App warms it at idle once
+// the user is logged in, and MessageEntry requests it on mount, so in the
+// normal flow it is a module-cache hit by the time a chat is opened.
+//
+// Loading on composer focus was deliberately rejected: mobile browsers only
+// raise the soft keyboard for a focus() that is synchronous within the user
+// gesture, so tap → await import() → focus() would leave the keyboard closed.
+
+type EditorComponent = typeof RichTextEditor;
+
+let loaded: EditorComponent | undefined;
+let loading: Promise<EditorComponent> | undefined;
+
+export function richTextEditorIfLoaded(): EditorComponent | undefined {
+    return loaded;
+}
+
+export function loadRichTextEditor(): Promise<EditorComponent> {
+    loading ??= import("./RichTextEditor.svelte").then(
+        (m) => (loaded = m.default),
+        (err) => {
+            // allow a later mount to retry (e.g. transient network failure)
+            loading = undefined;
+            throw err;
+        },
+    );
+    return loading;
+}
+
+export function warmRichTextEditor(): void {
+    const run = () => {
+        loadRichTextEditor().catch(() => {
+            // a failed warm-up is not an error; the mount path retries and reports
+        });
+    };
+    if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(run, { timeout: 5000 });
+    } else {
+        setTimeout(run, 1000);
+    }
+}


### PR DESCRIPTION
Editor half of #9199 (part of #9179; daily-js half was #9228).

## Why

tiptap + ProseMirror + lowlight sat in the vendor chunk via the static `RichTextEditor` import in `MessageEntry` — ~27% of the critical-path JS, paid before first paint by every session including chat-list-only, anonymous landing, and PWA/native cold start (parse).

## What

`RichTextEditor` is loaded through a new `components_shared/richTextEditorLoader.ts`, so rollup emits it as its own chunk. It is deliberately **not deferred to first use**:

- `App` (both trees) warms the chunk at idle (`requestIdleCallback`) once the user is logged in, so in the normal boot → chat list → open chat flow it is already a module-cache hit and nothing is visibly different.
- `MessageEntry` (both trees) requests it on mount (chat selected), **not on focus**. Mobile browsers only raise the soft keyboard for a `focus()` that is synchronous within the user gesture, so loading on focus would leave the keyboard closed on the first tap.
- While in flight (only on direct-to-chat entry: deep link, notification tap, restored chat) a same-height static placeholder is shown; a tap on it focuses the editor once it arrives. The `{#key textboxId}` predictive-text remount is untouched and stays synchronous once loaded.
- Failed loads reset so the next mount retries; a failed idle warm-up is silent, a failed mount load logs.

`RichTextEditor.svelte` itself is unchanged. No static import of it remains anywhere in `app/src`.

## Numbers (prod build)

| chunk | before | after |
|---|---|---|
| vendor | 1,542 KB raw / 434 KB gz | 1,160 KB raw / **316 KB gz** |
| RichTextEditor (new, lazy) | — | 393 KB raw / 121 KB gz |
| main + vendor critical path | 530 KB gz | **412 KB gz (−22%)** |

`ProseMirror` string count in vendor: 0. `index.html` still modulepreloads only main + vendor (the editor chunk must not be preloaded or the win is lost).

## Verification

- Deployed to webtest and exercised by hand — no negative impact observed.
- Local dev: direct-to-chat entry renders the real editor, typing works, `@` opens the mention picker, chat switch re-mounts cleanly, no console errors.
- `richTextEditorLoader.spec.ts`: dedupe of concurrent loads, retry after a failed load, idle warm-up swallows failures.
- `npm run typecheck && npm run typecheck:agent && npm run lint && npm test` green; no new svelte-check warnings.
- Service worker only caches documents, so there is no precache manifest to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
