### PR TITLE
perf: throttle the chat-state IndexedDB rewrite to one write per 30s

### DIFF
--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -1929,7 +1929,7 @@ export class OpenChatAgent extends EventTarget {
         const updatedEvents = getUpdatedEvents(directChatUpdates, groupUpdates, communityUpdates);
 
         if (this.userClient.userId !== ANON_USER_ID) {
-            this._chatsDb.setCachedChats(state, updatedEvents);
+            this._chatsDb.setCachedChatsThrottled(state, updatedEvents);
         }
 
         const directChatsAddedUpdatedIds = new Set([

--- a/frontend/openchat-agent/src/utils/chatsDb.spec.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.spec.ts
@@ -1,6 +1,6 @@
-import type { ChatIdentifier, GroupChatIdentifier } from "@shared";
+import { ChatMap, type ChatIdentifier, type GroupChatIdentifier, type UpdatedEvent } from "@shared";
 import type { Principal } from "@icp-sdk/core/principal";
-import { beforeAll, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { ChatsDb, createCacheKey } from "./chatsDb";
 
 const chatId: GroupChatIdentifier = { kind: "group_chat", groupId: "gid" };
@@ -163,5 +163,92 @@ describe("loadMessagesByMessageIndex", () => {
 
         expect([...missing]).toEqual([]);
         expect([...dirty]).toEqual([100]);
+    });
+});
+
+describe("setCachedChatsThrottled", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function state(tag: string): any {
+        return { tag };
+    }
+    function updated(chatId: ChatIdentifier, ...indexes: number[]): ChatMap<UpdatedEvent[]> {
+        const m = new ChatMap<UpdatedEvent[]>();
+        m.set(
+            chatId,
+            indexes.map((eventIndex) => ({ eventIndex, timestamp: 0n })),
+        );
+        return m;
+    }
+    const other: ChatIdentifier = { kind: "group_chat", groupId: "other" };
+
+    function setup() {
+        vi.useFakeTimers();
+        const chatsDb = new ChatsDb({ toString: () => "principal" } as Principal);
+        const writes: [unknown, ChatMap<UpdatedEvent[]>][] = [];
+        vi.spyOn(chatsDb, "setCachedChats").mockImplementation(async (s, u) => {
+            writes.push([s, u]);
+        });
+        return { chatsDb, writes };
+    }
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    test("first request writes immediately", async () => {
+        const { chatsDb, writes } = setup();
+        chatsDb.setCachedChatsThrottled(state("a"), updated(chatId, 1));
+        expect(writes).toHaveLength(0);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(writes).toHaveLength(1);
+        expect(writes[0][0]).toEqual(state("a"));
+        expect(writes[0][1].get(chatId)?.map((e) => e.eventIndex)).toEqual([1]);
+    });
+
+    test("requests inside the interval coalesce into one trailing write with the latest state and all dirty marks", async () => {
+        const { chatsDb, writes } = setup();
+        chatsDb.setCachedChatsThrottled(state("a"), updated(chatId, 1));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(writes).toHaveLength(1);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        chatsDb.setCachedChatsThrottled(state("b"), updated(chatId, 2));
+        await vi.advanceTimersByTimeAsync(5_000);
+        chatsDb.setCachedChatsThrottled(state("c"), updated(other, 7));
+        await vi.advanceTimersByTimeAsync(5_000);
+        chatsDb.setCachedChatsThrottled(state("d"), updated(chatId, 3));
+        expect(writes).toHaveLength(1);
+
+        // 30s after the first write the trailing write lands
+        await vi.advanceTimersByTimeAsync(15_000);
+        expect(writes).toHaveLength(2);
+        expect(writes[1][0]).toEqual(state("d"));
+        expect(writes[1][1].get(chatId)?.map((e) => e.eventIndex)).toEqual([2, 3]);
+        expect(writes[1][1].get(other)?.map((e) => e.eventIndex)).toEqual([7]);
+
+        // nothing more pending
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(writes).toHaveLength(2);
+    });
+
+    test("a request after a quiet period writes immediately again", async () => {
+        const { chatsDb, writes } = setup();
+        chatsDb.setCachedChatsThrottled(state("a"), updated(chatId, 1));
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(45_000);
+        chatsDb.setCachedChatsThrottled(state("b"), updated(chatId, 2));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(writes.map(([s]) => s)).toEqual([state("a"), state("b")]);
+    });
+
+    test("a failed write is logged, not thrown", async () => {
+        vi.useFakeTimers();
+        const chatsDb = new ChatsDb({ toString: () => "principal" } as Principal);
+        vi.spyOn(chatsDb, "setCachedChats").mockRejectedValue(new Error("quota"));
+        const err = vi.spyOn(console, "error").mockImplementation(() => {});
+        chatsDb.setCachedChatsThrottled(state("a"), updated(chatId, 1));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(err).toHaveBeenCalledWith("Failed to cache chat state", expect.any(Error));
     });
 });

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -60,6 +60,7 @@ import { IndexedDbConnectionManager } from "./indexedDb";
 
 const CACHE_VERSION = 150;
 const MAX_INDEX = 9999999999;
+const CHAT_STATE_WRITE_INTERVAL_MS = 30_000;
 
 export type Database = Promise<IDBPDatabase<ChatSchema>>;
 
@@ -265,6 +266,11 @@ export class ChatsDb {
     private readonly connectionManager: IndexedDbConnectionManager<ChatSchema>;
     private readonly principalString: string;
     private expiredEventSweeperJob: NodeJS.Timeout | undefined;
+    private pendingChatState:
+        | { state: ChatStateFull; updatedEvents: ChatMap<UpdatedEvent[]> }
+        | undefined;
+    private chatStateWriteTimer: ReturnType<typeof setTimeout> | undefined;
+    private lastChatStateWrite = 0;
 
     constructor(principal: Principal) {
         this.principalString = principal.toString();
@@ -337,6 +343,47 @@ export class ChatsDb {
             return undefined;
         }
         return chats;
+    }
+
+    // setCachedChats rewrites the WHOLE chat state under one key (~1.5 MB for a
+    // heavy account) and is requested by every poll that carried an update —
+    // potentially every 5s. Coalesce those requests: at most one write per
+    // CHAT_STATE_WRITE_INTERVAL_MS, always writing the latest state together
+    // with the union of the events to mark dirty (they are consistent with each
+    // other, and land in the same transaction). The first request after a quiet
+    // period writes immediately so a cold cache is populated promptly.
+    //
+    // Losing a trailing write on unload is harmless: the cached
+    // latestUserCanisterUpdates timestamp means the next session fetches — and
+    // re-marks — the same updates again.
+    setCachedChatsThrottled(chatState: ChatStateFull, updatedEvents: ChatMap<UpdatedEvent[]>) {
+        if (this.pendingChatState === undefined) {
+            this.pendingChatState = { state: chatState, updatedEvents: new ChatMap() };
+        } else {
+            this.pendingChatState.state = chatState;
+        }
+        const pending = this.pendingChatState.updatedEvents;
+        for (const [chatId, events] of updatedEvents.entries()) {
+            const existing = pending.get(chatId);
+            pending.set(chatId, existing === undefined ? events : [...existing, ...events]);
+        }
+        if (this.chatStateWriteTimer !== undefined) return;
+        const delay = Math.max(
+            0,
+            this.lastChatStateWrite + CHAT_STATE_WRITE_INTERVAL_MS - Date.now(),
+        );
+        this.chatStateWriteTimer = setTimeout(() => this.flushPendingChatState(), delay);
+    }
+
+    private flushPendingChatState() {
+        this.chatStateWriteTimer = undefined;
+        const pending = this.pendingChatState;
+        this.pendingChatState = undefined;
+        if (pending === undefined) return;
+        this.lastChatStateWrite = Date.now();
+        this.setCachedChats(pending.state, pending.updatedEvents).catch((err) =>
+            console.error("Failed to cache chat state", err),
+        );
     }
 
     async setCachedChats(
@@ -954,6 +1001,9 @@ export class ChatsDb {
     }
 
     async clearCache(): Promise<void> {
+        clearTimeout(this.chatStateWriteTimer);
+        this.chatStateWriteTimer = undefined;
+        this.pendingChatState = undefined;
         const name = `openchat_db_${this.principalString}`;
         try {
             (await this.getDb()).close();


### PR DESCRIPTION
Part of #9179; the measured item from #9207.

## Why

`ChatsDb.setCachedChats` rewrites the **entire** chat state under one key and was requested, fire-and-forget with no `.catch`, by every 5 s poll that carried an update. Measured on a heavy prod account (372 direct chats, 136 groups, 14 communities): **~1.5 MB JSON per write** (structured-clone size is larger — Maps/Sets serialise as `{}`), so an active session could be cloning and writing that every 5 s in the worker.

## What

`ChatsDb.setCachedChatsThrottled` coalesces requests: at most one write per 30 s, always the latest state plus the union of the events to mark dirty (they stay consistent with each other and land in the same transaction as before). First request after a quiet period writes immediately (cold cache populated promptly). Failures are logged instead of surfacing as unhandled rejections. `clearCache` drops any pending write.

Losing a trailing write on unload is harmless: the cached `latestUserCanisterUpdates` timestamp means the next session fetches — and re-marks — the same updates again.

The other measured item (event-store LRU): IndexedDB usage on the same account was 122 MB of a 10 GB quota → not needed.

## Tests

`chatsDb.spec.ts` (fake timers, spied `setCachedChats`): immediate first write; coalescing inside the interval with latest state + all dirty marks across chats; immediate write again after a quiet period; failure logged not thrown. `typecheck`, `typecheck:agent`, lint, `npm test` (809) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
