### PR TITLE
Post-release tidy for 2.0.2043–2046: cut changelogs, drop user_index one-off re-sync

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
+
 ### Changed
 
 - Accept the new `Attempting`, `ContingencyRequired` and `ValidationFailed` authority report states pushed by the user_index ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))

--- a/backend/canisters/storage_bucket/CHANGELOG.md
+++ b/backend/canisters/storage_bucket/CHANGELOG.md
@@ -9,8 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Optional `source_hash` on `upload_chunk_v2`: the hash of the bytes a client transcoded from (video re-encoded at upload). A verdict on the transcode denylists its declared sources as *derived* - uploads of them are refused platform-wide, but since the bucket cannot verify the claim nobody is sanctioned or reported on a derived match; only bytes a moderator saw carry sanctions ([#9254](https://github.com/open-chat-labs/open-chat/pull/9254))
-- Token-gated evidence export on `vault_file_chunk` for the NCA reporting service, logged as `ExportedForAuthorityReport` in the chain of custody ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
-- Accept the `SetAuthorityReporter` vault op carrying the service principal and the OC public key needed to verify export tokens ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
 
 ### Changed
 
@@ -20,6 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Treat the last byte position of a `Range` header as inclusive and add the `Accept-Ranges` header ([#9253](https://github.com/open-chat-labs/open-chat/pull/9253))
+
+## [[2.0.2043](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2043-storage_bucket)] - 2026-08-26
+
+### Added
+
+- Token-gated evidence export on `vault_file_chunk` for the NCA reporting service, logged as `ExportedForAuthorityReport` in the chain of custody ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
+- Accept the `SetAuthorityReporter` vault op carrying the service principal and the OC public key needed to verify export tokens ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
 
 ## [[2.0.2032](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2032-storage_bucket)] - 2026-08-20
 

--- a/backend/canisters/storage_index/CHANGELOG.md
+++ b/backend/canisters/storage_index/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Hold and fan out *derived* CSAM hashes (declared sources of upheld transcodes) alongside verified ones, seeding new buckets with both ([#9254](https://github.com/open-chat-labs/open-chat/pull/9254))
+
+## [[2.0.2044](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2044-storage_index)] - 2026-08-26
+
+### Added
+
 - Relay `SetAuthorityReporter` to every bucket and seed each new bucket with it ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
 
 ## [[2.0.2031](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2031-storage_index)] - 2026-08-20

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Removed
+
+- Remove the one-off `post_upgrade` privilege re-sync now that it has run on prod in the 2.0.2046 release ([#9255](https://github.com/open-chat-labs/open-chat/pull/9255))
+
 ## [[2.0.2046](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2046-user_index)] - 2026-08-26
 
 ### Added

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[2.0.2046](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2046-user_index)] - 2026-08-26
+
 ### Added
 
 - Automated NCA (CSEA-IRP) filing path for the off-chain reporting service: `authority_report_token` mints a vault-export + submitter token pair, `record_authority_report_attempt` opens a crash-safe attempt marker and returns the certified report data, and `clear_authority_report_attempt` / `record_authority_report_filed` complete the loop, classifying failures into the new `Attempting`, `ContingencyRequired` and `ValidationFailed` report states ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))

--- a/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,6 +1,6 @@
+use crate::Data;
 use crate::lifecycle::init_state;
 use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
-use crate::Data;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use ic_cdk::post_upgrade;

--- a/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -1,7 +1,6 @@
 use crate::lifecycle::init_state;
 use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
-use crate::model::moderation;
-use crate::{Data, mutate_state};
+use crate::Data;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use ic_cdk::post_upgrade;
@@ -27,23 +26,6 @@ fn post_upgrade(args: Args) {
     let env = Box::new(CanisterEnv::new(data.rng_seed));
     init_cycles_dispenser_client(data.cycles_dispenser_canister_id, data.test_mode);
     init_state(env, data, args.wasm_version);
-
-    // One-off: the suspension privilege freeze only runs on suspend/unsuspend transitions, so
-    // accounts already suspended when it shipped still hold moderator/operator flags on the
-    // local user indexes and sit on the bucket vault-reviewer allowlist. Re-sync them now.
-    // TODO remove after the release containing this has been deployed
-    mutate_state(|state| {
-        let suspended: Vec<_> = state
-            .data
-            .users
-            .iter()
-            .filter(|u| u.suspension_details.is_some())
-            .map(|u| u.user_id)
-            .collect();
-        for user_id in suspended {
-            moderation::sync_suspended_privileges(user_id, true, state);
-        }
-    });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");


### PR DESCRIPTION
Audit of every canister CHANGELOG against its latest tag and the version prod actually reports on `/metrics`:

| canister | changelog | tag | prod | |
|---|---|---|---|---|
| storage_bucket | 2032 | 2043 | 2043 | entries still under unreleased |
| storage_index | 2031 | 2044 | 2044 | entries still under unreleased |
| community | 2035 | 2045 | 2045 | entries still under unreleased |
| user_index | 2030 | 2046 | 2046 | entries still under unreleased |
| everything else | = | = | = | consistent |

All four were tagged at `9429a2ac9` on 2026-08-26 and are live.

- Moves the entries that were under `[unreleased]` at that commit beneath `## [[2.0.NNNN]] - 2026-08-26` headings. Entries merged after the tags stay unreleased: `#9253` (range serving) and `#9254` (`source_hash` / derived denylist) for `storage_bucket`, `#9254` for `storage_index`.
- Removes the one-off `post_upgrade` suspended-privilege re-sync from `user_index` (#9245, marked for removal once deployed) now that 2.0.2046 has run on prod. `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
