### PR TITLE
Fix store wedge behind the mobile thread/tip freeze; retry ReplicaNotUpToDate; Rollbar sweep fixes

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -160,6 +160,10 @@
 
     trackedEffect("calculate-height", calculateHeight);
 
+    $effect(() => {
+        botState.messageFormatter = $_;
+    });
+
     onMount(() => {
         const unsubs = [
             subscribe("startVideoCall", startVideoCall),
@@ -213,9 +217,6 @@
             resumeEventLoop: () => client.resumeEventLoop(),
         };
 
-        const unsub = _.subscribe((formatter) => {
-            botState.messageFormatter = formatter;
-        });
 
         if (client.isNativeApp()) {
             // Inform the native app that svelte code is ready! SetTimeout
@@ -235,7 +236,6 @@
                 window.visualViewport?.removeEventListener("resize", calculateHeight);
             }
             unsubs.forEach((u) => u());
-            unsub();
             unsubKeyboard();
         };
     });

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -177,21 +177,19 @@
                 }
             });
         }
+    });
 
-        if (expiresAt !== undefined) {
-            return now.subscribe((t) => {
-                const ttl = expiresAt ? expiresAt - Number(timestamp) : 0;
-                const age = t - Number(timestamp);
-                const expired = age > ttl;
-                percentageExpired = expired ? 100 : (age / ttl) * 100;
-                // if this message is the root of a thread, make sure that we close that thread when the message expires
-                if (percentageExpired >= 100 && msg.thread) {
-                    client.filterRightPanelHistory(
-                        (panel) => panel.kind !== "message_thread_panel",
-                    );
-                    navigate(removeQueryStringParam("open"));
-                }
-            });
+    $effect(() => {
+        if (expiresAt === undefined) return;
+        const ttl = expiresAt - Number(timestamp);
+        const age = $now - Number(timestamp);
+        const expired = age > ttl;
+        const percentage = expired ? 100 : (age / ttl) * 100;
+        percentageExpired = percentage;
+        // if this message is the root of a thread, make sure that we close that thread when the message expires
+        if (percentage >= 100 && msg.thread) {
+            client.filterRightPanelHistory((panel) => panel.kind !== "message_thread_panel");
+            navigate(removeQueryStringParam("open"));
         }
     });
 

--- a/frontend/app/src/components/home/ChatSummary.svelte
+++ b/frontend/app/src/components/home/ChatSummary.svelte
@@ -34,7 +34,7 @@
         byContext as typersByContext,
     } from "@client";
     import { navigate } from "@utils/navigation";
-    import { getContext, onMount, untrack } from "svelte";
+    import { getContext, untrack } from "svelte";
     import { _ } from "svelte-i18n";
     import ArchiveIcon from "svelte-material-icons/Archive.svelte";
     import BellIcon from "svelte-material-icons/Bell.svelte";
@@ -112,10 +112,9 @@
     let delOffset = $state(maxDelOffset);
     let swiped = $state(false);
 
-    $effect(() => updateUnreadCounts(chatSummary));
-
-    onMount(() => {
-        return messagesRead.subscribe(() => updateUnreadCounts(chatSummary));
+    $effect(() => {
+        void $messagesRead;
+        updateUnreadCounts(chatSummary);
     });
 
     /***

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -119,6 +119,7 @@
 
         const unsubs = [
             messagesRead.subscribe(() => {
+                if (chat === undefined) return;
                 unreadMessages = getUnreadMessageCount(chat);
                 firstUnreadMention = client.getFirstUnreadMention(chat);
             }),

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -118,11 +118,6 @@
         }
 
         const unsubs = [
-            messagesRead.subscribe(() => {
-                if (chat === undefined) return;
-                unreadMessages = getUnreadMessageCount(chat);
-                firstUnreadMention = client.getFirstUnreadMention(chat);
-            }),
             subscribe("createPoll", onCreatePoll),
             subscribe("attachGif", onAttachGif),
             subscribe("tokenTransfer", onTokenTransfer),
@@ -167,6 +162,12 @@
             setRightPanelHistory([]);
         }
     }
+
+    $effect(() => {
+        void $messagesRead;
+        unreadMessages = getUnreadMessageCount(chat);
+        firstUnreadMention = client.getFirstUnreadMention(chat);
+    });
 
     function getUnreadMessageCount(chat: ChatSummary): number {
         if (client.isPreviewing(chat.id) || client.isLapsed(chat.id)) return 0;

--- a/frontend/app/src/components/home/CurrentChatMenu.svelte
+++ b/frontend/app/src/components/home/CurrentChatMenu.svelte
@@ -144,6 +144,7 @@
     function setUnreadPinned(hasPinned: boolean, chat: ChatSummary) {
         hasUnreadPinned =
             hasPinned &&
+            chat !== undefined &&
             (chat.kind === "group_chat" || chat.kind === "channel") &&
             client.unreadPinned(chat.id, chat.dateLastPinned);
     }

--- a/frontend/app/src/components/home/CurrentChatMenu.svelte
+++ b/frontend/app/src/components/home/CurrentChatMenu.svelte
@@ -19,7 +19,7 @@
         publish,
         setRightPanelHistory,
     } from "@client";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import AccountMultiple from "svelte-material-icons/AccountMultiple.svelte";
     import AccountMultiplePlus from "svelte-material-icons/AccountMultiplePlus.svelte";
@@ -134,17 +134,13 @@
     let hasUnreadPinned = $state(false);
 
     $effect(() => {
+        void $messagesRead;
         setUnreadPinned(hasPinned, selectedChatSummary);
-    });
-
-    onMount(() => {
-        return messagesRead.subscribe(() => setUnreadPinned(hasPinned, selectedChatSummary));
     });
 
     function setUnreadPinned(hasPinned: boolean, chat: ChatSummary) {
         hasUnreadPinned =
             hasPinned &&
-            chat !== undefined &&
             (chat.kind === "group_chat" || chat.kind === "channel") &&
             client.unreadPinned(chat.id, chat.dateLastPinned);
     }

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -234,7 +234,9 @@
             }
         }
     });
-    let showAvatar = $derived(initialised && shouldShowAvatar(chat, $eventsStore[0]?.index));
+    let showAvatar = $derived(
+        initialised && chat !== undefined && shouldShowAvatar(chat, $eventsStore[0]?.index),
+    );
     let messageContext = $derived({ chatId: chat?.id, threadRootMessageIndex: undefined });
     let editingEvent = $derived($selectedChatDraftMessageStore?.editingEvent);
     const grouper = new TimelineGrouper();
@@ -246,7 +248,7 @@
         grouper.group(
             $eventsStore,
             $currentUserIdStore,
-            chat.kind === "channel" && chat.public,
+            chat?.kind === "channel" && chat.public,
             $selectedChatExpandedDeletedMessageStore,
             groupInnerFn,
             true,
@@ -254,7 +256,7 @@
     );
     let items = $derived.by<FlatChatItem[]>(() => {
         const flat: FlatChatItem[] = flattener.flatten(timeline);
-        if (showAvatar) {
+        if (showAvatar && chat !== undefined) {
             // rendered at the oldest end of the list (the visual top)
             flat.push(chatStartItem(chatIdentifierToString(chat.id)));
         }

--- a/frontend/app/src/components/home/ThreadSummary.svelte
+++ b/frontend/app/src/components/home/ThreadSummary.svelte
@@ -7,7 +7,7 @@
         mobileWidth,
         threadsFollowedByMeStore,
     } from "@client";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import { pop } from "../../utils/transition";
     import Avatar from "../Avatar.svelte";
@@ -35,14 +35,13 @@
         client.unreadThreadMessageCount(chatId, threadRootMessageIndex, lastMessageIndex),
     );
 
-    onMount(() => {
-        return messagesRead.subscribe(() => {
-            unreadCount = client.unreadThreadMessageCount(
-                chatId,
-                threadRootMessageIndex,
-                lastMessageIndex,
-            );
-        });
+    $effect(() => {
+        void $messagesRead;
+        unreadCount = client.unreadThreadMessageCount(
+            chatId,
+            threadRootMessageIndex,
+            lastMessageIndex,
+        );
     });
 </script>
 

--- a/frontend/app/src/components/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components/home/communities/explore/Explore.svelte
@@ -13,7 +13,7 @@
         ScreenWidth,
         screenWidth,
     } from "@client";
-    import { getContext, onMount, tick } from "svelte";
+    import { getContext, onMount, tick, untrack } from "svelte";
     import { _ } from "svelte-i18n";
     import ArrowUp from "svelte-material-icons/ArrowUp.svelte";
     import CloudOffOutline from "svelte-material-icons/CloudOffOutline.svelte";
@@ -104,7 +104,11 @@
             }
             onScroll();
         });
-        return exploreCommunitiesFiltersStore.subscribe((filters) => {
+    });
+
+    $effect(() => {
+        const filters = $exploreCommunitiesFiltersStore;
+        untrack(() => {
             if (initialised || communitySearchState.results.length === 0) {
                 search(filters, true);
             }

--- a/frontend/app/src/components/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components/home/pinned/PinnedMessages.svelte
@@ -43,15 +43,12 @@
     let pinnedMessages = $derived($selectedChatPinnedMessagesStore);
 
     onMount(() => {
-        const unsubs = [
-            subscribe("chatWith", onClose),
-            messagesRead.subscribe(() => {
-                unread = client.unreadPinned(chatId, dateLastPinned);
-            }),
-        ];
-        return () => {
-            unsubs.forEach((u) => u());
-        };
+        return subscribe("chatWith", onClose);
+    });
+
+    $effect(() => {
+        void $messagesRead;
+        unread = client.unreadPinned(chatId, dateLastPinned);
     });
 
     let messagesDiv: HTMLDivElement | undefined = $state();

--- a/frontend/app/src/components/home/thread/ThreadHeader.svelte
+++ b/frontend/app/src/components/home/thread/ThreadHeader.svelte
@@ -41,7 +41,7 @@
     let { chatSummary, rootEvent, threadRootMessageIndex, onCloseThread }: Props = $props();
 
     function close() {
-        onCloseThread(chatSummary.id);
+        if (chatSummary !== undefined) onCloseThread(chatSummary.id);
     }
 
     function normaliseChatSummary(_now: number, chatSummary: ChatSummary, typing: TypersByKey) {

--- a/frontend/app/src/components/home/thread/ThreadPreview.svelte
+++ b/frontend/app/src/components/home/thread/ThreadPreview.svelte
@@ -18,7 +18,7 @@
         type ThreadPreview,
     } from "@client";
     import { navigate } from "@utils/navigation";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import EyeOffIcon from "svelte-material-icons/EyeOffOutline.svelte";
     import { i18nKey } from "../../../i18n/i18n";
@@ -64,16 +64,15 @@
         avatarUrl: client.groupAvatarUrl(chat, $selectedCommunitySummaryStore),
     });
 
-    onMount(() => {
-        return messagesRead.subscribe(() => {
-            if (syncDetails !== undefined) {
-                unreadCount = client.unreadThreadMessageCount(
-                    thread.chatId,
-                    threadRootMessageIndex,
-                    syncDetails.latestMessageIndex,
-                );
-            }
-        });
+    $effect(() => {
+        void $messagesRead;
+        if (syncDetails !== undefined) {
+            unreadCount = client.unreadThreadMessageCount(
+                thread.chatId,
+                threadRootMessageIndex,
+                syncDetails.latestMessageIndex,
+            );
+        }
     });
 
     let grouped = $derived(client.groupBySender(thread.latestReplies));

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -132,6 +132,10 @@
 
     trackedEffect("calculate-height", calculateHeight);
 
+    $effect(() => {
+        botState.messageFormatter = $_;
+    });
+
     onMount(() => {
         const unsubs = [
             subscribe("startVideoCall", startVideoCall),
@@ -149,9 +153,6 @@
             window.visualViewport?.addEventListener("resize", calculateHeight);
         }
 
-        const unsub = _.subscribe((formatter) => {
-            botState.messageFormatter = formatter;
-        });
 
         const unsubKeyboard = setupKeyboardTracking();
         return () => {
@@ -161,7 +162,6 @@
                 window.visualViewport?.removeEventListener("resize", calculateHeight);
             }
             unsubs.forEach((u) => u());
-            unsub();
             unsubKeyboard();
         };
     });

--- a/frontend/app/src/components_mobile/home/ChatMessage.svelte
+++ b/frontend/app/src/components_mobile/home/ChatMessage.svelte
@@ -187,21 +187,19 @@
                 }
             });
         }
+    });
 
-        if (expiresAt !== undefined) {
-            return now.subscribe((t) => {
-                const ttl = expiresAt ? expiresAt - Number(timestamp) : 0;
-                const age = t - Number(timestamp);
-                const expired = age > ttl;
-                percentageExpired = expired ? 100 : (age / ttl) * 100;
-                // if this message is the root of a thread, make sure that we close that thread when the message expires
-                if (percentageExpired >= 100 && msg.thread) {
-                    client.filterRightPanelHistory(
-                        (panel) => panel.kind !== "message_thread_panel",
-                    );
-                    navigate(removeQueryStringParam("open"));
-                }
-            });
+    $effect(() => {
+        if (expiresAt === undefined) return;
+        const ttl = expiresAt - Number(timestamp);
+        const age = $now - Number(timestamp);
+        const expired = age > ttl;
+        const percentage = expired ? 100 : (age / ttl) * 100;
+        percentageExpired = percentage;
+        // if this message is the root of a thread, make sure that we close that thread when the message expires
+        if (percentage >= 100 && msg.thread) {
+            client.filterRightPanelHistory((panel) => panel.kind !== "message_thread_panel");
+            navigate(removeQueryStringParam("open"));
         }
     });
 

--- a/frontend/app/src/components_mobile/home/ChatSummary.svelte
+++ b/frontend/app/src/components_mobile/home/ChatSummary.svelte
@@ -41,7 +41,7 @@
         byContext as typersByContext,
     } from "@client";
     import { navigate } from "@utils/navigation";
-    import { getContext, onMount, untrack } from "svelte";
+    import { getContext, untrack } from "svelte";
     import { _ } from "svelte-i18n";
     import ArchiveIcon from "svelte-material-icons/Archive.svelte";
     import BellIcon from "svelte-material-icons/Bell.svelte";
@@ -114,10 +114,9 @@
 
     let longpressCooldown = $derived(scrollStatus.isCooldown);
 
-    $effect(() => updateUnreadCounts(chatSummary));
-
-    onMount(() => {
-        return messagesRead.subscribe(() => updateUnreadCounts(chatSummary));
+    $effect(() => {
+        void $messagesRead;
+        updateUnreadCounts(chatSummary);
     });
 
     trackedEffect("unarchive-chat", () => {

--- a/frontend/app/src/components_mobile/home/CurrentChat.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChat.svelte
@@ -99,11 +99,6 @@
         }
 
         const unsubs = [
-            messagesRead.subscribe(() => {
-                if (chat === undefined) return;
-                unreadMessages = getUnreadMessageCount(chat);
-                firstUnreadMention = client.getFirstUnreadMention(chat);
-            }),
             subscribe("tokenTransfer", onTokenTransfer),
             subscribe("createTestMessages", onCreateTestMessages),
             subscribe("searchChat", onSearchChat),
@@ -124,6 +119,12 @@
             createTestMessages(num);
         }
     }
+
+    $effect(() => {
+        void $messagesRead;
+        unreadMessages = getUnreadMessageCount(chat);
+        firstUnreadMention = client.getFirstUnreadMention(chat);
+    });
 
     function getUnreadMessageCount(chat: ChatSummary): number {
         if (client.isPreviewing(chat.id) || client.isLapsed(chat.id)) return 0;

--- a/frontend/app/src/components_mobile/home/CurrentChat.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChat.svelte
@@ -100,6 +100,7 @@
 
         const unsubs = [
             messagesRead.subscribe(() => {
+                if (chat === undefined) return;
                 unreadMessages = getUnreadMessageCount(chat);
                 firstUnreadMention = client.getFirstUnreadMention(chat);
             }),

--- a/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components_mobile/home/CurrentChatMessages.svelte
@@ -272,7 +272,9 @@
             }
         }
     });
-    let showAvatar = $derived(initialised && shouldShowAvatar(chat, $eventsStore[0]?.index));
+    let showAvatar = $derived(
+        initialised && chat !== undefined && shouldShowAvatar(chat, $eventsStore[0]?.index),
+    );
     let messageContext = $derived({ chatId: chat?.id, threadRootMessageIndex: undefined });
     const grouper = new TimelineGrouper();
     const flattener = new TimelineFlattener();
@@ -283,7 +285,7 @@
         grouper.group(
             $eventsStore,
             $currentUserIdStore,
-            chat.kind === "channel" && chat.public,
+            chat?.kind === "channel" && chat.public,
             $selectedChatExpandedDeletedMessageStore,
             groupInnerFn,
             true,
@@ -291,7 +293,7 @@
     );
     let items = $derived.by<FlatChatItem[]>(() => {
         const flat: FlatChatItem[] = flattener.flatten(timeline);
-        if (showAvatar) {
+        if (showAvatar && chat !== undefined) {
             // rendered at the oldest end of the list (the visual top)
             flat.push(chatStartItem(chatIdentifierToString(chat.id)));
         }

--- a/frontend/app/src/components_mobile/home/SlidingModals.svelte
+++ b/frontend/app/src/components_mobile/home/SlidingModals.svelte
@@ -42,7 +42,7 @@
         type UserGroupDetails,
     } from "@client";
     import page from "page";
-    import { getContext, onMount } from "svelte";
+    import { getContext, onMount, untrack } from "svelte";
     import { minimizeApp } from "tauri-plugin-oc-api";
     import { expectBackPress } from "../../utils/native/notification_channels";
     import { flushPendingNavigation, hasPendingNavigation } from "../../utils/navigation";
@@ -321,15 +321,6 @@
             subscribe("shareMessage", (share) =>
                 push({ kind: "share_message", share: share as unknown as ShareType }),
             ),
-            // Android share-target events use a store (rather than pubsub) so
-            // cold-start shares that arrive before this onMount runs aren't
-            // dropped. We consume on subscribe and clear so opening the modal
-            // a second time requires a fresh share.
-            pendingShareStore.subscribe((share) => {
-                if (share === undefined) return;
-                push({ kind: "share_message", share });
-                pendingShareStore.set(undefined);
-            }),
             subscribe("viewBotCommand", (command) => push({ kind: "view_bot_command", command })),
             subscribe("registerBot", () => push({ kind: "register_bot" })),
             subscribe("updateBot", () => push({ kind: "update_bot" })),
@@ -549,6 +540,18 @@
             history.pushState = originalPushState;
             unsubs.forEach((u) => u());
         };
+    });
+
+    // Android share-target events use a store (rather than pubsub) so cold-start shares that
+    // arrive before this component mounts aren't dropped. Consume and clear so opening the modal
+    // a second time requires a fresh share.
+    $effect(() => {
+        const share = $pendingShareStore;
+        if (share === undefined) return;
+        untrack(() => {
+            push({ kind: "share_message", share });
+            pendingShareStore.set(undefined);
+        });
     });
 </script>
 

--- a/frontend/app/src/components_mobile/home/ThreadSummary.svelte
+++ b/frontend/app/src/components_mobile/home/ThreadSummary.svelte
@@ -2,7 +2,7 @@
     import { Avatar } from "component-lib";
     import type { ChatIdentifier, OpenChat, ThreadSummary } from "@client";
     import { allUsersStore, messagesRead, threadsFollowedByMeStore } from "@client";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import { pop } from "../../utils/transition";
 
@@ -29,14 +29,13 @@
         client.unreadThreadMessageCount(chatId, threadRootMessageIndex, lastMessageIndex),
     );
 
-    onMount(() => {
-        return messagesRead.subscribe(() => {
-            unreadCount = client.unreadThreadMessageCount(
-                chatId,
-                threadRootMessageIndex,
-                lastMessageIndex,
-            );
-        });
+    $effect(() => {
+        void $messagesRead;
+        unreadCount = client.unreadThreadMessageCount(
+            chatId,
+            threadRootMessageIndex,
+            lastMessageIndex,
+        );
     });
 </script>
 

--- a/frontend/app/src/components_mobile/home/access/AccessGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateEvaluator.svelte
@@ -31,7 +31,7 @@
         Row,
         transition,
     } from "component-lib";
-    import { onMount } from "svelte";
+    import { untrack } from "svelte";
     import ShieldStar from "svelte-material-icons/ShieldStarOutline.svelte";
     import Translatable from "../../Translatable.svelte";
     import SlidingPageContent from "../SlidingPageContent.svelte";
@@ -57,10 +57,9 @@
 
     let { gate, onClose, onComplete }: Props = $props();
 
-    onMount(() => {
-        return cryptoBalanceStore.subscribe((_) => {
-            refreshBalanceGates();
-        });
+    $effect(() => {
+        void $cryptoBalanceStore;
+        untrack(refreshBalanceGates);
     });
 
     let flattenedGates = $state<SatisfiedLeafGate[]>(normaliseGates(gate));

--- a/frontend/app/src/components_mobile/home/communities/details/UserGroup.svelte
+++ b/frontend/app/src/components_mobile/home/communities/details/UserGroup.svelte
@@ -9,7 +9,7 @@
         type UserGroupDetails,
         type UserSummary,
     } from "@client";
-    import { getContext, onMount } from "svelte";
+    import { getContext, untrack } from "svelte";
     import { _ } from "svelte-i18n";
     import Edit from "svelte-material-icons/SquareEditOutline.svelte";
     import { i18nKey, interpolate } from "../../../../i18n/i18n";
@@ -26,16 +26,14 @@
         userGroup: UserGroupDetails;
     }
 
-    onMount(() => {
-        return selectedCommunityUserGroupsStore.subscribe((groups) => {
-            const ug = groups.get(userGroup.id);
-            if (ug !== undefined) {
-                userGroup = ug;
-            }
-        });
-    });
-
     let { community, userGroup }: Props = $props();
+
+    $effect(() => {
+        const ug = $selectedCommunityUserGroupsStore.get(untrack(() => userGroup.id));
+        if (ug !== undefined) {
+            userGroup = ug;
+        }
+    });
 
     let communityState = new CommunityState(client, community);
     let searchTermEntered = $state("");

--- a/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
@@ -29,7 +29,7 @@
         type OpenChat,
     } from "@client";
     import { navigate } from "@utils/navigation";
-    import { getContext, onMount, tick } from "svelte";
+    import { getContext, onMount, tick, untrack } from "svelte";
     import { _ } from "svelte-i18n";
     import Account from "svelte-material-icons/AccountGroupOutline.svelte";
     import ArrowUp from "svelte-material-icons/ArrowUp.svelte";
@@ -162,25 +162,29 @@
             onScroll();
         });
 
-        const unsub = exploreCommunitiesFiltersStore.subscribe((filters) => {
+        return () => {
+            scrollableElement?.removeEventListener("scroll", onScroll);
+        };
+    });
+
+    $effect(() => {
+        const filters = $exploreCommunitiesFiltersStore;
+        untrack(() => {
             if (initialised || communitySearchState.results.length === 0) {
                 searchCommunities(filters, true);
             }
             initialised = true;
         });
+    });
 
-        const unsubBot = showUnpublishedBots.subscribe((show) => {
+    $effect(() => {
+        const show = $showUnpublishedBots;
+        untrack(() => {
             if (initialised || botSearchState.results.length === 0) {
                 searchBots(show);
             }
             initialised = true;
-        }, undefined);
-
-        return () => {
-            scrollableElement?.removeEventListener("scroll", onScroll);
-            unsub();
-            unsubBot();
-        };
+        });
     });
 
     function setView(v: View) {

--- a/frontend/app/src/components_mobile/home/message/ThreadSummary.svelte
+++ b/frontend/app/src/components_mobile/home/message/ThreadSummary.svelte
@@ -18,7 +18,7 @@
         type ThreadSummary,
     } from "@client";
     import { navigate } from "@utils/navigation";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import ChevronRight from "svelte-material-icons/ChevronRight.svelte";
 
@@ -73,14 +73,13 @@
         }),
     );
 
-    onMount(() => {
-        return messagesRead.subscribe(() => {
-            unreadCount = client.unreadThreadMessageCount(
-                chatId,
-                threadRootMessageIndex,
-                lastMessageIndex,
-            );
-        });
+    $effect(() => {
+        void $messagesRead;
+        unreadCount = client.unreadThreadMessageCount(
+            chatId,
+            threadRootMessageIndex,
+            lastMessageIndex,
+        );
     });
 </script>
 

--- a/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components_mobile/home/pinned/PinnedMessages.svelte
@@ -39,15 +39,12 @@
     let pinnedMessages = $derived($selectedChatPinnedMessagesStore);
 
     onMount(() => {
-        const unsubs = [
-            subscribe("chatWith", () => publish("closeModalPage")),
-            messagesRead.subscribe(() => {
-                unread = client.unreadPinned(chat.id, chat.dateLastPinned);
-            }),
-        ];
-        return () => {
-            unsubs.forEach((u) => u());
-        };
+        return subscribe("chatWith", () => publish("closeModalPage"));
+    });
+
+    $effect(() => {
+        void $messagesRead;
+        unread = client.unreadPinned(chat.id, chat.dateLastPinned);
     });
 
     let messagesDiv: HTMLDivElement | undefined = $state();

--- a/frontend/app/src/components_mobile/home/thread/ThreadHeader.svelte
+++ b/frontend/app/src/components_mobile/home/thread/ThreadHeader.svelte
@@ -32,7 +32,7 @@
     let { chatSummary, rootEvent, threadRootMessageIndex, onCloseThread }: Props = $props();
 
     function close() {
-        onCloseThread(chatSummary.id);
+        if (chatSummary !== undefined) onCloseThread(chatSummary.id);
     }
 
     function normaliseChatSummary(_now: number, chatSummary: ChatSummary, typing: TypersByKey) {

--- a/frontend/app/src/components_mobile/home/thread/ThreadPreview.svelte
+++ b/frontend/app/src/components_mobile/home/thread/ThreadPreview.svelte
@@ -24,7 +24,7 @@
         selectedCommunitySummaryStore,
         type ThreadPreview,
     } from "@client";
-    import { getContext, onMount } from "svelte";
+    import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import DotsVertical from "svelte-material-icons/DotsVertical.svelte";
     import { i18nKey } from "../../../i18n/i18n";
@@ -74,16 +74,15 @@
         }
     }
 
-    onMount(() => {
-        return messagesRead.subscribe(() => {
-            if (syncDetails !== undefined) {
-                unreadCount = client.unreadThreadMessageCount(
-                    thread.chatId,
-                    threadRootMessageIndex,
-                    syncDetails.latestMessageIndex,
-                );
-            }
-        });
+    $effect(() => {
+        void $messagesRead;
+        if (syncDetails !== undefined) {
+            unreadCount = client.unreadThreadMessageCount(
+                thread.chatId,
+                threadRootMessageIndex,
+                syncDetails.latestMessageIndex,
+            );
+        }
     });
 
     let grouped = $derived(client.groupBySender(thread.latestReplies));

--- a/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
@@ -9,7 +9,6 @@
         OpenChat,
         publish,
         userMetricsStore,
-        type PublicProfile,
     } from "@client";
     import { getContext, onMount } from "svelte";
     import DotsVertical from "svelte-material-icons/DotsVertical.svelte";
@@ -21,16 +20,13 @@
     const client = getContext<OpenChat>("client");
 
     let user = $derived($allUsersStore.get($currentUserIdStore) ?? client.nullUser("unknown"));
-    let profile: PublicProfile | undefined = $state();
+    let profile = $derived($currentUserProfileStore);
 
     onMount(() => {
         client.getUser($currentUserIdStore).then((u) => {
             if (u) {
                 user = u;
             }
-        });
-        return currentUserProfileStore.subscribe((p) => {
-            profile = p;
         });
     });
 

--- a/frontend/openchat-agent/src/services/common/chatMappersV2.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappersV2.ts
@@ -115,6 +115,9 @@ import type {
     WebhookDetails,
 } from "@shared";
 import {
+    ErrorCode,
+    isError,
+    parseBigInt,
     CommonResponses,
     ICP_SYMBOL,
     ProposalDecisionStatus,
@@ -278,6 +281,7 @@ import {
     principalStringToBytes,
 } from "../../utils/mapping";
 import type { ApiPrincipal } from "../index";
+import { ReplicaNotUpToDateError } from "../error";
 import { ensureReplicaIsUpToDate } from "./replicaUpToDateChecker";
 const E8S_AS_BIGINT = BigInt(100_000_000);
 
@@ -301,6 +305,25 @@ export async function getEventsSuccess(
             latestEventIndex: value.latest_event_index,
         }
     );
+}
+
+// The canister answers ReplicaNotUpToDate (with its own timestamp as the message) when the replica
+// a query landed on is behind the client's latest_known_update. Returned as a plain error response
+// nothing would retry it and event merging would throw on it; rethrown as ReplicaNotUpToDateError
+// it goes through the query retry loop in CanisterAgent (backoff, so a later attempt lands on a
+// replica that has caught up) exactly like the client-side replica check does.
+export function throwIfReplicaNotUpToDate<T>(
+    response: T | OCError,
+    latestKnownUpdate: bigint | undefined,
+): T | OCError {
+    if (isError(response) && response.code === ErrorCode.ReplicaNotUpToDate) {
+        throw ReplicaNotUpToDateError.byTimestamp(
+            parseBigInt(response.message ?? "") ?? BigInt(0),
+            latestKnownUpdate ?? BigInt(0),
+            false,
+        );
+    }
+    return response;
 }
 
 export function eventWrapper(value: TEventWrapperChatEvent): EventWrapper<ChatEvent> {

--- a/frontend/openchat-agent/src/services/community/community.client.ts
+++ b/frontend/openchat-agent/src/services/community/community.client.ts
@@ -204,6 +204,7 @@ import {
     inviteCodeSuccess,
     isSuccess,
     mapResult,
+    throwIfReplicaNotUpToDate,
     proposalTallies,
     pushEventSuccess,
     searchGroupChatResponse,
@@ -521,7 +522,11 @@ export class CommunityClient
             chatId.communityId,
             "events",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             CommunityEventsArgs,
             CommunityEventsResponse,
         );
@@ -544,7 +549,11 @@ export class CommunityClient
             chatId.communityId,
             "events_by_index",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             CommunityEventsByIndexArgs,
             CommunityEventsResponse,
         );
@@ -570,7 +579,11 @@ export class CommunityClient
             chatId.communityId,
             "events_window",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             CommunityEventsWindowArgs,
             CommunityEventsResponse,
         );
@@ -594,7 +607,11 @@ export class CommunityClient
             chatId.communityId,
             "messages_by_message_index",
             args,
-            (resp) => mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             CommunityMessagesByMessageIndexArgs,
             CommunityMessagesByMessageIndexResponse,
         );

--- a/frontend/openchat-agent/src/services/group/group.client.ts
+++ b/frontend/openchat-agent/src/services/group/group.client.ts
@@ -151,6 +151,7 @@ import {
     inviteCodeSuccess,
     isSuccess,
     mapResult,
+    throwIfReplicaNotUpToDate,
     proposalTallies,
     pushEventSuccess,
     searchGroupChatResponse,
@@ -222,7 +223,11 @@ export class GroupClient
             chatId.groupId,
             "events_by_index",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             GroupEventsByIndexArgs,
             GroupEventsResponse,
         );
@@ -247,7 +252,11 @@ export class GroupClient
             chatId.groupId,
             "events_window",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             GroupEventsWindowArgs,
             GroupEventsResponse,
         );
@@ -274,7 +283,11 @@ export class GroupClient
             chatId.groupId,
             "events",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             GroupEventsArgs,
             GroupEventsResponse,
         );
@@ -670,7 +683,11 @@ export class GroupClient
             chatId.groupId,
             "messages_by_message_index",
             args,
-            (resp) => mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             GroupMessagesByMessageIndexArgs,
             GroupMessagesByMessageIndexResponse,
         );

--- a/frontend/openchat-agent/src/services/user/user.client.ts
+++ b/frontend/openchat-agent/src/services/user/user.client.ts
@@ -204,6 +204,7 @@ import {
     getMessagesSuccess,
     isSuccess,
     mapResult,
+    throwIfReplicaNotUpToDate,
     undeleteMessageSuccess,
     unitResult,
     apiOgPreview,
@@ -398,7 +399,11 @@ export class UserClient
         return this.query(
             "events_by_index",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             UserEventsByIndexArgs,
             UserEventsResponse,
         );
@@ -422,7 +427,11 @@ export class UserClient
         return this.query(
             "events_window",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             UserEventsWindowArgs,
             UserEventsResponse,
         );
@@ -450,7 +459,11 @@ export class UserClient
         return this.query(
             "events",
             args,
-            (resp) => mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getEventsSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             UserEventsArgs,
             UserEventsResponse,
         );
@@ -471,7 +484,11 @@ export class UserClient
         return this.query(
             "messages_by_message_index",
             args,
-            (resp) => mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+            (resp) =>
+                throwIfReplicaNotUpToDate(
+                    mapResult(resp, (value) => getMessagesSuccess(value, chatId, this.chatsDb)),
+                    latestKnownUpdate,
+                ),
             UserMessagesByMessageIndexArgs,
             UserMessagesByMessageIndexResponse,
         );

--- a/frontend/openchat-client/src/utils/stores.spec.ts
+++ b/frontend/openchat-client/src/utils/stores.spec.ts
@@ -288,3 +288,50 @@ describe("writable with notEq equality check", () => {
         expect(publishes).toBe(1);
     });
 });
+
+describe("subscriber failures do not wedge the store machinery", () => {
+    test("a subscriber that throws does not stop later updates reaching other subscribers", () => {
+        const w = writable(0);
+        const seen: number[] = [];
+        w.subscribe((v) => {
+            if (v > 0) throw new Error("boom");
+        });
+        w.subscribe((v) => seen.push(v));
+
+        expect(() => w.set(1)).toThrow("boom");
+        // the throw must not leave the pending queue populated
+        expect(() => w.set(2)).toThrow("boom");
+        expect(seen).toEqual([0, 1, 2]);
+    });
+
+    test("a throw inside withPausedStores still unpauses and publishes", () => {
+        const w = writable(0);
+        const seen: number[] = [];
+        const unsub = w.subscribe((v) => {
+            if (v > 0) throw new Error("boom");
+        });
+        w.subscribe((v) => seen.push(v));
+
+        expect(() => withPausedStores(() => w.set(1))).toThrow("boom");
+        unsub();
+        w.set(2);
+        expect(seen).toEqual([0, 1, 2]);
+    });
+
+    test("a subscriber that unsubscribes while an update is pending is not called", () => {
+        const w = writable(0);
+        const seen: number[] = [];
+        let unsubB: () => void = () => {};
+        w.subscribe((v) => {
+            seen.push(v);
+            // unsubscribe b while b's callback for this same publish is still queued
+            if (v === 1) unsubB();
+        });
+        const calls: number[] = [];
+        unsubB = w.subscribe((v) => calls.push(v));
+
+        w.set(1);
+        expect(seen).toEqual([0, 1]);
+        expect(calls).toEqual([0]);
+    });
+});

--- a/frontend/openchat-client/src/utils/stores.ts
+++ b/frontend/openchat-client/src/utils/stores.ts
@@ -22,9 +22,10 @@ type Stores =
     | SvelteReadable<unknown>
     | [SvelteReadable<unknown>, ...Array<SvelteReadable<unknown>>]
     | Array<SvelteReadable<unknown>>;
-type StoresValues<T> = T extends SvelteReadable<infer U>
-    ? U
-    : { [K in keyof T]: T[K] extends SvelteReadable<infer U> ? U : never };
+type StoresValues<T> =
+    T extends SvelteReadable<infer U>
+        ? U
+        : { [K in keyof T]: T[K] extends SvelteReadable<infer U> ? U : never };
 
 let pauseCount = 0;
 // Callbacks to publish dirty values from writable stores
@@ -40,14 +41,17 @@ export function withPausedStores<T>(fn: () => T) {
         return fn();
     } finally {
         if (pauseCount === 1) {
-            // Publish all changes to writable stores
-            executeCallbacks(publishesPending);
+            try {
+                // Publish all changes to writable stores
+                executeCallbacks(publishesPending);
+            } finally {
+                // Unpause - must happen even if a publish threw, or every later store update
+                // would be queued behind a pause that never ends
+                pauseCount = 0;
 
-            // Unpause
-            pauseCount = 0;
-
-            // Run the derived store subscriptions
-            runSubscriptions();
+                // Run the derived store subscriptions
+                runSubscriptions();
+            }
         } else {
             pauseCount--;
         }
@@ -66,10 +70,24 @@ function runSubscriptions() {
 }
 
 function executeCallbacks(callbacks: (() => void)[]) {
+    // A callback that throws must not leave the queue populated: #publish only runs
+    // subscriptions when subscriptionsPending is empty, so a stranded queue would silently
+    // stop every subsequent store update reaching its subscribers until the page is reloaded.
+    // Run everything, clear the queue, then rethrow the first error so it is still reported.
+    let thrown = false;
+    let error: unknown;
     for (let index = 0; index < callbacks.length; index++) {
-        callbacks[index]();
+        try {
+            callbacks[index]();
+        } catch (err) {
+            if (!thrown) {
+                thrown = true;
+                error = err;
+            }
+        }
     }
     callbacks.length = 0;
+    if (thrown) throw error;
 }
 
 export function writable<T>(
@@ -184,9 +202,14 @@ class _Writable<T> {
                 const shouldRunSubscriptions =
                     pauseCount === 0 && subscriptionsPending.length === 0;
 
-                for (const [subscription, invalidate] of this.#subscriptions.values()) {
+                for (const [id, [subscription, invalidate]] of this.#subscriptions) {
                     invalidate?.();
-                    subscriptionsPending.push(() => subscription(this.#value));
+                    subscriptionsPending.push(() => {
+                        // The subscriber may have unsubscribed (its component unmounted) between
+                        // this being queued and it running - calling it then would hand torn-down
+                        // state to dead code
+                        if (this.#subscriptions.has(id)) subscription(this.#value);
+                    });
                 }
 
                 if (shouldRunSubscriptions) {

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -6,7 +6,12 @@ import {
     INVALID_DELEGATION_ERROR_NAME,
     SESSION_EXPIRY_ERROR_NAME,
 } from "../domain";
-import { requiresLogout, shouldReportMessage, shouldReportWorkerError } from "./error";
+import {
+    requiresLogout,
+    shouldReportError,
+    shouldReportMessage,
+    shouldReportWorkerError,
+} from "./error";
 
 // `toCanisterResponseError` copies the IC error code of the rejection onto the mapped error
 function rejection(rejectErrorCode: string): HttpError {
@@ -73,10 +78,7 @@ describe("shouldReportWorkerError", () => {
     test("silences gateway errors and failed fetches for every kind", () => {
         expect(shouldReportWorkerError("chatEvents", boundary)).toBe(false);
         expect(
-            shouldReportWorkerError(
-                "getUsers",
-                new HttpError(504, new Error("Gateway timeout")),
-            ),
+            shouldReportWorkerError("getUsers", new HttpError(504, new Error("Gateway timeout"))),
         ).toBe(false);
         expect(shouldReportWorkerError("getBots", new TypeError("Failed to fetch"))).toBe(false);
         expect(shouldReportWorkerError("getBots", new TypeError("Load failed"))).toBe(false);
@@ -89,6 +91,54 @@ describe("shouldReportWorkerError", () => {
         expect(
             shouldReportWorkerError("chatEvents", new HttpError(500, new Error("canister trap"))),
         ).toBe(true);
+    });
+});
+
+describe("shouldReportError", () => {
+    test("silences IndexedDB backing-store failures", () => {
+        const noTx = new Error(
+            "Attempt to get a record from database without an in-progress transaction",
+        );
+        noTx.name = "UnknownError";
+        const lost = new Error(
+            "Connection to Indexed Database server lost. Refresh the page to try again",
+        );
+        lost.name = "UnknownError";
+
+        expect(shouldReportError(noTx)).toBe(false);
+        expect(shouldReportError(lost)).toBe(false);
+    });
+
+    test("silences the IC agent giving up after its fetch retries", () => {
+        expect(
+            shouldReportError(
+                new HttpError(500, new Error("Retry strategy exhausted after 1 attempts.")),
+            ),
+        ).toBe(false);
+        // the same words from anything other than the agent's HttpError are still a signal
+        expect(shouldReportError(new Error("Retry strategy exhausted after 1 attempts."))).toBe(
+            true,
+        );
+    });
+
+    test("silences errors thrown from browser-extension code", () => {
+        const v8 = new Error("func sseError not found");
+        v8.stack =
+            "Error: func sseError not found\n" +
+            "    at Object.<anonymous> (chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js:252:19758)\n" +
+            "    at S (chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js:219:37976)";
+        const gecko = new Error("boom");
+        gecko.stack = "inject@moz-extension://abc/inject.js:25:10\nrun@https://oc.app/main.js:1:2";
+        // an extension frame further up the stack does not make it the extension's error
+        const ours = new Error("boom");
+        ours.stack =
+            "Error: boom\n" +
+            "    at fn (https://oc.app/main.js:1:2)\n" +
+            "    at hook (chrome-extension://abc/inject.js:1:2)";
+
+        expect(shouldReportError(v8)).toBe(false);
+        expect(shouldReportError(gecko)).toBe(false);
+        expect(shouldReportError(ours)).toBe(true);
     });
 });
 

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -56,6 +56,8 @@ const NETWORK_NOISE_PATTERN =
 
 const REQWEST_NOISE_PATTERN = /error decoding response body/i;
 
+const RETRY_EXHAUSTED_PATTERN = /retry strategy exhausted after \d+ attempts/i;
+
 function isTransientNetworkError(error: unknown): boolean {
     // Structural checks rather than instanceof: errors which crossed the worker boundary
     // arrive as plain objects where only name/message/code survive
@@ -68,6 +70,9 @@ function isTransientNetworkError(error: unknown): boolean {
     // Exempt from the TypeError rule below because it only ever originates from the Tauri
     // native fetch layer
     if (REQWEST_NOISE_PATTERN.test(message)) return true;
+    // The IC agent gave up after its fetch retries: every attempt failed at the transport
+    // layer (a replica rejection is thrown immediately, without retrying)
+    if (name === "HttpError" && RETRY_EXHAUSTED_PATTERN.test(message)) return true;
     // Only for the browser's own TypeError: our code also throws Errors whose text happens to
     // start "Failed to fetch ...", and those must stay reportable. A bare string carries no
     // name, so it can never satisfy this and is reported like any other unrecognised failure.
@@ -92,6 +97,9 @@ const ENVIRONMENT_NOISE_PATTERNS: RegExp[] = [
     /failed to delete record from object store/i,
     /unable to store record in object store/i,
     /delete range from database without an in-progress transaction/i,
+    /get a record from database without an in-progress transaction/i,
+    // Safari / Firefox-on-iOS dropping the IndexedDB connection; only a reload recovers it
+    /connection to indexed database server lost/i,
     // The client's clock is wrong, so the replica certificate looks like it is from the future
     /certificate is signed more than 5 minutes in the future/i,
     // Safari's built-in media controls script, no frame of ours involved
@@ -109,6 +117,20 @@ function errorMessage(error: unknown): string {
     if (typeof error === "string") return error;
     if (error == null || typeof error !== "object" || !("message" in error)) return "";
     return typeof error.message === "string" ? error.message : "";
+}
+
+// The throw site is browser-extension code (wallet inpage scripts, injected wasm hitting our
+// CSP, ...): not ours to fix. Rollbar's checkIgnore does the same from the payload frames for
+// uncaught errors that bypass the logger; this covers the ones the window error handler routes
+// through the logger, where only the Error (and its stack string) is available.
+const EXTENSION_FRAME_PATTERN = /^\s*(at .*|.*@)(chrome|moz|safari-web)-extension:\/\//;
+function thrownByExtension(error: unknown): boolean {
+    if (error == null || typeof error !== "object" || !("stack" in error)) return false;
+    if (typeof error.stack !== "string") return false;
+    // V8 puts "Name: message" on the first line and frames below ("    at fn (url)"); JSC and
+    // Gecko start with frames ("fn@url"). Either way the first frame line is the throw site.
+    const frame = error.stack.split("\n").find((line) => /^\s*at |@/.test(line));
+    return frame !== undefined && EXTENSION_FRAME_PATTERN.test(frame);
 }
 
 function isEnvironmentNoise(error: unknown): boolean {
@@ -148,7 +170,8 @@ export function shouldReportError(error: unknown): boolean {
         isExpectedSessionError(error) ||
         isTransientNetworkError(error) ||
         isEnvironmentNoise(error) ||
-        isExpectedAccessError(error)
+        isExpectedAccessError(error) ||
+        thrownByExtension(error)
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the Rollbar noise filters (#9159/#9160): a sweep of the last 24h of Rollbar plus a local repro of the "app freezes after tipping in a thread, back button dead, no errors, reload needed" bug.

### Store wedge (the freeze root cause) — `openchat-client/src/utils/stores.ts`

- `executeCallbacks` ran the queue with no error handling. If a subscriber threw, `callbacks.length = 0` was never reached, so `subscriptionsPending` stayed populated. `_Writable.#publish` only runs subscriptions when that queue is empty, so every subsequent store update was queued forever: silent app-wide freeze with no further errors, only a reload recovers. Now runs everything, clears the queue, rethrows the first error.
- `withPausedStores` now unpauses and runs subscriptions in a `finally`, so a throwing publish can't leave `pauseCount` stuck.
- Queued subscriber closures skip subscribers that unsubscribed in the meantime. This was the throw that started it: `CurrentChat`/`CurrentChatMenu` unmount inside `withPausedStores` (e.g. `markAllReadForCurrentScope`) and their already-queued `messagesRead` callbacks ran against torn-down props (Rollbar #31740, #31731; the `reading 'id'` entries in the crash log).
- Three new tests in `stores.spec.ts`.

### ReplicaNotUpToDate (288) never retried

The canister returns `Err(ReplicaNotUpToDate)` when the replica a query lands on is behind `latest_known_update`. That came back through `mapResult` as a plain `{kind:"error", code:288}`: nothing retried it (the `CanisterAgent` retry loop only fires for a thrown `ReplicaNotUpToDateError`) and `mergeEventStreamResponses` then threw on it (Rollbar #31480/#31481/#31503/#31490 `chatEvents`, #31739/#31622 `chatEventsWindow`, ~50 IPs/week). New `throwIfReplicaNotUpToDate` wraps the events / window / by-index / messages-by-index mappers in the user, group and community clients so it goes through the existing backoff retry like the client-side replica check does. Other error codes still throw in the merge, deliberately, so they stay visible.

### Guards for reads between a store write and the flush

- `CurrentChatMessages` (both trees): `chat?.kind`, `showAvatar`/`items` guard (#31460, #31742).
- `ThreadHeader.close()` (both trees): `chatSummary` can be undefined when close is tapped during the panel outro (#31732).
- `CurrentChat` `messagesRead` subscription (both trees) and `CurrentChatMenu.setUnreadPinned`.

### Kill the raw `store.subscribe` anti-pattern in components (second commit)

Why the props were undefined at all: in Svelte 5 a prop is a live getter into the parent's state, and the parent's `{#if $store !== undefined}` narrowing is compile-time only. A store subscription made from a component runs synchronously inside the store's publish - the same fan-out that has just flipped the parent's `$store` signal - so its callback can read a prop as `undefined` while the component is still mounted; the `{#if}` teardown is an effect and hasn't run yet.

Every raw store subscription in a `.svelte` file (22 files: the 12 `messagesRead.subscribe` sites, `now` in `ChatMessage`, `cryptoBalanceStore`, `selectedCommunityUserGroupsStore`, `exploreCommunitiesFiltersStore` / `showUnpublishedBots`, `currentUserProfileStore`, `pendingShareStore`, i18n `_` in both `App.svelte`s) is now `$effect(() => { void $store; ... })`, which runs in Svelte's flush after the parent branch has torn the child down. Bodies that read and write the same state are wrapped in `untrack` so the effect still depends only on the store, like the subscription did. The `chat !== undefined` guards the first commit added to those callbacks are dropped again. `getPublicProfile().subscribe({...})` is a `Stream`, not a store, and is untouched.

### Rollbar noise still leaking through `shouldReportError`

- IndexedDB backing-store failures: `get a record from database without an in-progress transaction`, `connection to indexed database server lost`.
- `HttpError` `Retry strategy exhausted after N attempts` (the IC agent giving up after transport retries; replica rejections do not go through that path).
- Errors thrown from browser-extension code reported via the logger path: the existing `thrownByExtension` in `checkIgnore` only ran for uncaught errors, but `App.svelte` routes window errors through `logger.error("Unhandled error:")`, so wallet inpage / injected-wasm errors still reached Rollbar (#31117, #31153). Now also checked from the error's stack string.
- Tests added for each.

## Not in this PR

- #31741 `VirtualChatList` `viewport` null mid scroll handler (guard at the top of the handler already exists).
- #31465 `each_key_duplicate` (no project frames).
- `DataCloneError` from `@icp-sdk/auth` IdbStorage on Firefox (filtering it could hide our own worker `postMessage` bugs).

## Test plan

- [x] `vitest` `stores.spec.ts` + `error.spec.ts` (31 passing)
- [x] `svelte-check` 0 errors, eslint + prettier clean on changed files (both commits)
- [ ] Mobile web: open a thread, tip several messages in a row, back button still works
- [ ] Watch Rollbar for the `chatEvents` 288 items and the extension / IDB items dropping off after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
