### PR TITLE
Fix GIF picker crash on scrolling past the last page of results

### DIFF
--- a/frontend/app/src/components/home/GiphySelector.svelte
+++ b/frontend/app/src/components/home/GiphySelector.svelte
@@ -39,6 +39,7 @@
     const gutter = 5;
     let imgWidth = $state(0);
     let pos = "";
+    let exhausted = false;
 
     const TRENDING_API_URL = `https://api.klipy.com/v2/featured?contentfilter=off&media_filter=tinygif,mediumgif,mp4&key=${
         import.meta.env.OC_KLIPY_APIKEY
@@ -124,6 +125,7 @@
             .then((res) => res.json())
             .then((res: KlipySearchResponse) => {
                 pos = `${res.next}`;
+                exhausted = pos === "";
                 return res.results;
             })
             .then((res) => res.map((result, i) => addKey(i, pos, result)))
@@ -136,6 +138,7 @@
         selectedGif = undefined;
         gifs = [];
         pos = "";
+        exhausted = false;
         nextPage();
     }
 
@@ -173,9 +176,10 @@
     }
 
     async function nextPage() {
-        if (refreshing) return;
+        if (refreshing || exhausted) return;
         const nextPage = await getMoreGifs();
-        gifs = [...gifs, ...nextPage];
+        const seen = new Set(gifs.map((g) => g.id));
+        gifs = [...gifs, ...nextPage.filter((g) => !seen.has(g.id))];
     }
 
     function onScroll() {

--- a/frontend/app/src/components_mobile/home/GiphySelector.svelte
+++ b/frontend/app/src/components_mobile/home/GiphySelector.svelte
@@ -25,6 +25,7 @@
     const gutter = 5;
     let imgWidth = $state(0);
     let pos = "";
+    let exhausted = false;
 
     const TRENDING_API_URL = `https://api.klipy.com/v2/featured?contentfilter=off&media_filter=tinygif,mediumgif,mp4&key=${
         import.meta.env.OC_KLIPY_APIKEY
@@ -93,6 +94,7 @@
             .then((res: KlipySearchResponse) => {
                 if (!res) return [];
                 pos = `${res.next}`;
+                exhausted = pos === "";
                 return res.results;
             })
             .then((res) => {
@@ -106,6 +108,7 @@
         searchTerm = search;
         gifs = [];
         pos = "";
+        exhausted = false;
         nextPage();
     }
 
@@ -132,9 +135,10 @@
     }
 
     async function nextPage() {
-        if (refreshing) return;
+        if (refreshing || exhausted) return;
         const nextPage = await getMoreGifs();
-        gifs = [...gifs, ...nextPage];
+        const seen = new Set(gifs.map((g) => g.id));
+        gifs = [...gifs, ...nextPage.filter((g) => !seen.has(g.id))];
     }
 
     $effect(() => {

--- a/frontend/app/src/components_mobile/home/user_profile/About.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/About.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
     import { i18nKey } from "@src/i18n/i18n";
-    import { Body, BodySmall, ColourVars, Container, Logo, Overview } from "component-lib";
+    import {
+        Body,
+        BodySmall,
+        ColourVars,
+        CommonButton,
+        Container,
+        Logo,
+        Overview,
+        Row,
+        Sheet,
+        Subtitle,
+    } from "component-lib";
     import { publish, type OpenChat } from "@client";
+    import { toastStore } from "@src/stores/toast";
+    import { clearCrashLog, formatCrashLog } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
     import { getContext } from "svelte";
     import ChevronRight from "svelte-material-icons/ChevronRight.svelte";
@@ -14,6 +27,32 @@
 
     //@ts-ignore
     let version = window.OC_WEBSITE_VERSION;
+
+    let crashLogTaps = 0;
+    let crashLogTapTimer: number | undefined = undefined;
+    let showCrashLog = $state(false);
+    let crashLogText = $state("");
+
+    function versionTapped() {
+        window.clearTimeout(crashLogTapTimer);
+        crashLogTapTimer = window.setTimeout(() => (crashLogTaps = 0), 2000);
+        if (++crashLogTaps >= 5) {
+            crashLogTaps = 0;
+            crashLogText = formatCrashLog();
+            showCrashLog = true;
+        }
+    }
+
+    function copyCrashLog() {
+        navigator.clipboard.writeText(crashLogText).then(() => {
+            toastStore.showSuccessToast(i18nKey("copiedToClipboard"));
+        });
+    }
+
+    function onClearCrashLog() {
+        clearCrashLog();
+        crashLogText = formatCrashLog();
+    }
 
     function goTo(url: string, local: boolean = true) {
         if (client.isNativeApp()) {
@@ -44,9 +83,13 @@
     >
         <Logo size={"huge"} />
         <Overview align={"center"} colour={"primary"}>OpenChat</Overview>
-        <BodySmall fontWeight={"bold"} align={"center"} colour={"textSecondary"}
-            >Android / {version}</BodySmall
-        >
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div onclick={versionTapped}>
+            <BodySmall fontWeight={"bold"} align={"center"} colour={"textSecondary"}
+                >Android / {version}</BodySmall
+            >
+        </div>
         <div class="line"></div>
         <Container direction={"vertical"} gap={"xl"}>
             {@render menuitem("Architecture", {
@@ -69,7 +112,33 @@
     </Container>
 </SlidingPageContent>
 
+{#if showCrashLog}
+    <Sheet onDismiss={() => (showCrashLog = false)}>
+        <Container direction={"vertical"} gap={"lg"} padding={"lg"}>
+            <Subtitle fontWeight={"bold"}>Crash log</Subtitle>
+            <pre class="crash-log">{crashLogText}</pre>
+            <Row gap={"md"} mainAxisAlignment={"end"} crossAxisAlignment={"center"}>
+                <CommonButton size={"small_text"} onClick={onClearCrashLog}>Clear</CommonButton>
+                <CommonButton mode={"active"} size={"medium"} onClick={copyCrashLog}
+                    >Copy</CommonButton>
+            </Row>
+        </Container>
+    </Sheet>
+{/if}
+
 <style lang="scss">
+    .crash-log {
+        max-height: 50vh;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        font-size: 0.7rem;
+        line-height: 1.3;
+        user-select: text;
+        -webkit-user-select: text;
+        color: var(--text-secondary);
+    }
+
     .line {
         margin: var(--sp-xl) 0;
         height: 6px;

--- a/frontend/app/src/utils/errorPostmortem.ts
+++ b/frontend/app/src/utils/errorPostmortem.ts
@@ -12,13 +12,46 @@ export type CrashLogEntry = {
     stack?: string;
 };
 
+const MAX_MESSAGE = 2000;
+
+// Non-Error values (plain objects, OC error responses, DOMExceptions on old
+// browsers) used to be logged via String(), which yields "[object Object]".
+export function describeError(err: unknown): string {
+    if (err instanceof Error) return `${err.name}: ${err.message}`;
+    if (typeof err === "string") return err;
+    if (err === null || typeof err !== "object") return String(err);
+    const { name, message } = err as { name?: unknown; message?: unknown };
+    if (typeof message === "string") {
+        return typeof name === "string" && name !== "" ? `${name}: ${message}` : message;
+    }
+    try {
+        const seen = new WeakSet<object>();
+        return JSON.stringify(err, (_k, v) => {
+            if (typeof v === "bigint") return v.toString();
+            if (typeof v === "function") return `[function ${v.name}]`;
+            if (v !== null && typeof v === "object") {
+                if (seen.has(v)) return "[circular]";
+                seen.add(v);
+            }
+            return v;
+        }).slice(0, MAX_MESSAGE);
+    } catch {
+        return Object.prototype.toString.call(err);
+    }
+}
+
+function stackOf(err: unknown): string | undefined {
+    const stack = (err as { stack?: unknown } | null)?.stack;
+    return typeof stack === "string" ? stack.slice(0, 2000) : undefined;
+}
+
 export function recordError(source: string, err: unknown): void {
     try {
         const entry: CrashLogEntry = {
             ts: new Date().toISOString(),
             source,
-            message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
-            stack: err instanceof Error ? err.stack?.slice(0, 2000) : undefined,
+            message: describeError(err),
+            stack: stackOf(err),
         };
         const log = readCrashLog();
         log.push(entry);


### PR DESCRIPTION
## Summary
- A user's client log showed `each_key_duplicate` caught by the `App.svelte` boundary while choosing a GIF (whole app dies).
- Klipy returns the last page with `next: ""`. We stored that as `pos`, so the next scroll/`onInsideEnd` fetched `pos=` = page 1 again, and its items reuse the `${index}_${next}` keys of the first batch. Verified against the live API: `dfinity` → `Mg==` → `Mw==` → `""` → `Mg==` (loops); a 1-result search (`openchat`) returns `next: ""` immediately, so any refetch duplicates.
- Fix in both desktop and mobile `GiphySelector`: stop paginating once `next` is empty (reset on new search) and dedupe appended results by gif id.
- Also: the same log had several `[object Object]` / `null` entries. `recordError` used `String(err)` for non-Error rejections, hiding whatever was actually thrown. Now describes Error-like objects as `name: message` and JSON-serialises the rest (bigint/function/circular safe, capped).

- v2 (Android) layout had no way to reach the crash log. Five taps on the version line on the About page now open a sheet with the log + Copy/Clear (same gesture as the v1 profile).

## Test plan
- [x] Search for a term with few results (e.g. `openchat`), scroll/drag in the grid → no crash
- [x] Search for a term with a few pages (e.g. `dfinity`), scroll to end repeatedly → no crash, no duplicate thumbnails
- [x] Trending: scroll through 4+ pages → no crash
- [x] Mobile picker: same checks
- [x] `Promise.reject({kind:"error",code:288})` in console → crash log shows the JSON, not `[object Object]`
- [x] Android: About → tap version 5× → sheet shows log, Copy toasts, Clear empties
- `svelte-check`: 0 errors; `describeError` exercised with Error / string / null / bigint / plain object / circular / DOMException

🤖 Generated with [Claude Code](https://claude.com/claude-code)