### PR TITLE
Fix anchored sheet 0px on hidden mount; cancel community preview via navigate()

### DIFF
--- a/frontend/app/src/components/Router.svelte
+++ b/frontend/app/src/components/Router.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
     import { initNavigationHistoryTracking, navigate } from "@src/utils/navigation";
     import { handleLinkClick, removeQueryStringParam } from "@src/utils/urls";
-    import { type ChatIdentifier, OpenChat, type RouteParams, adminRoute, blogRoute, chatIdentifiersEqual, chatListRoute, chatListScopeStore, chatsInitialisedStore, communitesRoute, exploringStore, globalDirectChatSelectedRoute, globalGroupChatSelectedRoute, messageIndexStore, notFoundStore, routeKindStore, routeStore, routerReadyStore, selectedChannelRoute, selectedChatIdStore, selectedCommunityIdStore, selectedCommunityRoute, selectedServerChatStore, shareRoute, threadMessageIndexStore, threadOpenStore } from "@client";
+    import { type ChatIdentifier, type CommunityIdentifier, OpenChat, type RouteParams, adminRoute, blogRoute, chatIdentifiersEqual, chatListRoute, chatListScopeStore, chatsInitialisedStore, communitesRoute, communityIdentifiersEqual, exploringStore, globalDirectChatSelectedRoute, globalGroupChatSelectedRoute, messageIndexStore, notFoundStore, routeKindStore, routeStore, routerReadyStore, selectedChannelRoute, selectedChatIdStore, selectedCommunityIdStore, selectedCommunityRoute, selectedServerChatStore, shareRoute, threadMessageIndexStore, threadOpenStore } from "@client";
     import page from "page";
     import { getContext, onMount, untrack } from "svelte";
     import Home, { type HomeType } from "./home/HomeRoute.svelte";
@@ -227,6 +227,21 @@
 
     // This is where our general effects are going to go. They don't *really* belong in a component at all
     // but unfortunately unowned effects do not respond to store value changes
+
+    // Drop a previewed community once we navigate away from it
+    let previousCommunityId: CommunityIdentifier | undefined = undefined;
+    $effect(() => {
+        const id = $selectedCommunityIdStore;
+        untrack(() => {
+            if (
+                previousCommunityId !== undefined &&
+                !communityIdentifiersEqual(previousCommunityId, id)
+            ) {
+                client.removeCommunityIfPreviewing(previousCommunityId);
+            }
+            previousCommunityId = id;
+        });
+    });
 
     // Set selected community
     $effect(() => {

--- a/frontend/app/src/components_mobile/Router.svelte
+++ b/frontend/app/src/components_mobile/Router.svelte
@@ -7,7 +7,7 @@
     } from "@utils/native/notification_channels";
     import { handleLinkClick, removeQueryStringParam } from "@src/utils/urls";
     import type { TransitionType } from "component-lib";
-    import { type ChatIdentifier, OpenChat, type RouteParams, adminRoute, chatIdentifiersEqual, chatListRoute, chatListScopeStore, chatsInitialisedStore, communitesRoute, communitiesStore, communityIdentifiersEqual, exploringStore, globalDirectChatSelectedRoute, globalGroupChatSelectedRoute, isMessageIndexRoute, messageIndexStore, notFoundStore, notificationsRoute, profileSummaryRoute, publish, routeKindStore, routeStore, routerReadyStore, selectedChannelRoute, selectedChatIdStore, selectedCommunityIdStore, selectedCommunityRoute, selectedServerChatStore, shareRoute, threadMessageIndexStore, threadOpenStore, walletRoute, welcomeRoute } from "@client";
+    import { type ChatIdentifier, type CommunityIdentifier, OpenChat, type RouteParams, adminRoute, chatIdentifiersEqual, chatListRoute, chatListScopeStore, chatsInitialisedStore, communitesRoute, communitiesStore, communityIdentifiersEqual, exploringStore, globalDirectChatSelectedRoute, globalGroupChatSelectedRoute, isMessageIndexRoute, messageIndexStore, notFoundStore, notificationsRoute, profileSummaryRoute, publish, routeKindStore, routeStore, routerReadyStore, selectedChannelRoute, selectedChatIdStore, selectedCommunityIdStore, selectedCommunityRoute, selectedServerChatStore, shareRoute, threadMessageIndexStore, threadOpenStore, walletRoute, welcomeRoute } from "@client";
     import page from "page";
     import { type Component, getContext, onMount, tick, untrack } from "svelte";
     import Home from "./home/HomeRoute.svelte";
@@ -254,6 +254,21 @@
 
     // This is where our general effects are going to go. They don't *really* belong in a component at all
     // but unfortunately unowned effects do not respond to store value changes
+
+    // Drop a previewed community once we navigate away from it
+    let previousCommunityId: CommunityIdentifier | undefined = undefined;
+    $effect(() => {
+        const id = $selectedCommunityIdStore;
+        untrack(() => {
+            if (
+                previousCommunityId !== undefined &&
+                !communityIdentifiersEqual(previousCommunityId, id)
+            ) {
+                client.removeCommunityIfPreviewing(previousCommunityId);
+            }
+            previousCommunityId = id;
+        });
+    });
 
     // Set selected community
     $effect(() => {

--- a/frontend/app/src/components_mobile/home/WelcomePage.svelte
+++ b/frontend/app/src/components_mobile/home/WelcomePage.svelte
@@ -20,6 +20,7 @@
         type CommunitySummary,
         type OpenChat,
     } from "@client";
+    import { communityPreviewState } from "@src/utils/preview.svelte";
     import { navigate } from "@utils/navigation";
     import { getContext, onMount } from "svelte";
     import { _ } from "svelte-i18n";
@@ -60,6 +61,7 @@
         });
     }
     function goToCommunity(id: CommunityIdentifier) {
+        communityPreviewState.setOrigin(id.communityId, "/welcome");
         navigate(`/community/${id.communityId}`);
     }
 </script>

--- a/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { disableRestrictedContent } from "@src/utils/features";
+    import { communityPreviewState } from "@src/utils/preview.svelte";
     import {
         Body,
         Button,
@@ -210,6 +211,7 @@
     let loading = $derived(searching && searchState.results.length === 0);
 
     function goToCommunity(community: CommunityMatch) {
+        communityPreviewState.setOrigin(community.id.communityId, "/communities");
         navigate(`/community/${community.id.communityId}`);
     }
 

--- a/frontend/app/src/utils/navigation.spec.ts
+++ b/frontend/app/src/utils/navigation.spec.ts
@@ -84,6 +84,9 @@ const channelWithOpenThread: RouteParams = {
 
 const notFound: RouteParams = { kind: "not_found_route", scope: { kind: "none" } };
 
+const explore: RouteParams = { kind: "communities_route", scope: { kind: "none" } };
+const welcome: RouteParams = { kind: "welcome_route", scope: { kind: "none" } };
+
 // ---------------------------------------------------------------------------
 // Real destination paths used in assertions
 // ---------------------------------------------------------------------------
@@ -91,6 +94,8 @@ const notFound: RouteParams = { kind: "not_found_route", scope: { kind: "none" }
 const P = {
     chats: "/chats",
     chatsRoot: "/",
+    explore: "/communities",
+    welcome: "/welcome",
     notifications: "/notifications",
     profile: "/profile_summary",
     group: "/group/group_1",
@@ -184,6 +189,20 @@ describe("navigationMode", () => {
         it("should be a pop", () => {
             expect(navigationMode(P.chats, community)).toBe("pop");
             expect(navigationMode(P.chatsRoot, community)).toBe("pop");
+        });
+    });
+
+    describe("explore/welcome -> community", () => {
+        it("should be a push", () => {
+            expect(navigationMode(P.community, explore)).toBe("push");
+            expect(navigationMode(P.community, welcome)).toBe("push");
+        });
+    });
+
+    describe("community -> explore/welcome", () => {
+        it("should be a pop", () => {
+            expect(navigationMode(P.explore, community)).toBe("pop");
+            expect(navigationMode(P.welcome, community)).toBe("pop");
         });
     });
 

--- a/frontend/app/src/utils/navigation.ts
+++ b/frontend/app/src/utils/navigation.ts
@@ -195,6 +195,8 @@ export function parentRoute(from: RouteParams): string | null {
  *   non-root tab → chat                    → push
  *   community → channel (same community)   → push
  *   community → chats                      → pop
+ *   explore/welcome → community            → push    (drill in from explorer / welcome)
+ *   community → explore/welcome            → pop     (back out to explorer / welcome)
  *   channel   → community                  → push
  *   chat (no thread) → same chat + thread  → push     (open thread)
  *   chat + thread → same chat (no thread)  → pop      (close thread)
@@ -220,8 +222,12 @@ export function navigationMode(
     const toIsNonRootTab = TAB_ROUTES.includes(toKind) && !toIsRootTab;
     const toIsChat = ["global_chat_selected_route", "selected_channel_route"].includes(toKind);
     const toIsCommunity = toKind === "selected_community_route";
+    const fromIsExplore = from.kind === "communities_route" || from.kind === "welcome_route";
+    const toIsExplore = toKind === "communities_route" || toKind === "welcome_route";
 
     if (fromIsRootTab && !toIsRootTab) return "push";
+    if (fromIsExplore && toIsCommunity) return "push";
+    if (fromIsCommunity && toIsExplore) return "pop";
     if (fromIsNonRootTab && toIsRootTab) return "pop";
     if (fromIsNonRootTab && toIsNonRootTab) return "replace";
     if (fromIsNonRootTab && toIsChat) return "push";

--- a/frontend/app/src/utils/preview.svelte.ts
+++ b/frontend/app/src/utils/preview.svelte.ts
@@ -200,6 +200,9 @@ class CommunityPreview {
     #gateCheckFailed = $state<EnhancedAccessGate>();
     #gatesToEvaluate = $state<EnhancedAccessGate>();
     #community = $state<CommunitySummary>();
+    // Where cancelling the preview should return to, if the preview was entered
+    // from somewhere other than the default scope (e.g. the community explorer)
+    #origin: { communityId: string; path: string } | undefined = undefined;
     #gatesInEffect = $derived(
         this.#community !== undefined &&
             // Suspended (unique person) gates are stripped, so a lone unique person gate is no gate.
@@ -246,6 +249,10 @@ class CommunityPreview {
     reset() {
         this.#gatesToEvaluate = undefined;
         this.#gateCheckFailed = undefined;
+    }
+
+    setOrigin(communityId: string, path: string) {
+        this.#origin = { communityId, path };
     }
 
     doJoinCommunity(client: OpenChat, gateCheck?: GateCheckSucceeded): Promise<void> {
@@ -299,8 +306,15 @@ class CommunityPreview {
 
     cancelPreview(client: OpenChat) {
         if (this.#previewing && this.#community) {
+            const communityId = this.#community.id.communityId;
+            const origin = this.#origin;
+            this.#origin = undefined;
             client.removeCommunity(this.#community.id);
-            navigate(routeForScope(client.getDefaultScope()));
+            navigate(
+                origin?.communityId === communityId
+                    ? origin.path
+                    : routeForScope(client.getDefaultScope()),
+            );
         }
     }
 }

--- a/frontend/app/src/utils/preview.svelte.ts
+++ b/frontend/app/src/utils/preview.svelte.ts
@@ -300,7 +300,7 @@ class CommunityPreview {
     cancelPreview(client: OpenChat) {
         if (this.#previewing && this.#community) {
             client.removeCommunity(this.#community.id);
-            history.back();
+            navigate(routeForScope(client.getDefaultScope()));
         }
     }
 }

--- a/frontend/component-lib/src/components/sheet/SheetBehavior.svelte.ts
+++ b/frontend/component-lib/src/components/sheet/SheetBehavior.svelte.ts
@@ -63,6 +63,7 @@ export class SheetBehavior {
     }
 
     init(instantShow = false): () => void {
+        let resizeObserver: ResizeObserver | undefined;
         this._calcSheetHeight();
         this._switch({
             transient: () => {
@@ -74,12 +75,24 @@ export class SheetBehavior {
                 // By default anchored sheet is collapsed
                 // TODO make the default height configurable
                 // TODO plugin instantShow
-                this._collapsedHeight = this.sheet?.offsetHeight ?? 100;
+                const height = this.sheet?.offsetHeight ?? 100;
 
-                // Setting the initial height, important for css height
-                // animation to run correctly when sheet is expanded initially
-                // with the expand function and not dragged.
-                this._setSheetHeight(this._collapsedHeight);
+                if (height > 0) {
+                    this._setCollapsedHeight(height);
+                } else if (this.sheet && typeof ResizeObserver !== "undefined") {
+                    // The sheet mounted inside a hidden (display: none) subtree so it
+                    // has no layout yet. Pinning 0px here would leave the sheet
+                    // permanently invisible, so wait for the first non-zero size.
+                    resizeObserver = new ResizeObserver(() => {
+                        const measured = this.sheet?.offsetHeight ?? 0;
+                        if (measured > 0) {
+                            resizeObserver?.disconnect();
+                            resizeObserver = undefined;
+                            this._setCollapsedHeight(measured);
+                        }
+                    });
+                    resizeObserver.observe(this.sheet);
+                }
             },
         });
 
@@ -90,10 +103,20 @@ export class SheetBehavior {
 
         // Return unmount fn
         return () => {
+            resizeObserver?.disconnect();
             if (window.visualViewport) {
                 window.visualViewport.removeEventListener("resize", this._handleViewportChange);
             }
         };
+    }
+
+    // Remember the natural (collapsed) height of an anchored sheet and pin it.
+    // Setting the initial height is important for the css height animation to
+    // run correctly when the sheet is expanded initially with the expand
+    // function and not dragged.
+    private _setCollapsedHeight(height: number) {
+        this._collapsedHeight = height;
+        this._setSheetHeight(height);
     }
 
     collapse(instant?: boolean): Promise<void> {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3283,6 +3283,16 @@ export class OpenChat {
         localUpdates.removeCommunity(id);
     }
 
+    // Called when the selected community changes. If we were only previewing the
+    // community we just left, drop the preview (and any of its channels we were
+    // previewing) so that leaving by any route behaves the same as cancelling.
+    removeCommunityIfPreviewing(id: CommunityIdentifier): void {
+        const preview = localUpdates.getPreviewingCommunity(id);
+        if (preview === undefined) return;
+        preview.channels.forEach((c) => localUpdates.removeGroupPreview(c.id));
+        localUpdates.removeCommunityPreview(id);
+    }
+
     diffGroupPermissions = diffGroupPermissions;
 
     messageContentFromFile(file: File | LazyFile, context: MessageContext): Promise<AttachmentContent> {


### PR DESCRIPTION
Four mobile fixes (the last also applies to desktop).

## 1. Anchored sheet collapses to 0px when mounted while hidden

### Problem

On the Tauri Android app, the communities scroller sometimes doesn't render when the bottom bar has communities selected. Toggling to chats and back fixes it.

### Cause

`SheetBehavior.init()` (anchored mode) measures `sheet.offsetHeight` once at mount and pins it as inline `height`. `CommunitiesSheet` mounts whenever `chatListScope` becomes `community`, with no `showLeft` guard — so if a community channel is opened from another scope (notification, link, activity feed), the sheet mounts while the left panel is `display: none`. `offsetHeight` is `0`, so the sheet gets `height: 0px` + `overflow: hidden`. Nothing re-measures, and `collapse()` no-ops for anchored sheets with `_collapsedHeight === 0`, so it stays invisible until remounted.

### Fix

If the initial measurement is `0`, don't pin. Attach a `ResizeObserver` to the sheet and pin the first non-zero height, then disconnect. Observer is also disconnected on unmount. Transient sheets unchanged.

## 2. `CommunityPreview.cancelPreview` used `history.back()`

`preview.svelte.ts` called `history.back()` directly, bypassing `navigate()`:

- Deep link / notification / cold start: nothing behind → no-op on Android WebView → user stranded on `/community/x` after the community was removed from the store (blank list, dead tap).
- Ignores live dummy history states (zoom/emoji/tray) — just pops those and stays put.
- Desyncs the router's `backStack`.

Now goes through `navigate()`, matching the desktop `cancelPreview` implementations and `GroupPreview.cancelPreview`.

## 3. Cancelling a preview entered from Explore / Welcome returns there

`explore/welcome → community` was a `replace` in `navigationMode`, so the explorer entry was overwritten and nothing (including the old `history.back()`) could return to it.

- `navigationMode`: `communities_route|welcome_route → selected_community_route` = push; reverse = pop. Tests added.
- `CommunityPreview` records origin (`Explore.goToCommunity`, `WelcomePage.goToCommunity` set it). `cancelPreview` navigates to origin when it matches the current community, else `routeForScope(client.getDefaultScope())`.

Side effect: after *joining* from explorer, hardware back now returns to explorer rather than whatever preceded it.

## 4. Previewed community lingers after leaving by any route other than the cancel button

The preview was only removed from `localUpdates.previewCommunities` by the in-app cancel button or by joining. Browser/hardware back, tab switches, etc. left a ghost community in the list and scroller.

New `OpenChat.removeCommunityIfPreviewing(id)` (drops the community preview and its channels' group previews). Both routers call it whenever `selectedCommunityIdStore` changes to a different id or `undefined`, so every exit path behaves like cancel.

## Testing

- `svelte-check` on component-lib and app: 0 errors; `navigation.spec.ts` 35/35.
- Tested on Android: scroller visible after opening channel from another scope; deep-link preview → Back lands on chats; explore → preview → Back returns to explorer; preview → hardware back / tab switch removes the preview; join still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
