### PR TITLE
Give UserId an embedded index so a canister can hold many users

### DIFF
--- a/backend/canisters/airdrop_bot/CHANGELOG.md
+++ b/backend/canisters/airdrop_bot/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `og_previews` field to messages for handling OpenGraph previews ([#9002](https://github.com/open-chat-labs/open-chat/pull/9002))
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ### Fixed
 
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/airdrop_bot/impl/src/actions.rs
+++ b/backend/canisters/airdrop_bot/impl/src/actions.rs
@@ -9,8 +9,8 @@ use timer_job_queues::TimerJobItem;
 use tracing::{error, info, trace};
 use types::icrc1::{self, Account};
 use types::{
-    BotMessage, CanisterId, ChannelId, CommunityId, CompletedCryptoTransaction, CryptoContent, CryptoTransaction,
-    MessageContentInitial, Milliseconds, UserId,
+    BotMessage, ChannelId, CommunityId, CompletedCryptoTransaction, CryptoContent, CryptoTransaction, MessageContentInitial,
+    Milliseconds, UserId,
 };
 use utils::canister::delay_if_should_retry_failed_c2c_call;
 use utils::time::{MONTHS, MonthKey};
@@ -132,7 +132,7 @@ async fn handle_transfer_action(action: AirdropTransfer) -> Result<(), Option<Mi
         )
     });
 
-    let to = Account::from(action.recipient);
+    let to = Account::for_user(action.recipient);
     let memo = match action.airdrop_type {
         AirdropType::Main(_) => MEMO_CHIT_FOR_CHAT_AIRDROP,
         AirdropType::Lottery(_) => MEMO_CHIT_FOR_CHAT_LOTTERY,
@@ -228,7 +228,7 @@ async fn handle_main_message_action(action: AirdropMessage) -> Result<(), Option
         }],
     };
 
-    match user_canister_c2c_client::c2c_handle_bot_messages(CanisterId::from(action.recipient), &args).await {
+    match user_canister_c2c_client::c2c_handle_bot_messages(action.recipient.canister_id(), &args).await {
         Ok(user_canister::c2c_handle_bot_messages::Response::Success) => Ok(()),
         Ok(resp) => {
             error!(?args, ?resp, "Failed to send DM");

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 
 ### Changed

--- a/backend/canisters/community/impl/src/jobs/make_pending_payments.rs
+++ b/backend/canisters/community/impl/src/jobs/make_pending_payments.rs
@@ -4,7 +4,6 @@ use constants::{
 };
 use group_community_common::{PaymentRecipient, PendingPayment, PendingPaymentReason};
 use ic_cdk_timers::TimerId;
-use ic_principal::Principal;
 use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg};
 use ledger_utils::icrc1::make_transfer;
 use std::cell::Cell;
@@ -43,7 +42,7 @@ async fn process_payment(pending_payment: PendingPayment, now_nanos: TimestampNa
         // Note in the case of CHAT this will cause the tokens to be burned
         PaymentRecipient::SnsTreasury => SNS_GOVERNANCE_CANISTER_ID.into(),
         PaymentRecipient::TreasuryCanister => OPENCHAT_TREASURY_CANISTER_ID.into(),
-        PaymentRecipient::Member(user_id) => Principal::from(user_id).into(),
+        PaymentRecipient::Member(user_id) => user_id.into(),
         PaymentRecipient::Account(account) => account,
     };
 

--- a/backend/canisters/community/impl/src/lib.rs
+++ b/backend/canisters/community/impl/src/lib.rs
@@ -88,7 +88,7 @@ impl RuntimeState {
     }
 
     pub fn is_caller_proposals_bot(&self) -> bool {
-        self.env.caller() == self.data.proposals_bot_user_id.into()
+        self.env.caller() == self.data.proposals_bot_user_id.canister_id()
     }
 
     pub fn is_caller_escrow_canister(&self) -> bool {
@@ -478,7 +478,7 @@ impl RuntimeState {
                 user_index: self.data.user_index_canister_id,
                 group_index: self.data.group_index_canister_id,
                 local_user_index: self.data.local_user_index_canister_id,
-                proposals_bot: self.data.proposals_bot_user_id.into(),
+                proposals_bot: self.data.proposals_bot_user_id.canister_id(),
                 escrow: self.data.escrow_canister_id,
                 icp_ledger: ICP_LEDGER_CANISTER_ID,
                 internet_identity: self.data.internet_identity_canister_id,

--- a/backend/canisters/community/impl/src/model/members.rs
+++ b/backend/canisters/community/impl/src/model/members.rs
@@ -215,7 +215,7 @@ impl CommunityMembers {
         now: TimestampMillis,
     ) -> OCResult<ChangeRoleSuccess> {
         // Is the caller authorized to change the user to this role
-        let initiator = self.get_verified_member(user_id.into())?;
+        let initiator = self.get_verified_member(user_id.as_principal())?;
 
         if !initiator.role.can_change_roles(new_role, permissions) {
             return Err(OCErrorCode::InitiatorNotAuthorized.into());

--- a/backend/canisters/community/impl/src/model/members/proptests.rs
+++ b/backend/canisters/community/impl/src/model/members/proptests.rs
@@ -94,7 +94,7 @@ fn execute_operation(members: &mut CommunityMembers, op: Operation, timestamp: T
                     Some(get_from_map(&members.members_and_channels, i))
                 }
             });
-            members.add(user_id, user_id.into(), UserType::User, referred_by, timestamp);
+            members.add(user_id, user_id.as_principal(), UserType::User, referred_by, timestamp);
         }
         Operation::ChangeRole {
             owner_index,

--- a/backend/canisters/community/impl/src/model/user_event_batch.rs
+++ b/backend/canisters/community/impl/src/model/user_event_batch.rs
@@ -13,7 +13,7 @@ impl TimerJobItem for UserEventBatch {
         }
 
         let response = user_canister_c2c_client::c2c_community_canister(
-            self.key.into(),
+            self.key.canister_id(),
             &user_canister::c2c_community_canister::Args {
                 events: self.items.clone(),
             },

--- a/backend/canisters/community/impl/src/queries/c2c_can_issue_access_token.rs
+++ b/backend/canisters/community/impl/src/queries/c2c_can_issue_access_token.rs
@@ -16,7 +16,7 @@ fn c2c_can_issue_access_token_impl(args_outer: Args, state: &RuntimeState) -> Re
         // Ensure the initiator has the necessary seniority according to required role
         if !state
             .data
-            .is_same_or_senior(args.initiator.into(), args_outer.channel_id, args.initiator_role)
+            .is_same_or_senior(args.initiator.as_principal(), args_outer.channel_id, args.initiator_role)
         {
             return Response::Failure;
         }

--- a/backend/canisters/community/impl/src/timer_job_types.rs
+++ b/backend/canisters/community/impl/src/timer_job_types.rs
@@ -377,7 +377,7 @@ impl Job for NotifyEscrowCanisterOfDepositJob {
                 escrow_canister_id,
                 &escrow_canister::notify_deposit::Args {
                     swap_id: self.swap_id,
-                    deposited_by: Some(self.user_id.into()),
+                    deposited_by: Some(self.user_id.as_principal()),
                 },
             )
             .await

--- a/backend/canisters/community/impl/src/updates/accept_p2p_swap.rs
+++ b/backend/canisters/community/impl/src/updates/accept_p2p_swap.rs
@@ -26,7 +26,7 @@ async fn accept_p2p_swap_impl(args: Args) -> Response {
         Err(response) => return Error(response),
     };
 
-    let result = match user_canister_c2c_client::c2c_accept_p2p_swap(user_id.into(), &c2c_args).await {
+    let result = match user_canister_c2c_client::c2c_accept_p2p_swap(user_id.canister_id(), &c2c_args).await {
         Ok(user_canister::c2c_accept_p2p_swap::Response::Success(transaction_index)) => {
             NotifyEscrowCanisterOfDepositJob::run(
                 user_id,

--- a/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
@@ -66,7 +66,7 @@ struct PrepareResult {
 fn prepare(args: &Args, state: &mut RuntimeState) -> OCResult<PrepareResult> {
     state.data.verify_not_frozen()?;
 
-    let member = state.get_member(true, *args.user_id)?;
+    let member = state.get_member(true, args.user_id.as_principal())?;
     let channel = state.data.channels.get_mut_or_err(&args.channel_id)?;
     let now = state.env.now();
     let now_nanos = state.env.now_nanos();

--- a/backend/canisters/community/impl/src/updates/c2c_install_bot.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_install_bot.rs
@@ -15,7 +15,7 @@ fn c2c_install_bot(args: Args) -> Response {
 fn c2c_install_bot_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     state.data.verify_not_frozen()?;
 
-    let member = state.data.members.get_verified_member(args.caller.into())?;
+    let member = state.data.members.get_verified_member(args.caller.as_principal())?;
 
     if !member.role().is_owner() {
         return Err(OCErrorCode::InitiatorNotAuthorized.into());

--- a/backend/canisters/community/impl/src/updates/c2c_invite_users.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_invite_users.rs
@@ -41,7 +41,7 @@ pub(crate) fn invite_users_to_community_impl(
     }
 
     let invited_by = if let Some(initiator) = caller.initiator() {
-        let member = state.data.members.get_verified_member(*initiator)?;
+        let member = state.data.members.get_verified_member(initiator.as_principal())?;
         if !member.role().can_invite_users(&state.data.permissions) {
             return Err(OCErrorCode::InitiatorNotAuthorized.into());
         }

--- a/backend/canisters/community/impl/src/updates/c2c_uninstall_bot.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_uninstall_bot.rs
@@ -15,7 +15,7 @@ fn c2c_uninstall_bot(args: Args) -> Response {
 
 fn c2c_uninstall_bot_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     if args.caller != OPENCHAT_BOT_USER_ID {
-        let member = state.data.members.get_verified_member(args.caller.into())?;
+        let member = state.data.members.get_verified_member(args.caller.as_principal())?;
         if !member.role().is_owner() {
             return Err(OCErrorCode::InitiatorNotAuthorized.into());
         }

--- a/backend/canisters/community/impl/src/updates/register_proposal_vote.rs
+++ b/backend/canisters/community/impl/src/updates/register_proposal_vote.rs
@@ -29,7 +29,7 @@ async fn register_proposal_vote_impl(args: Args) -> Response {
         proposal_id,
         adopt: args.adopt,
     };
-    match user_canister_c2c_client::c2c_vote_on_proposal(user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_vote_on_proposal(user_id.canister_id(), &c2c_args).await {
         Ok(response) => match response {
             user_canister::c2c_vote_on_proposal::Response::Success => {
                 if let Err(error) = mutate_state(|state| commit(args.channel_id, user_id, args, state)) {

--- a/backend/canisters/community/impl/src/updates/remove_member.rs
+++ b/backend/canisters/community/impl/src/updates/remove_member.rs
@@ -74,7 +74,7 @@ async fn remove_member_impl(user_id: UserId, block: bool, ext_caller: Option<Cal
     // to check whether they are a "platform moderator" in which case this removal
     // is not authorized
     if prepare_result.is_user_to_remove_an_owner {
-        match lookup_user(user_id.into(), prepare_result.local_user_index_canister_id).await {
+        match lookup_user(user_id.as_principal(), prepare_result.local_user_index_canister_id).await {
             Ok(Some(user)) if !user.is_platform_moderator => (),
             Ok(_) => return Response::Error(OCErrorCode::InitiatorNotAuthorized.into()),
             Err(error) => return Response::Error(error.into()),
@@ -118,7 +118,7 @@ fn prepare(user_id: UserId, block: bool, ext_caller: Option<Caller>, state: &Run
 
         // Check if the caller is authorized to remove the user
         if let Some(initiator) = caller.initiator() {
-            let member = state.data.members.get_verified_member(*initiator)?;
+            let member = state.data.members.get_verified_member(initiator.as_principal())?;
             if !member
                 .role()
                 .can_remove_members_with_role(user_to_remove_role, &state.data.permissions)
@@ -205,7 +205,7 @@ fn remove_membership_from_user_canister(
         public,
     };
     fire_and_forget_handler.send(
-        user_id.into(),
+        user_id.canister_id(),
         "c2c_remove_from_community_msgpack".to_string(),
         serialize_then_unwrap(args),
     );

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 
 ### Added

--- a/backend/canisters/group/impl/src/jobs/make_pending_payments.rs
+++ b/backend/canisters/group/impl/src/jobs/make_pending_payments.rs
@@ -4,7 +4,6 @@ use constants::{
 };
 use group_community_common::{PaymentRecipient, PendingPayment, PendingPaymentReason};
 use ic_cdk_timers::TimerId;
-use ic_principal::Principal;
 use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg};
 use ledger_utils::icrc1::make_transfer;
 use std::cell::Cell;
@@ -43,7 +42,7 @@ async fn process_payment(pending_payment: PendingPayment, now_nanos: TimestampNa
         // Note in the case of CHAT this will cause the tokens to be burned
         PaymentRecipient::SnsTreasury => SNS_GOVERNANCE_CANISTER_ID.into(),
         PaymentRecipient::TreasuryCanister => OPENCHAT_TREASURY_CANISTER_ID.into(),
-        PaymentRecipient::Member(user_id) => Principal::from(user_id).into(),
+        PaymentRecipient::Member(user_id) => user_id.into(),
         PaymentRecipient::Account(account) => account,
     };
 

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -523,7 +523,7 @@ impl RuntimeState {
                 user_index: self.data.user_index_canister_id,
                 group_index: self.data.group_index_canister_id,
                 local_user_index: self.data.local_user_index_canister_id,
-                proposals_bot: self.data.proposals_bot_user_id.into(),
+                proposals_bot: self.data.proposals_bot_user_id.canister_id(),
                 escrow_canister_id: self.data.escrow_canister_id,
                 icp_ledger: ICP_LEDGER_CANISTER_ID,
             },

--- a/backend/canisters/group/impl/src/model/user_event_batch.rs
+++ b/backend/canisters/group/impl/src/model/user_event_batch.rs
@@ -13,7 +13,7 @@ impl TimerJobItem for UserEventBatch {
         }
 
         let response = user_canister_c2c_client::c2c_group_canister(
-            self.key.into(),
+            self.key.canister_id(),
             &user_canister::c2c_group_canister::Args {
                 events: self.items.clone(),
             },

--- a/backend/canisters/group/impl/src/queries/c2c_can_issue_access_token_v2.rs
+++ b/backend/canisters/group/impl/src/queries/c2c_can_issue_access_token_v2.rs
@@ -14,7 +14,7 @@ fn c2c_can_issue_access_token_v2(args: Args) -> Response {
 fn c2c_can_issue_access_token_impl(args_outer: Args, state: &RuntimeState) -> Response {
     if let AccessTypeArgs::BotActionByCommand(args) = &args_outer {
         // Ensure the initiator is a member
-        let Some(member) = state.data.get_member(args.initiator.into()) else {
+        let Some(member) = state.data.get_member(args.initiator.as_principal()) else {
             return Response::Failure;
         };
 

--- a/backend/canisters/group/impl/src/timer_job_types.rs
+++ b/backend/canisters/group/impl/src/timer_job_types.rs
@@ -315,7 +315,7 @@ impl Job for NotifyEscrowCanisterOfDepositJob {
                 escrow_canister_id,
                 &escrow_canister::notify_deposit::Args {
                     swap_id: self.swap_id,
-                    deposited_by: Some(self.user_id.into()),
+                    deposited_by: Some(self.user_id.as_principal()),
                 },
             )
             .await

--- a/backend/canisters/group/impl/src/updates/accept_p2p_swap.rs
+++ b/backend/canisters/group/impl/src/updates/accept_p2p_swap.rs
@@ -24,7 +24,7 @@ async fn accept_p2p_swap_impl(args: Args) -> Response {
     };
 
     let result =
-        match user_canister_c2c_client::c2c_accept_p2p_swap(user_id.into(), &c2c_args).await {
+        match user_canister_c2c_client::c2c_accept_p2p_swap(user_id.canister_id(), &c2c_args).await {
             Ok(user_canister::c2c_accept_p2p_swap::Response::Success(transaction_index)) => {
                 NotifyEscrowCanisterOfDepositJob::run(
                     user_id,

--- a/backend/canisters/group/impl/src/updates/register_proposal_vote.rs
+++ b/backend/canisters/group/impl/src/updates/register_proposal_vote.rs
@@ -30,7 +30,7 @@ async fn register_proposal_vote_impl(args: Args) -> Response {
         proposal_id,
         adopt: args.adopt,
     };
-    match user_canister_c2c_client::c2c_vote_on_proposal(user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_vote_on_proposal(user_id.canister_id(), &c2c_args).await {
         Ok(response) => match response {
             user_canister::c2c_vote_on_proposal::Response::Success => mutate_state(|state| commit(user_id, args, state)).into(),
             user_canister::c2c_vote_on_proposal::Response::Error(error) => Response::Error(error),

--- a/backend/canisters/group/impl/src/updates/remove_participant.rs
+++ b/backend/canisters/group/impl/src/updates/remove_participant.rs
@@ -56,7 +56,7 @@ async fn remove_participant_impl(user_to_remove: UserId, block: bool, ext_caller
     // to check whether they are a "platform moderator" in which case this removal
     // is not authorized
     if prepare_result.is_user_to_remove_an_owner {
-        match lookup_user(user_to_remove.into(), prepare_result.local_user_index_canister_id).await? {
+        match lookup_user(user_to_remove.as_principal(), prepare_result.local_user_index_canister_id).await? {
             Some(user) if !user.is_platform_moderator => (),
             _ => return Err(OCErrorCode::InitiatorNotAuthorized.into()),
         }
@@ -176,7 +176,7 @@ fn remove_membership_from_user_canister(
         public,
     };
     fire_and_forget_handler.send(
-        user_to_remove.into(),
+        user_to_remove.canister_id(),
         "c2c_remove_from_group_msgpack".to_string(),
         serialize_then_unwrap(args),
     );

--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Expose count of failed community-deleted notifications in metrics ([#9245](https://github.com/open-chat-labs/open-chat/pull/9245))
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ## [[2.0.2034](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2034-group_index)] - 2026-08-20
 
 ### Added

--- a/backend/canisters/group_index/impl/src/jobs/push_community_deleted_notifications.rs
+++ b/backend/canisters/group_index/impl/src/jobs/push_community_deleted_notifications.rs
@@ -57,7 +57,7 @@ async fn push_notifications(notifications: Vec<(UserId, DeletedCommunityInfo)>) 
 async fn push_notification(user_id: UserId, deleted_community: DeletedCommunityInfo) {
     let args = user_canister::c2c_notify_community_deleted::Args { deleted_community };
 
-    if user_canister_c2c_client::c2c_notify_community_deleted(user_id.into(), &args)
+    if user_canister_c2c_client::c2c_notify_community_deleted(user_id.canister_id(), &args)
         .await
         .is_err()
     {

--- a/backend/canisters/group_index/impl/src/jobs/push_group_deleted_notifications.rs
+++ b/backend/canisters/group_index/impl/src/jobs/push_group_deleted_notifications.rs
@@ -55,7 +55,7 @@ async fn push_notifications(notifications: Vec<(UserId, DeletedGroupInfoInternal
 async fn push_notification(user_id: UserId, deleted_group: DeletedGroupInfoInternal) {
     let args = user_canister::c2c_notify_group_deleted::Args { deleted_group };
 
-    if user_canister_c2c_client::c2c_notify_group_deleted(user_id.into(), &args)
+    if user_canister_c2c_client::c2c_notify_group_deleted(user_id.canister_id(), &args)
         .await
         .is_err()
     {

--- a/backend/canisters/group_index/impl/src/lib.rs
+++ b/backend/canisters/group_index/impl/src/lib.rs
@@ -289,7 +289,7 @@ impl RuntimeState {
             stable_memory_sizes: memory::memory_sizes(),
             canister_ids: CanisterIds {
                 user_index: self.data.user_index_canister_id,
-                proposals_bot: self.data.proposals_bot_user_id.into(),
+                proposals_bot: self.data.proposals_bot_user_id.canister_id(),
                 cycles_dispenser: self.data.cycles_dispenser_canister_id,
                 escrow: self.data.escrow_canister_id,
                 event_relay: self.data.event_relay_canister_id,

--- a/backend/canisters/group_index/impl/src/updates/c2c_create_community.rs
+++ b/backend/canisters/group_index/impl/src/updates/c2c_create_community.rs
@@ -80,7 +80,7 @@ async fn validate_caller() -> Result<(UserId, Principal), Response> {
     match user_index_canister_c2c_client::c2c_lookup_user(
         user_index_canister_id,
         &user_index_canister::c2c_lookup_user::Args {
-            user_id_or_principal: caller.into(),
+            user_id_or_principal: caller.as_principal(),
         },
     )
     .await

--- a/backend/canisters/group_index/impl/src/updates/c2c_create_group.rs
+++ b/backend/canisters/group_index/impl/src/updates/c2c_create_group.rs
@@ -78,7 +78,7 @@ async fn validate_caller() -> Result<(UserId, Principal), Response> {
     match user_index_canister_c2c_client::c2c_lookup_user(
         user_index_canister_id,
         &user_index_canister::c2c_lookup_user::Args {
-            user_id_or_principal: caller.into(),
+            user_id_or_principal: caller.as_principal(),
         },
     )
     .await

--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ## [[2.0.1979](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1979-identity)] - 2026-04-10
 
 ### Removed

--- a/backend/canisters/identity/impl/src/updates/create_account_linking_code.rs
+++ b/backend/canisters/identity/impl/src/updates/create_account_linking_code.rs
@@ -13,7 +13,7 @@ async fn create_account_linking_code(_args: Args) -> Response {
     match mutate_state(prepare) {
         PrepareResult::ExistingCode(linking_code) => Response::Success(linking_code),
         PrepareResult::NewCode(user_id, user_index_canister_id) => {
-            match user_index_canister_c2c_client::lookup_user(user_id.into(), user_index_canister_id).await {
+            match user_index_canister_c2c_client::lookup_user(user_id.as_principal(), user_index_canister_id).await {
                 Ok(Some(user_details)) => mutate_state(|state| {
                     let now = state.env.now();
                     let rng = state.env.rng();

--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Harden the message-classification job against API throttling: rate-limit and outage rejections no longer count towards the drop-after-3-attempts limit (queue residency is bounded at 24h instead), the API's Retry-After is honoured, error bodies are logged so throttle and quota failures are distinguishable, and batches are token-capped and paced to stay under the moderation model's tokens-per-minute limit while a deep queue drains ([#9176](https://github.com/open-chat-labs/open-chat/pull/9176))
 
 ## [[2.0.2033](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2033-local_user_index)] - 2026-08-20

--- a/backend/canisters/local_user_index/impl/src/jobs/delete_users.rs
+++ b/backend/canisters/local_user_index/impl/src/jobs/delete_users.rs
@@ -67,7 +67,7 @@ async fn process_user(user: UserToDelete) {
 
 async fn process_user_inner(user: &UserToDelete) -> Result<DeleteUserSuccess, C2CError> {
     let user_id = user.user_id;
-    let canister_id = user_id.into();
+    let canister_id = user_id.canister_id();
 
     let (groups, communities) = user_canister_c2c_client::c2c_groups_and_communities(canister_id, &Empty {})
         .await

--- a/backend/canisters/local_user_index/impl/src/jobs/topup_canisters.rs
+++ b/backend/canisters/local_user_index/impl/src/jobs/topup_canisters.rs
@@ -25,7 +25,7 @@ fn populate_canisters() {
             state
                 .data
                 .cycles_balance_check_queue
-                .extend(state.data.local_users.iter().map(|(u, _)| CanisterId::from(*u)));
+                .extend(state.data.local_users.iter().map(|(u, _)| u.canister_id()));
             state
                 .data
                 .cycles_balance_check_queue

--- a/backend/canisters/local_user_index/impl/src/model/user_event_batch.rs
+++ b/backend/canisters/local_user_index/impl/src/model/user_event_batch.rs
@@ -9,7 +9,7 @@ grouped_timer_job_batch!(UserEventBatch, UserId, IdempotentEnvelope<UserEvent>, 
 impl TimerJobItem for UserEventBatch {
     async fn process(&self) -> Result<(), Option<Milliseconds>> {
         let response = user_canister_c2c_client::c2c_local_user_index(
-            self.key.into(),
+            self.key.canister_id(),
             &user_canister::c2c_local_user_index::Args {
                 events: self
                     .items
@@ -26,7 +26,7 @@ impl TimerJobItem for UserEventBatch {
             Ok(user_canister::c2c_local_user_index::Response::Success) => Ok(()),
             Err(error) => {
                 if is_out_of_cycles_error(error.reject_code(), error.message()) {
-                    top_up_child_canister(Some(self.key.into())).await;
+                    top_up_child_canister(Some(self.key.canister_id())).await;
                 }
                 let delay_if_should_retry = delay_if_should_retry_failed_c2c_call(&error);
                 Err(delay_if_should_retry)

--- a/backend/canisters/local_user_index/impl/src/queries/bot_chat_events.rs
+++ b/backend/canisters/local_user_index/impl/src/queries/bot_chat_events.rs
@@ -35,7 +35,7 @@ async fn bot_chat_events(args: Args) -> Response {
             args: args.events,
             latest_known_update: None,
         },
-        context.bot_id.into(),
+        context.bot_id.canister_id(),
         context.bot_id,
         Some(context.initiator),
     )

--- a/backend/canisters/local_user_index/impl/src/queries/chat_events.rs
+++ b/backend/canisters/local_user_index/impl/src/queries/chat_events.rs
@@ -31,7 +31,8 @@ pub(crate) async fn make_c2c_call_to_get_events(
 ) -> EventsResponse {
     match events_args.context {
         EventsContext::Direct(them) => {
-            let (user_id, canister_id) = if bot_initiator.is_some() { (user_id, them.into()) } else { (them, user_id.into()) };
+            let (user_id, canister_id) =
+                if bot_initiator.is_some() { (user_id, them.canister_id()) } else { (them, user_id.canister_id()) };
 
             match events_args.args {
                 EventsSelectionCriteria::Page(args) => map_response(

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_upgrade_user_canister_wasm.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_upgrade_user_canister_wasm.rs
@@ -85,10 +85,15 @@ fn commit(
         .iter()
         .filter(|(user_id, _)| active_users_filter.as_ref().is_none_or(|a| a.contains(user_id)))
         .filter(|(user_id, user)| {
-            should_perform_upgrade((**user_id).into(), user.wasm_version, version, &filter, state.data.test_mode)
-                && !state.data.global_users.is_bot(user_id)
+            should_perform_upgrade(
+                user_id.canister_id(),
+                user.wasm_version,
+                version,
+                &filter,
+                state.data.test_mode,
+            ) && !state.data.global_users.is_bot(user_id)
         })
-        .map(|(user_id, _)| CanisterId::from(*user_id))
+        .map(|(user_id, _)| user_id.canister_id())
         .sorted_by_key(|&c| Reverse(state.data.global_users.diamond_membership_expiry_date(&c.into())))
     {
         state.data.users_requiring_upgrade.enqueue(canister_id, false);

--- a/backend/canisters/local_user_index/impl/src/updates/invite_users_to_community.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/invite_users_to_community.rs
@@ -40,7 +40,7 @@ fn prepare(args: &Args, state: &RuntimeState) -> PrepareResult {
     let users = args
         .user_ids
         .iter()
-        .filter_map(|user_id| state.data.global_users.get(&(*user_id).into()))
+        .filter_map(|user_id| state.data.global_users.get(&user_id.as_principal()))
         .map(|user| (user.user_id, user.principal))
         .collect();
     PrepareResult { invited_by, users }

--- a/backend/canisters/local_user_index/impl/src/updates/invite_users_to_group.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/invite_users_to_group.rs
@@ -40,7 +40,7 @@ fn prepare(args: &Args, state: &RuntimeState) -> PrepareResult {
     let users = args
         .user_ids
         .iter()
-        .filter_map(|user_id| state.data.global_users.get(&(*user_id).into()))
+        .filter_map(|user_id| state.data.global_users.get(&user_id.as_principal()))
         .map(|user| (user.user_id, user.principal))
         .collect();
     PrepareResult { invited_by, users }

--- a/backend/canisters/local_user_index/impl/src/updates/pay_for_premium_item.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/pay_for_premium_item.rs
@@ -13,7 +13,7 @@ async fn pay_for_premium_item(args: Args) -> Response {
     match read_state(|state| prepare(&args, state)) {
         Ok(PrepareResult { user_id }) => {
             match user_canister_c2c_client::c2c_pay_for_premium_item(
-                user_id.into(),
+                user_id.canister_id(),
                 &user_canister::c2c_pay_for_premium_item::Args {
                     item_id: args.item_id,
                     pay_in_chat: args.pay_in_chat,

--- a/backend/canisters/local_user_index/impl/src/updates/register_user.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/register_user.rs
@@ -5,7 +5,6 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use constants::{CREATE_CANISTER_CYCLES_FEE, USER_LIMIT, min_cycles_balance};
 use email_address::EmailAddress;
-use ledger_utils::default_ledger_account;
 use local_user_index_canister::ChildCanisterType;
 use local_user_index_canister::register_user::{Response::*, *};
 use rand::RngExt;
@@ -63,7 +62,7 @@ async fn register_user(args: Args) -> Response {
             });
             Success(SuccessResult {
                 user_id,
-                icp_account: default_ledger_account(user_id.into()),
+                icp_account: user_id.into(),
             })
         }
         Err((canister_id, error)) => {

--- a/backend/canisters/local_user_index/impl/src/updates/withdraw_from_icpswap.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/withdraw_from_icpswap.rs
@@ -13,7 +13,7 @@ async fn withdraw_from_icpswap(args: Args) -> Response {
     }
 
     user_canister_c2c_client::c2c_withdraw_from_icpswap(
-        args.user_id.into(),
+        args.user_id.canister_id(),
         &user_canister::c2c_withdraw_from_icpswap::Args {
             swap_id: args.swap_id,
             input_token: args.input_token,

--- a/backend/canisters/online_users/CHANGELOG.md
+++ b/backend/canisters/online_users/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ### Fixed
 
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/online_users/impl/src/model/last_online_dates.rs
+++ b/backend/canisters/online_users/impl/src/model/last_online_dates.rs
@@ -12,15 +12,15 @@ pub struct LastOnlineDates {
 
 impl LastOnlineDates {
     pub fn mark_online(&mut self, user_id: UserId, now: TimestampMillis) -> Option<TimestampMillis> {
-        self.map.insert(user_id.into(), now)
+        self.map.insert(user_id.as_principal(), now)
     }
 
     pub fn get(&self, user_id: UserId) -> Option<TimestampMillis> {
-        self.map.get(&user_id.into())
+        self.map.get(&user_id.as_principal())
     }
 
     pub fn remove(&mut self, user_id: UserId) -> Option<TimestampMillis> {
-        self.map.remove(&user_id.into())
+        self.map.remove(&user_id.as_principal())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (Principal, TimestampMillis)> + '_ {

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `og_previews` field to messages for handling OpenGraph previews ([#9002](https://github.com/open-chat-labs/open-chat/pull/9002))
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ### Fixed
 
 - Detect an already pushed proposal via `MessageIdAlreadyExists` rather than the error message ([#9124](https://github.com/open-chat-labs/open-chat/pull/9124))

--- a/backend/canisters/proposals_bot/api/src/updates/appoint_admins.rs
+++ b/backend/canisters/proposals_bot/api/src/updates/appoint_admins.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
 use types::{CanisterId, UserId};
@@ -31,7 +31,7 @@ impl ToHumanReadable for Args {
                 .users
                 .iter()
                 .copied()
-                .map(|u| HumanReadablePrincipal::from(Principal::from(u)))
+                .map(|u| HumanReadablePrincipal::from(u.as_principal()))
                 .collect(),
         }
     }

--- a/backend/canisters/registry/CHANGELOG.md
+++ b/backend/canisters/registry/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add TACO as a swap provider ([#8979](https://github.com/open-chat-labs/open-chat/pull/8979))
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ### Fixed
 
 - Detect an uninstalled ledger from the reject message, since the `IC0537` code it was matching on is never sent to canisters ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/registry/api/src/updates/add_token.rs
+++ b/backend/canisters/registry/api/src/updates/add_token.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
 use types::{CanisterId, UnitResult, UserId};
@@ -29,7 +29,7 @@ impl ToHumanReadable for Args {
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
             ledger_canister_id: self.ledger_canister_id.into(),
-            payer: self.payer.map(|user_id| Principal::from(user_id).into()),
+            payer: self.payer.map(|user_id| user_id.as_principal().into()),
             info_url: self.info_url.clone(),
             transaction_url_format: self.transaction_url_format.clone(),
             one_sec_enabled: self.one_sec_enabled == Some(true),

--- a/backend/canisters/registry/impl/src/updates/add_token.rs
+++ b/backend/canisters/registry/impl/src/updates/add_token.rs
@@ -1,7 +1,6 @@
 use crate::guards::caller_is_governance_principal;
 use crate::metadata_helper::MetadataHelper;
 use crate::{mutate_state, read_state};
-use candid::Principal;
 use canister_api_macros::proposal;
 use canister_tracing_macros::trace;
 use constants::{CHAT_LEDGER_CANISTER_ID, MEMO_LIST_TOKEN, SNS_GOVERNANCE_CANISTER_ID};
@@ -97,10 +96,9 @@ async fn add_token_impl(
     let mut payment: Option<Payment> = None;
     if let Some(user_id) = payer {
         let amount = if test_mode { 100_000_000 } else { TOKEN_LISTING_FEE_E8S };
-        let from: Principal = user_id.into();
         let transfer_args = TransferFromArgs {
             spender_subaccount: None,
-            from: from.into(),
+            from: user_id.into(),
             to: SNS_GOVERNANCE_CANISTER_ID.into(),
             amount: amount.into(),
             fee: None, // No transfer fee for BURNing

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
+### Fixed
+
+- Validate the whole recipient account rather than only its owner when sending crypto ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ## [[2.0.2015](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2015-user)] - 2026-08-13
 
 ### Changed

--- a/backend/canisters/user/impl/src/crypto.rs
+++ b/backend/canisters/user/impl/src/crypto.rs
@@ -30,5 +30,5 @@ async fn process_transaction_internal(
         UserId::from(state.env.canister_id())
     });
 
-    ledger_utils::process_transaction(transaction, my_user_id.into(), false).await
+    ledger_utils::process_transaction(transaction, my_user_id.canister_id(), false).await
 }

--- a/backend/canisters/user/impl/src/lib.rs
+++ b/backend/canisters/user/impl/src/lib.rs
@@ -161,7 +161,7 @@ impl RuntimeState {
     }
 
     pub fn push_user_canister_event(&mut self, canister_id: CanisterId, event: UserCanisterEvent) {
-        if canister_id != OPENCHAT_BOT_USER_ID.into() && canister_id != self.env.canister_id() {
+        if canister_id != OPENCHAT_BOT_USER_ID.canister_id() && canister_id != self.env.canister_id() {
             self.data.user_canister_events_queue.push(
                 canister_id.into(),
                 IdempotentEnvelope {

--- a/backend/canisters/user/impl/src/model/user_canister_event_batch.rs
+++ b/backend/canisters/user/impl/src/model/user_canister_event_batch.rs
@@ -13,7 +13,7 @@ impl TimerJobItem for UserCanisterEventBatch {
         }
 
         let response = user_canister_c2c_client::c2c_user_canister(
-            self.key.into(),
+            self.key.canister_id(),
             &user_canister::c2c_user_canister::Args {
                 events: self.items.clone(),
             },

--- a/backend/canisters/user/impl/src/updates/accept_p2p_swap.rs
+++ b/backend/canisters/user/impl/src/updates/accept_p2p_swap.rs
@@ -40,7 +40,7 @@ async fn accept_p2p_swap_impl(mut args: Args) -> Response {
             from_subaccount: None,
             to: Account {
                 owner: escrow_canister_id,
-                subaccount: Some(deposit_subaccount(my_user_id.into(), content.swap_id)),
+                subaccount: Some(deposit_subaccount(my_user_id.as_principal(), content.swap_id)),
             },
             fee: Some(content.token1.fee.into()),
             created_at_time: Some(now * NANOS_PER_MILLISECOND),
@@ -81,7 +81,7 @@ async fn accept_p2p_swap_impl(mut args: Args) -> Response {
                     if let Ok(result) = chat.events.accept_p2p_swap(my_user_id, None, args.message_id, index, now) {
                         let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
                         state.push_user_canister_event(
-                            args.user_id.into(),
+                            args.user_id.canister_id(),
                             UserCanisterEvent::P2PSwapStatusChange(Box::new(P2PSwapStatusChange {
                                 thread_root_message_id,
                                 message_id: args.message_id,

--- a/backend/canisters/user/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/user/impl/src/updates/add_reaction.rs
@@ -44,7 +44,7 @@ fn add_reaction_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
     state.push_user_canister_event(
-        args.user_id.into(),
+        args.user_id.canister_id(),
         UserCanisterEvent::ToggleReaction(Box::new(ToggleReactionArgs {
             thread_root_message_id,
             message_id: args.message_id,

--- a/backend/canisters/user/impl/src/updates/c2c_accept_p2p_swap.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_accept_p2p_swap.rs
@@ -33,7 +33,7 @@ async fn c2c_accept_p2p_swap_impl(mut args: Args) -> Response {
             from_subaccount: None,
             to: Account {
                 owner: escrow_canister_id,
-                subaccount: Some(deposit_subaccount(my_user_id.into(), args.swap_id)),
+                subaccount: Some(deposit_subaccount(my_user_id.as_principal(), args.swap_id)),
             },
             fee: Some(args.token1.fee.into()),
             created_at_time: Some(now * NANOS_PER_MILLISECOND),

--- a/backend/canisters/user/impl/src/updates/c2c_local_user_index.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_local_user_index.rs
@@ -129,7 +129,10 @@ fn process_event(event: LocalUserIndexEvent, state: &mut RuntimeState) {
                 } else {
                     ReferralStatus::Diamond
                 };
-                state.push_user_canister_event(referred_by.into(), UserCanisterEvent::SetReferralStatus(Box::new(status)))
+                state.push_user_canister_event(
+                    referred_by.canister_id(),
+                    UserCanisterEvent::SetReferralStatus(Box::new(status)),
+                )
             }
         }
         LocalUserIndexEvent::NotifyUniquePersonProof(proof) => {
@@ -138,7 +141,7 @@ fn process_event(event: LocalUserIndexEvent, state: &mut RuntimeState) {
 
             if let Some(referred_by) = state.data.referred_by {
                 state.push_user_canister_event(
-                    referred_by.into(),
+                    referred_by.canister_id(),
                     UserCanisterEvent::SetReferralStatus(Box::new(ReferralStatus::UniquePerson)),
                 )
             }

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -130,7 +130,7 @@ pub(crate) fn get_sender_status(state: &RuntimeState) -> SenderStatus {
 
 pub(crate) async fn verify_user(local_user_index_canister_id: CanisterId, user_id: UserId) -> Option<UserType> {
     let args = local_user_index_canister::c2c_lookup_user::Args {
-        user_id_or_principal: user_id.into(),
+        user_id_or_principal: user_id.as_principal(),
     };
     if let Ok(response) = local_user_index_canister_c2c_client::c2c_lookup_user(local_user_index_canister_id, &args).await {
         if let local_user_index_canister::c2c_lookup_user::Response::Success(r) = response {

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -42,7 +42,7 @@ async fn c2c_user_canister_impl(args: Args) -> Response {
 }
 
 fn c2c_notify_user_canister_events_impl(args: Args, caller_user_id: UserId, state: &mut RuntimeState) -> Response {
-    let caller = caller_user_id.into();
+    let caller = caller_user_id.as_principal();
     for event in args.events {
         if state
             .data

--- a/backend/canisters/user/impl/src/updates/delete_messages.rs
+++ b/backend/canisters/user/impl/src/updates/delete_messages.rs
@@ -66,7 +66,7 @@ fn delete_messages_impl(args: Args, state: &mut RuntimeState) -> OCResult {
                 let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
                 state.push_user_canister_event(
-                    args.user_id.into(),
+                    args.user_id.canister_id(),
                     UserCanisterEvent::DeleteMessages(Box::new(user_canister::DeleteUndeleteMessagesArgs {
                         thread_root_message_id,
                         message_ids: my_messages,

--- a/backend/canisters/user/impl/src/updates/edit_message.rs
+++ b/backend/canisters/user/impl/src/updates/edit_message.rs
@@ -49,7 +49,7 @@ fn edit_message_impl(args: Args, state: &mut RuntimeState) -> OCResult {
             let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
             state.push_user_canister_event(
-                args.user_id.into(),
+                args.user_id.canister_id(),
                 UserCanisterEvent::EditMessage(Box::new(user_canister::EditMessageArgs {
                     thread_root_message_id,
                     message_id: args.message_id,

--- a/backend/canisters/user/impl/src/updates/join_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/join_video_call.rs
@@ -34,7 +34,7 @@ fn join_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
         )?;
 
         state.push_user_canister_event(
-            args.user_id.into(),
+            args.user_id.canister_id(),
             UserCanisterEvent::JoinVideoCall(Box::new(JoinVideoCall {
                 message_id: args.message_id,
             })),

--- a/backend/canisters/user/impl/src/updates/remove_reaction.rs
+++ b/backend/canisters/user/impl/src/updates/remove_reaction.rs
@@ -32,7 +32,7 @@ fn remove_reaction_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
     state.push_user_canister_event(
-        args.user_id.into(),
+        args.user_id.canister_id(),
         UserCanisterEvent::ToggleReaction(Box::new(ToggleReactionArgs {
             thread_root_message_id,
             message_id: args.message_id,

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -11,7 +11,6 @@ use chat_events::{
     TextContentInternal, ValidateNewMessageContentResult,
 };
 use constants::{MEMO_MESSAGE, OPENCHAT_BOT_USER_ID};
-use ic_principal::Principal;
 use oc_error_codes::OCErrorCode;
 use rand::RngExt;
 use std::ops::Not;
@@ -45,7 +44,7 @@ async fn send_message_v2_impl(mut args: Args) -> Response {
         recipient_type
     } else {
         let c2c_args = local_user_index_canister::c2c_lookup_user::Args {
-            user_id_or_principal: args.recipient.into(),
+            user_id_or_principal: args.recipient.as_principal(),
         };
         match local_user_index_canister_c2c_client::c2c_lookup_user(local_user_index_canister_id, &c2c_args).await {
             Ok(local_user_index_canister::c2c_lookup_user::Response::Success(result)) => RecipientType::Other(result.user_type),
@@ -76,7 +75,7 @@ async fn send_message_v2_impl(mut args: Args) -> Response {
                 // When transferring to bot users, each user transfers to their own subaccount, this way it
                 // is trivial for the bots to keep track of each user's funds
                 if recipient_type.user_type().is_bot() {
-                    pending_transfer.set_recipient(args.recipient.into(), Principal::from(my_user_id).into());
+                    pending_transfer.set_recipient(args.recipient.as_principal(), my_user_id.as_principal().into());
                 }
 
                 // We have to use `process_transaction_without_caller_check` because we may be within a
@@ -118,7 +117,7 @@ async fn send_message_v2_impl(mut args: Args) -> Response {
                     token1_principal: None,
                     expires_at: now + content.expires_in,
                     additional_admins: Vec::new(),
-                    canister_to_notify: Some(args.recipient.into()),
+                    canister_to_notify: Some(args.recipient.canister_id()),
                     is_public: false,
                 };
                 match set_up_p2p_swap(escrow_canister_id, create_swap_args).await {
@@ -509,7 +508,7 @@ fn send_message_impl(
             ));
         } else {
             state.push_user_canister_event(
-                recipient.into(),
+                recipient.canister_id(),
                 UserCanisterEvent::SendMessages(Box::new(SendMessagesArgs {
                     messages: vec![send_message_args],
                     sender_name,
@@ -564,7 +563,7 @@ async fn send_to_bot_canister(
     message_index: MessageIndex,
     args: legacy_bot_api::handle_direct_message::Args,
 ) {
-    match legacy_bot_c2c_client::handle_direct_message(recipient.into(), &args).await {
+    match legacy_bot_c2c_client::handle_direct_message(recipient.canister_id(), &args).await {
         Ok(legacy_bot_api::handle_direct_message::Response::Success(result)) => {
             mutate_state(|state| {
                 if let Some(chat) = state.data.direct_chats.get_mut(&recipient.into()) {

--- a/backend/canisters/user/impl/src/updates/send_message_with_transfer.rs
+++ b/backend/canisters/user/impl/src/updates/send_message_with_transfer.rs
@@ -391,7 +391,7 @@ pub(crate) async fn set_up_p2p_swap(
             amount: args.token0_amount + args.token0.fee,
             to: Account {
                 owner: state.data.escrow_canister_id,
-                subaccount: Some(deposit_subaccount(my_user_id.into(), id)),
+                subaccount: Some(deposit_subaccount(my_user_id.as_principal(), id)),
             },
             fee: args.token0.fee,
             memo: Some(MEMO_P2P_SWAP_CREATE.to_vec().into()),

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -59,7 +59,7 @@ fn start_video_call_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     }
 
     state.push_user_canister_event(
-        sender.into(),
+        sender.canister_id(),
         UserCanisterEvent::StartVideoCall(Box::new(StartVideoCallArgs {
             message_id: args.message_id,
             message_index: message_event.event.message_index,

--- a/backend/canisters/user/impl/src/updates/tip_message.rs
+++ b/backend/canisters/user/impl/src/updates/tip_message.rs
@@ -5,7 +5,6 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use chat_events::TipMessageArgs;
 use constants::{MEMO_TIP, NANOS_PER_MILLISECOND};
-use ic_principal::Principal;
 use oc_error_codes::OCErrorCode;
 use serde::Serialize;
 use types::{
@@ -31,7 +30,7 @@ async fn tip_message_impl(mut args: Args) -> Response {
         ledger: args.ledger,
         token_symbol: args.token_symbol.clone(),
         amount: args.amount,
-        to: Principal::from(args.recipient).into(),
+        to: icrc1::Account::for_user(args.recipient),
         fee: args.fee,
         memo: Some(MEMO_TIP.to_vec().into()),
         created: now_nanos,
@@ -163,7 +162,7 @@ fn tip_direct_chat_message(args: TipMessageArgs, decimals: u8, state: &mut Runti
             let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
             state.push_user_canister_event(
-                args.recipient.into(),
+                args.recipient.canister_id(),
                 UserCanisterEvent::TipMessage(Box::new(user_canister::TipMessageArgs {
                     thread_root_message_id,
                     message_id: args.message_id,

--- a/backend/canisters/user/impl/src/updates/undelete_messages.rs
+++ b/backend/canisters/user/impl/src/updates/undelete_messages.rs
@@ -53,7 +53,7 @@ fn undelete_messages_impl(args: Args, state: &mut RuntimeState) -> OCResult<Succ
         let thread_root_message_id = args.thread_root_message_index.map(|i| chat.main_message_index_to_id(i));
 
         state.push_user_canister_event(
-            args.user_id.into(),
+            args.user_id.canister_id(),
             UserCanisterEvent::UndeleteMessages(Box::new(user_canister::DeleteUndeleteMessagesArgs {
                 thread_root_message_id,
                 message_ids: deleted,

--- a/backend/canisters/user/impl/src/updates/update_chat_settings.rs
+++ b/backend/canisters/user/impl/src/updates/update_chat_settings.rs
@@ -16,7 +16,7 @@ async fn update_chat_settings(args: Args) -> Response {
 
 async fn update_chat_settings_impl(args: Args) -> OCResult {
     if let Err(local_user_index_canister) = read_state(|state| check_chat_exists(args.user_id, state)) {
-        let user = local_user_index_canister_c2c_client::lookup_user(args.user_id.into(), local_user_index_canister)
+        let user = local_user_index_canister_c2c_client::lookup_user(args.user_id.as_principal(), local_user_index_canister)
             .await?
             .ok_or(OCErrorCode::TargetUserNotFound)?;
 
@@ -39,7 +39,7 @@ async fn update_chat_settings_impl(args: Args) -> OCResult {
                 .set_events_time_to_live(state.env.canister_id().into(), events_ttl, now);
 
             state.push_user_canister_event(
-                args.user_id.into(),
+                args.user_id.canister_id(),
                 UserCanisterEvent::SetEventsTtl(Box::new(SetEventsTtl {
                     events_ttl,
                     timestamp: now,

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+
 ### Removed
 
 - Remove the one-off `post_upgrade` privilege re-sync now that it has run on prod in the 2.0.2046 release ([#9255](https://github.com/open-chat-labs/open-chat/pull/9255))

--- a/backend/canisters/user_index/api/src/updates/add_platform_moderator.rs
+++ b/backend/canisters/user_index/api/src/updates/add_platform_moderator.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use oc_error_codes::OCError;
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            user_id: Principal::from(self.user_id).into(),
+            user_id: self.user_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/api/src/updates/add_platform_operator.rs
+++ b/backend/canisters/user_index/api/src/updates/add_platform_operator.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
 use types::{SuccessOnly, UserId};
@@ -20,7 +20,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            user_id: Principal::from(self.user_id).into(),
+            user_id: self.user_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/api/src/updates/publish_bot.rs
+++ b/backend/canisters/user_index/api/src/updates/publish_bot.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use oc_error_codes::OCError;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            bot_id: Principal::from(self.bot_id).into(),
+            bot_id: self.bot_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/api/src/updates/register_external_achievement.rs
+++ b/backend/canisters/user_index/api/src/updates/register_external_achievement.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
 use types::{CanisterId, SuccessOnly, TimestampMillis, UserId};
@@ -37,7 +37,7 @@ impl ToHumanReadable for Args {
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
             id: self.id,
-            submitted_by: Principal::from(self.submitted_by).into(),
+            submitted_by: self.submitted_by.as_principal().into(),
             name: self.name.clone(),
             logo: self.logo.clone(),
             url: self.url.clone(),

--- a/backend/canisters/user_index/api/src/updates/remove_bot.rs
+++ b/backend/canisters/user_index/api/src/updates/remove_bot.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use oc_error_codes::OCError;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            bot_id: Principal::from(self.bot_id).into(),
+            bot_id: self.bot_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/api/src/updates/remove_platform_moderator.rs
+++ b/backend/canisters/user_index/api/src/updates/remove_platform_moderator.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use oc_error_codes::OCError;
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            user_id: Principal::from(self.user_id).into(),
+            user_id: self.user_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/api/src/updates/remove_platform_operator.rs
+++ b/backend/canisters/user_index/api/src/updates/remove_platform_operator.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Principal};
+use candid::CandidType;
 use human_readable::{HumanReadablePrincipal, ToHumanReadable};
 use serde::{Deserialize, Serialize};
 use types::{SuccessOnly, UserId};
@@ -20,7 +20,7 @@ impl ToHumanReadable for Args {
 
     fn to_human_readable(&self) -> Self::Target {
         HumanReadableArgs {
-            user_id: Principal::from(self.user_id).into(),
+            user_id: self.user_id.as_principal().into(),
         }
     }
 }

--- a/backend/canisters/user_index/impl/src/queries/current_user.rs
+++ b/backend/canisters/user_index/impl/src/queries/current_user.rs
@@ -1,6 +1,5 @@
 use crate::{RuntimeState, read_state};
 use canister_api_macros::query;
-use ledger_utils::default_ledger_account;
 use user_index_canister::current_user::{Response::*, *};
 
 #[query(candid = true, msgpack = true)]
@@ -22,7 +21,7 @@ fn current_user_impl(state: &RuntimeState) -> Response {
             date_created: u.date_created,
             display_name: u.display_name.clone(),
             avatar_id: u.avatar_id,
-            icp_account: default_ledger_account(u.user_id.into()),
+            icp_account: u.user_id.into(),
             referrals: state.data.users.referrals(&u.user_id),
             // Role flags read false while suspended: a suspended account holds no authority,
             // and the client must not offer surfaces the canisters will refuse

--- a/backend/canisters/user_index/impl/src/updates/add_platform_moderator.rs
+++ b/backend/canisters/user_index/impl/src/updates/add_platform_moderator.rs
@@ -15,7 +15,7 @@ async fn add_platform_moderator(args: Args) -> Response {
     }
 
     let c2c_args = c2c_grant_super_admin::Args {};
-    match user_canister_c2c_client::c2c_grant_super_admin(args.user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_grant_super_admin(args.user_id.canister_id(), &c2c_args).await {
         Ok(_) => {
             mutate_state(|state| commit(args.user_id, state));
             Success

--- a/backend/canisters/user_index/impl/src/updates/c2c_notify_low_balance.rs
+++ b/backend/canisters/user_index/impl/src/updates/c2c_notify_low_balance.rs
@@ -15,7 +15,7 @@ async fn c2c_notify_low_balance(_args: NotifyLowBalanceArgs) -> NotifyLowBalance
     };
     let amount = prepare_ok.top_up.amount;
 
-    if deposit_cycles(prepare_ok.user_id.into(), amount).await.is_ok() {
+    if deposit_cycles(prepare_ok.user_id.canister_id(), amount).await.is_ok() {
         mutate_state(|state| commit(prepare_ok.user_id, prepare_ok.top_up, state));
         NotifyLowBalanceResponse::Success(amount)
     } else {

--- a/backend/canisters/user_index/impl/src/updates/pay_for_diamond_membership.rs
+++ b/backend/canisters/user_index/impl/src/updates/pay_for_diamond_membership.rs
@@ -50,7 +50,7 @@ pub(crate) async fn pay_for_diamond_membership_impl(args: Args, user_id: UserId,
         amount: ICP::from_e8s(args.expected_price_e8s - fee as u64),
     };
 
-    let response = match user_canister_c2c_client::c2c_charge_user_account(user_id.into(), &c2c_args).await {
+    let response = match user_canister_c2c_client::c2c_charge_user_account(user_id.canister_id(), &c2c_args).await {
         Ok(result) => match result {
             user_canister::c2c_charge_user_account::Response::Success(block_index) => {
                 mutate_state(|state| process_charge(args, user_id, block_index, manual_payment, state))

--- a/backend/canisters/user_index/impl/src/updates/register_external_achievement.rs
+++ b/backend/canisters/user_index/impl/src/updates/register_external_achievement.rs
@@ -1,6 +1,5 @@
 use crate::guards::caller_is_governance_principal;
 use crate::{RuntimeState, mutate_state, read_state};
-use candid::Principal;
 use canister_api_macros::proposal;
 use canister_tracing_macros::trace;
 use constants::{CHAT_LEDGER_CANISTER_ID, CHAT_TRANSFER_FEE};
@@ -26,11 +25,10 @@ async fn register_external_achievement(args: Args) -> Response {
 
     let payment_block_index = if !result.test_mode {
         // Try to make the CHAT transfer from the given user's wallet
-        let from: Principal = args.submitted_by.into();
         let amount = (chit_budget as u128) * CHAT_FEE_PER_CHIT_AWARD;
         let transfer_args = TransferFromArgs {
             spender_subaccount: None,
-            from: from.into(),
+            from: args.submitted_by.into(),
             to: result.this_canister_id.into(),
             amount: amount.into(),
             fee: Some(CHAT_TRANSFER_FEE.into()),

--- a/backend/canisters/user_index/impl/src/updates/remove_platform_moderator.rs
+++ b/backend/canisters/user_index/impl/src/updates/remove_platform_moderator.rs
@@ -15,7 +15,7 @@ async fn remove_platform_moderator(args: Args) -> Response {
     }
 
     let c2c_args = c2c_revoke_super_admin::Args {};
-    match user_canister_c2c_client::c2c_revoke_super_admin(args.user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_revoke_super_admin(args.user_id.canister_id(), &c2c_args).await {
         Ok(_) => {
             mutate_state(|state| commit(args.user_id, state));
             Success

--- a/backend/canisters/user_index/impl/src/updates/suspend_user.rs
+++ b/backend/canisters/user_index/impl/src/updates/suspend_user.rs
@@ -31,7 +31,7 @@ pub(crate) async fn suspend_user_impl(
     caused_by_report: Option<u64>,
 ) -> Response {
     let c2c_args = user_canister::c2c_set_user_suspended::Args { suspended: true };
-    match user_canister_c2c_client::c2c_set_user_suspended(user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_set_user_suspended(user_id.canister_id(), &c2c_args).await {
         Ok(user_canister::c2c_set_user_suspended::Response::Success(result)) => {
             mutate_state(|state| {
                 commit(

--- a/backend/canisters/user_index/impl/src/updates/unsuspend_user.rs
+++ b/backend/canisters/user_index/impl/src/updates/unsuspend_user.rs
@@ -34,7 +34,7 @@ fn caller_is(user_id: &UserId, state: &RuntimeState) -> bool {
 
 pub(crate) async fn unsuspend_user_impl(user_id: UserId) -> Response {
     let c2c_args = user_canister::c2c_set_user_suspended::Args { suspended: false };
-    match user_canister_c2c_client::c2c_set_user_suspended(user_id.into(), &c2c_args).await {
+    match user_canister_c2c_client::c2c_set_user_suspended(user_id.canister_id(), &c2c_args).await {
         Ok(user_canister::c2c_set_user_suspended::Response::Success(result)) => {
             mutate_state(|state| commit(user_id, result.groups, result.communities, state));
             Success

--- a/backend/integration_tests/src/bot_tests.rs
+++ b/backend/integration_tests/src/bot_tests.rs
@@ -665,7 +665,7 @@ fn send_direct_message() {
     env.advance_time(Duration::from_millis(1));
     let owner = client::register_diamond_user(env, canister_ids, *controller);
 
-    let local_user_index = canister_ids.local_user_index(env, owner.user_id);
+    let local_user_index = canister_ids.local_user_index(env, owner.user_id.canister_id());
 
     // Register a bot
     let (bot_id, bot_principal) = client::user_index::happy_path::register_bot(

--- a/backend/integration_tests/src/client/community.rs
+++ b/backend/integration_tests/src/client/community.rs
@@ -257,7 +257,7 @@ pub mod happy_path {
         let response = user::send_message_with_transfer_to_channel(
             env,
             sender.principal,
-            sender.user_id.into(),
+            sender.user_id.canister_id(),
             &user_canister::send_message_with_transfer_to_channel::Args {
                 channel_id,
                 thread_root_message_index: None,

--- a/backend/integration_tests/src/client/group.rs
+++ b/backend/integration_tests/src/client/group.rs
@@ -139,7 +139,7 @@ pub mod happy_path {
         let response = user::send_message_with_transfer_to_group(
             env,
             sender.principal,
-            sender.user_id.into(),
+            sender.user_id.canister_id(),
             &user_canister::send_message_with_transfer_to_group::Args {
                 thread_root_message_index: None,
                 message_id: message_id.unwrap_or_else(random_from_u128),

--- a/backend/integration_tests/src/client/user.rs
+++ b/backend/integration_tests/src/client/user.rs
@@ -427,7 +427,7 @@ pub mod happy_path {
         let response = super::start_video_call_v2(
             env,
             VIDEO_CALL_OPERATOR,
-            recipient.into(),
+            recipient.canister_id(),
             &user_canister::start_video_call_v2::Args {
                 message_id,
                 initiator: user.user_id,
@@ -460,7 +460,7 @@ pub mod happy_path {
         let response = super::end_video_call_v2(
             env,
             VIDEO_CALL_OPERATOR,
-            recipient.into(),
+            recipient.canister_id(),
             &user_canister::end_video_call_v2::Args {
                 user_id: initiator,
                 message_id,

--- a/backend/integration_tests/src/communities/delete_community_tests.rs
+++ b/backend/integration_tests/src/communities/delete_community_tests.rs
@@ -85,7 +85,7 @@ fn user_canister_notified_of_community_deleted() {
     // next attempt (still inside the 10 minute window) is delivered.
     tick_many(env, 3);
 
-    start_canister(env, user2.local_user_index, user2.user_id.into());
+    start_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     env.tick();
 
@@ -108,7 +108,7 @@ fn user_canister_notified_of_community_deleted() {
     // cannot show this (it reads zero while the attempt is in flight), so wait for the drop
     // itself: group_index's failed count rising is the deterministic endpoint.
     wait_for_community_deleted_notification_dropped(env, canister_ids.group_index, failed_before);
-    start_canister(env, user3.local_user_index, user3.user_id.into());
+    start_canister(env, user3.local_user_index, user3.user_id.canister_id());
     env.tick();
 
     // Only retry for 10 minutes so the notification shouldn't have made it to user3's canister

--- a/backend/integration_tests/src/communities/import_group_tests.rs
+++ b/backend/integration_tests/src/communities/import_group_tests.rs
@@ -122,7 +122,7 @@ fn read_up_to_data_maintained_after_import() {
     client::user::mark_read(
         env,
         user2.principal,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         &user_canister::mark_read::Args {
             messages_read: vec![ChatMessagesRead {
                 chat_id: group_id,

--- a/backend/integration_tests/src/communities/p2p_swap_tests.rs
+++ b/backend/integration_tests/src/communities/p2p_swap_tests.rs
@@ -2,7 +2,6 @@ use crate::env::ENV;
 use crate::p2p_swap_tests::verify_swap_status;
 use crate::utils::{chat_token_info, icp_token_info, tick_many};
 use crate::{TestEnv, client};
-use candid::Principal;
 use constants::{CHAT_TRANSFER_FEE, DAY_IN_MS, MINUTE_IN_MS};
 use std::ops::Deref;
 use std::time::Duration;
@@ -32,20 +31,8 @@ fn p2p_swap_in_channel_succeeds() {
 
     client::community::happy_path::join_community(env, user2.principal, community_id);
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.icp_ledger,
-        Principal::from(user1.user_id),
-        1_100_000_000,
-    );
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.chat_ledger,
-        Principal::from(user2.user_id),
-        11_000_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, user1.user_id, 1_100_000_000);
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.chat_ledger, user2.user_id, 11_000_000_000);
 
     let message_id = random_from_u128();
 
@@ -105,12 +92,12 @@ fn p2p_swap_in_channel_succeeds() {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         10_000_000_000
     );
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, Principal::from(user2.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user2.user_id),
         1_000_000_000
     );
 
@@ -154,7 +141,7 @@ fn cancel_p2p_swap_in_channel_succeeds(delete_message: bool) {
         env,
         *controller,
         canister_ids.chat_ledger,
-        Principal::from(user1.user_id),
+        user1.user_id,
         original_chat_balance,
     );
 
@@ -238,7 +225,7 @@ fn cancel_p2p_swap_in_channel_succeeds(delete_message: bool) {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         original_chat_balance - (2 * CHAT_TRANSFER_FEE)
     );
 

--- a/backend/integration_tests/src/communities/send_message_tests.rs
+++ b/backend/integration_tests/src/communities/send_message_tests.rs
@@ -76,7 +76,7 @@ fn send_crypto_in_channel(with_c2c_error: bool) {
     let send_message_result = client::user::send_message_with_transfer_to_channel(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_channel::Args {
             community_id,
             channel_id,

--- a/backend/integration_tests/src/delete_group_tests.rs
+++ b/backend/integration_tests/src/delete_group_tests.rs
@@ -66,7 +66,7 @@ fn user_canister_notified_of_group_deleted() {
 
     env.advance_time(Duration::from_secs(9 * 60));
     env.tick();
-    start_canister(env, user2.local_user_index, user2.user_id.into());
+    start_canister(env, user2.local_user_index, user2.user_id.canister_id());
     env.tick();
 
     let initial_state2 = client::user::happy_path::initial_state(env, &user1);
@@ -74,7 +74,7 @@ fn user_canister_notified_of_group_deleted() {
 
     env.advance_time(Duration::from_secs(2 * 60));
     env.tick();
-    start_canister(env, user3.local_user_index, user3.user_id.into());
+    start_canister(env, user3.local_user_index, user3.user_id.canister_id());
     env.tick();
 
     // Only retry for 10 minutes so the notification shouldn't have made it to user3's canister

--- a/backend/integration_tests/src/delete_message_tests.rs
+++ b/backend/integration_tests/src/delete_message_tests.rs
@@ -235,7 +235,7 @@ fn delete_then_undelete_direct_message(delay: bool) {
     let delete_messages_response = client::user::delete_messages(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::delete_messages::Args {
             user_id: user2.user_id,
             thread_root_message_index: None,
@@ -255,7 +255,7 @@ fn delete_then_undelete_direct_message(delay: bool) {
     let undelete_messages_response = client::user::undelete_messages(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::undelete_messages::Args {
             user_id: user2.user_id,
             thread_root_message_index: None,

--- a/backend/integration_tests/src/escrow_tests.rs
+++ b/backend/integration_tests/src/escrow_tests.rs
@@ -29,7 +29,7 @@ fn swap_via_escrow_canister_succeeds() {
 
     let swap_id = client::escrow::happy_path::create_swap(
         env,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         canister_ids.escrow,
         P2PSwapLocation::from_message(Chat::Direct(user2.user_id.into()), None, 0u64.into()),
         icp_token_info(),
@@ -43,7 +43,7 @@ fn swap_via_escrow_canister_succeeds() {
 
     let user1_deposit_account = Account {
         owner: canister_ids.escrow,
-        subaccount: Some(deposit_subaccount(user1.user_id.into(), swap_id)),
+        subaccount: Some(deposit_subaccount(user1.user_id.as_principal(), swap_id)),
     };
 
     client::ledger::happy_path::transfer(
@@ -56,7 +56,7 @@ fn swap_via_escrow_canister_succeeds() {
 
     let user2_deposit_account = Account {
         owner: canister_ids.escrow,
-        subaccount: Some(deposit_subaccount(user2.user_id.into(), swap_id)),
+        subaccount: Some(deposit_subaccount(user2.user_id.as_principal(), swap_id)),
     };
 
     client::ledger::happy_path::transfer(
@@ -67,8 +67,10 @@ fn swap_via_escrow_canister_succeeds() {
         chat_amount + 100_000,
     );
 
-    let result1 = client::escrow::happy_path::notify_deposit(env, user1.user_id.into(), canister_ids.escrow, swap_id, None);
-    let result2 = client::escrow::happy_path::notify_deposit(env, user2.user_id.into(), canister_ids.escrow, swap_id, None);
+    let result1 =
+        client::escrow::happy_path::notify_deposit(env, user1.user_id.canister_id(), canister_ids.escrow, swap_id, None);
+    let result2 =
+        client::escrow::happy_path::notify_deposit(env, user2.user_id.canister_id(), canister_ids.escrow, swap_id, None);
 
     assert!(!result1.complete);
     assert!(result2.complete);
@@ -172,7 +174,7 @@ fn deposits_refunded_if_swap_no_longer_available(expired: bool) {
 
     let swap_id = client::escrow::happy_path::create_swap(
         env,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         canister_ids.escrow,
         P2PSwapLocation::from_message(Chat::Direct(user2.user_id.into()), None, 0u64.into()),
         icp_token_info(),
@@ -186,7 +188,7 @@ fn deposits_refunded_if_swap_no_longer_available(expired: bool) {
 
     let user1_deposit_account = Account {
         owner: canister_ids.escrow,
-        subaccount: Some(deposit_subaccount(user1.user_id.into(), swap_id)),
+        subaccount: Some(deposit_subaccount(user1.user_id.as_principal(), swap_id)),
     };
 
     client::ledger::happy_path::transfer(
@@ -199,7 +201,7 @@ fn deposits_refunded_if_swap_no_longer_available(expired: bool) {
 
     let user2_deposit_account = Account {
         owner: canister_ids.escrow,
-        subaccount: Some(deposit_subaccount(user2.user_id.into(), swap_id)),
+        subaccount: Some(deposit_subaccount(user2.user_id.as_principal(), swap_id)),
     };
 
     client::ledger::happy_path::transfer(
@@ -210,17 +212,17 @@ fn deposits_refunded_if_swap_no_longer_available(expired: bool) {
         chat_amount + 100_000,
     );
 
-    client::escrow::happy_path::notify_deposit(env, user1.user_id.into(), canister_ids.escrow, swap_id, None);
+    client::escrow::happy_path::notify_deposit(env, user1.user_id.canister_id(), canister_ids.escrow, swap_id, None);
 
     if expired {
         env.advance_time(Duration::from_millis((60 * MINUTE_IN_MS) + 1));
     } else {
-        client::escrow::happy_path::cancel_swap(env, user1.user_id.into(), canister_ids.escrow, swap_id);
+        client::escrow::happy_path::cancel_swap(env, user1.user_id.canister_id(), canister_ids.escrow, swap_id);
     }
 
     let notify_response = client::escrow::notify_deposit(
         env,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         canister_ids.escrow,
         &escrow_canister::notify_deposit::Args {
             swap_id,

--- a/backend/integration_tests/src/fire_and_forget_handler_tests.rs
+++ b/backend/integration_tests/src/fire_and_forget_handler_tests.rs
@@ -28,7 +28,7 @@ fn retries_after_failures(failures: usize) {
     assert_eq!(events_response1.events.len(), 1);
     assert!(matches!(events_response1.events[0].event, ChatEvent::Message(_)));
 
-    stop_canister(env, user2.local_user_index, user2.user_id.into());
+    stop_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     client::user::happy_path::add_reaction(env, &user1, user2.user_id, "1", message_id);
 
@@ -37,7 +37,7 @@ fn retries_after_failures(failures: usize) {
         env.tick();
     }
 
-    start_canister(env, user2.local_user_index, user2.user_id.into());
+    start_canister(env, user2.local_user_index, user2.user_id.canister_id());
     env.tick();
     env.advance_time(Duration::from_secs(100));
     tick_many(env, 3);

--- a/backend/integration_tests/src/gated_group_tests.rs
+++ b/backend/integration_tests/src/gated_group_tests.rs
@@ -26,7 +26,7 @@ fn public_group_diamond_member_gate_check(is_diamond: bool, is_invited: bool) {
     let group_id = match client::user::create_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::create_group::Args {
             is_public: true,
             name: group_name.clone(),
@@ -106,7 +106,7 @@ fn public_group_token_balance_gate_check(has_sufficient_balance: bool) {
     let group_id = match client::user::create_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::create_group::Args {
             is_public: true,
             name: group_name.clone(),
@@ -187,7 +187,7 @@ fn public_group_composite_gate_check(is_diamond: bool, has_sufficient_balance: b
     let group_id = match client::user::create_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::create_group::Args {
             is_public: true,
             name: group_name.clone(),
@@ -268,7 +268,7 @@ fn owner_receives_transfer_after_user_joins_via_payment_gate(composite_gate: boo
     let user1 = client::register_diamond_user(env, canister_ids, *controller);
     let user2 = client::register_user(env, canister_ids);
 
-    let original_balance = client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, Principal::from(user1.user_id));
+    let original_balance = client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user1.user_id);
 
     let group_name = random_string();
     let amount = 1_0000_0000;
@@ -295,7 +295,7 @@ fn owner_receives_transfer_after_user_joins_via_payment_gate(composite_gate: boo
     let group_id = match client::user::create_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::create_group::Args {
             is_public: true,
             name: group_name.clone(),
@@ -316,7 +316,7 @@ fn owner_receives_transfer_after_user_joins_via_payment_gate(composite_gate: boo
     client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, user2.user_id, amount);
     client::ledger::happy_path::approve(
         env,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         canister_ids.icp_ledger,
         Principal::from(group_id),
         amount - fee,
@@ -325,7 +325,7 @@ fn owner_receives_transfer_after_user_joins_via_payment_gate(composite_gate: boo
 
     tick_many(env, 3);
 
-    let balance = client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, Principal::from(user1.user_id));
+    let balance = client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user1.user_id);
 
     assert_eq!(balance - original_balance, (amount * 98) / 100);
 }
@@ -347,7 +347,7 @@ fn only_selected_composite_gate_checked_if_index_provided() {
     let group_id = match client::user::create_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::create_group::Args {
             is_public: true,
             name: group_name.clone(),
@@ -390,14 +390,14 @@ fn only_selected_composite_gate_checked_if_index_provided() {
 
     client::ledger::happy_path::approve(
         env,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         canister_ids.icp_ledger,
         Principal::from(group_id),
         initial_balance,
     );
     client::ledger::happy_path::approve(
         env,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         canister_ids.chat_ledger,
         Principal::from(group_id),
         initial_balance,

--- a/backend/integration_tests/src/lib.rs
+++ b/backend/integration_tests/src/lib.rs
@@ -96,7 +96,7 @@ impl UserAuth {
 
 impl User {
     pub fn canister(&self) -> CanisterId {
-        self.user_id.into()
+        self.user_id.canister_id()
     }
 
     pub fn username(&self) -> String {

--- a/backend/integration_tests/src/message_activity_tests.rs
+++ b/backend/integration_tests/src/message_activity_tests.rs
@@ -233,7 +233,7 @@ fn send_crypto_message_and_check_activity_feed(chat_type: ChatType) {
         fee: 10_000,
         token_symbol: ICP_SYMBOL.to_string(),
         amount,
-        to: us.user_id.into(),
+        to: types::icrc1::Account::for_user(us.user_id),
         memo: None,
         created: now_nanos(env),
     });
@@ -384,21 +384,9 @@ fn accept_p2p_swap_and_check_activity_feed(chat_type: ChatType) {
         true,
     );
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.icp_ledger,
-        Principal::from(us.user_id),
-        1_100_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, us.user_id, 1_100_000_000);
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.chat_ledger,
-        Principal::from(them.user_id),
-        11_000_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.chat_ledger, them.user_id, 11_000_000_000);
 
     let message_id = random_from_u128();
     let content = MessageContentInitial::P2PSwap(P2PSwapContentInitial {

--- a/backend/integration_tests/src/notification_tests.rs
+++ b/backend/integration_tests/src/notification_tests.rs
@@ -101,7 +101,7 @@ fn direct_message_notification_muted() {
     client::user::mute_notifications(
         env,
         user2.principal,
-        user2.user_id.into(),
+        user2.user_id.canister_id(),
         &user_canister::mute_notifications::Args {
             chat_id: user1.user_id.into(),
         },

--- a/backend/integration_tests/src/p2p_swap_tests.rs
+++ b/backend/integration_tests/src/p2p_swap_tests.rs
@@ -1,7 +1,6 @@
 use crate::env::ENV;
 use crate::utils::{chat_token_info, icp_token_info, tick_many};
 use crate::{TestEnv, client};
-use candid::Principal;
 use constants::{CHAT_TRANSFER_FEE, DAY_IN_MS, MINUTE_IN_MS};
 use oc_error_codes::OCErrorCode;
 use std::ops::Deref;
@@ -23,20 +22,8 @@ fn p2p_swap_in_direct_chat_succeeds() {
     let user1 = client::register_diamond_user(env, canister_ids, *controller);
     let user2 = client::register_user(env, canister_ids);
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.icp_ledger,
-        Principal::from(user1.user_id),
-        1_100_000_000,
-    );
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.chat_ledger,
-        Principal::from(user2.user_id),
-        11_000_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, user1.user_id, 1_100_000_000);
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.chat_ledger, user2.user_id, 11_000_000_000);
 
     let message_id = random_from_u128();
 
@@ -92,12 +79,12 @@ fn p2p_swap_in_direct_chat_succeeds() {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         10_000_000_000
     );
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, Principal::from(user2.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user2.user_id),
         1_000_000_000
     );
 
@@ -140,20 +127,8 @@ fn p2p_swap_in_group_succeeds() {
     let group_id = client::user::happy_path::create_group(env, &user1, &random_string(), true, true);
     client::group::happy_path::join_group(env, user2.principal, group_id);
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.icp_ledger,
-        Principal::from(user1.user_id),
-        1_100_000_000,
-    );
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.chat_ledger,
-        Principal::from(user2.user_id),
-        11_000_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, user1.user_id, 1_100_000_000);
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.chat_ledger, user2.user_id, 11_000_000_000);
 
     let message_id = random_from_u128();
 
@@ -210,12 +185,12 @@ fn p2p_swap_in_group_succeeds() {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         10_000_000_000
     );
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, Principal::from(user2.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user2.user_id),
         1_000_000_000
     );
 
@@ -251,7 +226,7 @@ fn cancel_p2p_swap_in_direct_chat_succeeds(delete_message: bool) {
         env,
         *controller,
         canister_ids.chat_ledger,
-        Principal::from(user1.user_id),
+        user1.user_id,
         original_chat_balance,
     );
 
@@ -327,7 +302,7 @@ fn cancel_p2p_swap_in_direct_chat_succeeds(delete_message: bool) {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         original_chat_balance - (2 * CHAT_TRANSFER_FEE)
     );
 
@@ -379,7 +354,7 @@ fn cancel_p2p_swap_in_group_chat_succeeds(delete_message: bool) {
         env,
         *controller,
         canister_ids.chat_ledger,
-        Principal::from(user1.user_id),
+        user1.user_id,
         original_chat_balance,
     );
 
@@ -459,7 +434,7 @@ fn cancel_p2p_swap_in_group_chat_succeeds(delete_message: bool) {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         original_chat_balance - (2 * CHAT_TRANSFER_FEE)
     );
 
@@ -496,7 +471,7 @@ fn deposit_refunded_if_swap_expires() {
         env,
         *controller,
         canister_ids.chat_ledger,
-        Principal::from(user1.user_id),
+        user1.user_id,
         original_chat_balance,
     );
 
@@ -536,7 +511,7 @@ fn deposit_refunded_if_swap_expires() {
     tick_many(env, 10);
 
     assert_eq!(
-        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, Principal::from(user1.user_id)),
+        client::ledger::happy_path::balance_of(env, canister_ids.chat_ledger, user1.user_id),
         original_chat_balance - (2 * CHAT_TRANSFER_FEE)
     );
 
@@ -579,13 +554,7 @@ fn p2p_swap_blocked_if_token_disabled(input_token: bool) {
 
     let group_id = client::user::happy_path::create_group(env, &user, &random_string(), true, true);
 
-    client::ledger::happy_path::transfer(
-        env,
-        *controller,
-        canister_ids.icp_ledger,
-        Principal::from(user.user_id),
-        1_100_000_000,
-    );
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, user.user_id, 1_100_000_000);
 
     let message_id = random_from_u128();
 

--- a/backend/integration_tests/src/pin_number_tests.rs
+++ b/backend/integration_tests/src/pin_number_tests.rs
@@ -161,7 +161,7 @@ fn transfer_requires_correct_pin(test_case: u32) {
     let response = client::user::send_message_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_v2::Args {
             recipient: user2.user_id,
             thread_root_message_index: None,

--- a/backend/integration_tests/src/prize_message_tests.rs
+++ b/backend/integration_tests/src/prize_message_tests.rs
@@ -40,7 +40,7 @@ fn prize_messages_can_be_claimed_successfully() {
     let send_message_response = client::user::send_message_with_transfer_to_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_group::Args {
             group_id,
             thread_root_message_index: None,
@@ -149,7 +149,7 @@ fn prize_message_requiring_reauthentication() {
     let send_message_response = client::user::send_message_with_transfer_to_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_group::Args {
             group_id,
             thread_root_message_index: None,
@@ -267,7 +267,7 @@ fn unclaimed_prizes_get_refunded(case: u32) {
     client::user::send_message_with_transfer_to_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_group::Args {
             group_id,
             thread_root_message_index: None,
@@ -364,7 +364,7 @@ fn old_transactions_fixed_by_updating_created_date() {
     let send_message_response = client::user::send_message_with_transfer_to_group(
         env,
         user.principal,
-        user.user_id.into(),
+        user.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_group::Args {
             group_id,
             thread_root_message_index: None,

--- a/backend/integration_tests/src/send_crypto_tests.rs
+++ b/backend/integration_tests/src/send_crypto_tests.rs
@@ -46,7 +46,7 @@ fn send_direct_message_with_transfer_succeeds(with_c2c_error: bool, icrc2: bool)
             token_symbol: ICP_SYMBOL.to_string(),
             amount,
             from: random_principal.into(),
-            to: user2.user_id.into(),
+            to: types::icrc1::Account::for_user(user2.user_id),
             memo: None,
             created: now_nanos,
         })
@@ -59,7 +59,7 @@ fn send_direct_message_with_transfer_succeeds(with_c2c_error: bool, icrc2: bool)
             fee,
             token_symbol: ICP_SYMBOL.to_string(),
             amount,
-            to: user2.user_id.into(),
+            to: types::icrc1::Account::for_user(user2.user_id),
             memo: None,
             created: now_nanos,
         })
@@ -68,7 +68,7 @@ fn send_direct_message_with_transfer_succeeds(with_c2c_error: bool, icrc2: bool)
     let send_message_result = client::user::send_message_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_v2::Args {
             recipient: user2.user_id,
             thread_root_message_index: None,
@@ -154,7 +154,7 @@ fn send_message_with_transfer_to_group_succeeds(with_c2c_error: bool, icrc2: boo
             token_symbol: ICP_SYMBOL.to_string(),
             amount,
             from: random_principal.into(),
-            to: user2.user_id.into(),
+            to: types::icrc1::Account::for_user(user2.user_id),
             memo: None,
             created: now_nanos,
         })
@@ -167,7 +167,7 @@ fn send_message_with_transfer_to_group_succeeds(with_c2c_error: bool, icrc2: boo
             fee,
             token_symbol: ICP_SYMBOL.to_string(),
             amount,
-            to: user2.user_id.into(),
+            to: types::icrc1::Account::for_user(user2.user_id),
             memo: None,
             created: now_nanos,
         })
@@ -180,7 +180,7 @@ fn send_message_with_transfer_to_group_succeeds(with_c2c_error: bool, icrc2: boo
     let send_message_result = client::user::send_message_with_transfer_to_group(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_with_transfer_to_group::Args {
             group_id,
             thread_root_message_index: None,

--- a/backend/integration_tests/src/send_direct_message_tests.rs
+++ b/backend/integration_tests/src/send_direct_message_tests.rs
@@ -96,12 +96,12 @@ fn send_message_retries_if_fails() {
     let user1 = client::register_user(env, canister_ids);
     let user2 = client::register_user(env, canister_ids);
 
-    stop_canister(env, user2.local_user_index, user2.user_id.into());
+    stop_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     let send_message_result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, "TEXT", None);
     tick_many(env, 3);
 
-    start_canister(env, user2.local_user_index, user2.user_id.into());
+    start_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     env.advance_time(Duration::from_secs(10));
     tick_many(env, 3);
@@ -121,12 +121,12 @@ fn messages_arrive_in_order_even_if_some_fail_originally() {
     let user1 = client::register_user(env, canister_ids);
     let user2 = client::register_user(env, canister_ids);
 
-    stop_canister(env, user2.local_user_index, user2.user_id.into());
+    stop_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     client::user::happy_path::send_text_message(env, &user1, user2.user_id, "1", None);
     client::user::happy_path::send_text_message(env, &user1, user2.user_id, "2", None);
 
-    start_canister(env, user2.local_user_index, user2.user_id.into());
+    start_canister(env, user2.local_user_index, user2.user_id.canister_id());
 
     client::user::happy_path::send_text_message(env, &user1, user2.user_id, "3", None);
 

--- a/backend/integration_tests/src/set_message_reminder_tests.rs
+++ b/backend/integration_tests/src/set_message_reminder_tests.rs
@@ -29,7 +29,7 @@ fn set_message_reminder_succeeds() {
     client::user::set_message_reminder_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::set_message_reminder_v2::Args {
             chat: Chat::Direct(user2.user_id.into()),
             thread_root_message_index: None,
@@ -97,7 +97,7 @@ fn cancel_message_reminder_succeeds() {
     let set_message_reminder_response = client::user::set_message_reminder_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::set_message_reminder_v2::Args {
             chat: Chat::Direct(user2.user_id.into()),
             thread_root_message_index: None,
@@ -115,7 +115,7 @@ fn cancel_message_reminder_succeeds() {
     client::user::cancel_message_reminder(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::cancel_message_reminder::Args { reminder_id },
     );
 

--- a/backend/integration_tests/src/suspend_user_tests.rs
+++ b/backend/integration_tests/src/suspend_user_tests.rs
@@ -48,7 +48,7 @@ fn suspend_user() {
     let direct_message_response1 = client::user::send_message_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_v2::Args {
             recipient: user2.user_id,
             thread_root_message_index: None,
@@ -134,7 +134,7 @@ fn suspend_user() {
     let direct_message_response2 = client::user::send_message_v2(
         env,
         user1.principal,
-        user1.user_id.into(),
+        user1.user_id.canister_id(),
         &user_canister::send_message_v2::Args {
             recipient: user2.user_id,
             thread_root_message_index: None,

--- a/backend/integration_tests/src/webhook_tests.rs
+++ b/backend/integration_tests/src/webhook_tests.rs
@@ -132,24 +132,14 @@ fn post_message_to_webhook(
     let (domain, url) = match chat {
         Chat::Group(group_id) => {
             let domain = format!("{group_id}.localhost");
-            let url = format!(
-                "http://{}:{}/webhook/{}/{}",
-                domain,
-                port,
-                webhook_id.to_text(),
-                webhook_secret
-            );
+            let url = format!("http://{}:{}/webhook/{}/{}", domain, port, webhook_id, webhook_secret);
             (domain, url)
         }
         Chat::Channel(community_id, channel_id) => {
             let domain = format!("{community_id}.localhost");
             let url = format!(
                 "http://{}:{}/channel/{}/webhook/{}/{}",
-                domain,
-                port,
-                channel_id,
-                webhook_id.to_text(),
-                webhook_secret
+                domain, port, channel_id, webhook_id, webhook_secret
             );
             (domain, url)
         }

--- a/backend/libraries/chat_events/src/message_content_internal.rs
+++ b/backend/libraries/chat_events/src/message_content_internal.rs
@@ -1719,11 +1719,13 @@ impl MessageContentInternalSubtype for PrizeWinnerContentInternal {
                     subaccount: None,
                 }
                 .into(),
-                to: types::icrc1::Account {
-                    owner: my_user_id.map(|u| u.into()).unwrap_or(Principal::anonymous()),
-                    subaccount: None,
-                }
-                .into(),
+                to: my_user_id
+                    .map(types::icrc1::Account::for_user)
+                    .unwrap_or(types::icrc1::Account {
+                        owner: Principal::anonymous(),
+                        subaccount: None,
+                    })
+                    .into(),
                 fee: self.fee,
                 memo: None,
                 created: 0,

--- a/backend/libraries/constants/src/lib.rs
+++ b/backend/libraries/constants/src/lib.rs
@@ -96,6 +96,17 @@ mod tests {
         );
     }
 
+    // A UserId whose final byte is tagged is read as carrying an index into a shared canister. No
+    // sentinel may look like one, else it would resolve to the wrong canister and to a non-zero
+    // index.
+    #[test]
+    fn sentinel_user_ids_are_not_indexed() {
+        for user_id in [OPENCHAT_BOT_USER_ID, DELETED_USER_ID] {
+            assert_eq!(user_id.index(), 0, "{user_id}");
+            assert_eq!(user_id.canister_id(), user_id.as_principal(), "{user_id}");
+        }
+    }
+
     #[test]
     fn sns_root_canister_id() {
         assert_eq!(

--- a/backend/libraries/gated_groups/src/lib.rs
+++ b/backend/libraries/gated_groups/src/lib.rs
@@ -312,7 +312,7 @@ async fn check_sns_neuron_gate(gate: &SnsNeuronGate, user_id: UserId) -> CheckIf
     let args = sns_governance_canister::list_neurons::Args {
         limit: 10,
         start_page_at: None,
-        of_principal: Some(Principal::from(user_id)),
+        of_principal: Some(user_id.as_principal()),
     };
 
     match sns_governance_canister_c2c_client::list_neurons(gate.governance_canister_id, &args).await {
@@ -353,11 +353,10 @@ async fn try_transfer_from(
     this_canister_id: CanisterId,
     now: TimestampMillis,
 ) -> CheckIfPassesGateResult {
-    let from: Principal = user_id.into();
     let amount = gate.amount - 2 * gate.fee;
     let transfer_args = TransferFromArgs {
         spender_subaccount: None,
-        from: from.into(),
+        from: user_id.into(),
         to: this_canister_id.into(),
         // The amount the gate amount less the approval fee and the transfer_from fee
         amount: amount.into(),

--- a/backend/libraries/ledger_utils/src/lib.rs
+++ b/backend/libraries/ledger_utils/src/lib.rs
@@ -23,7 +23,7 @@ pub fn create_pending_transaction(
         fee,
         token_symbol: token_symbol.clone(),
         amount,
-        to: user_id.into(),
+        to: types::icrc1::Account::for_user(user_id),
         memo: memo.map(|bytes| bytes.to_vec().into()),
         created: now_nanos,
     })

--- a/backend/libraries/ledger_utils/src/nns.rs
+++ b/backend/libraries/ledger_utils/src/nns.rs
@@ -12,7 +12,7 @@ pub async fn process_transaction(
 
     let from = default_ledger_account(sender);
     let to = match transaction.to {
-        types::nns::UserOrAccount::User(u) => default_ledger_account(u.into()),
+        types::nns::UserOrAccount::User(u) => u.into(),
         types::nns::UserOrAccount::Account(a) => a,
     };
 

--- a/backend/libraries/types/src/chat_id.rs
+++ b/backend/libraries/types/src/chat_id.rs
@@ -23,7 +23,9 @@ impl From<ChatId> for CanisterId {
 
 impl From<UserId> for ChatId {
     fn from(user_id: UserId) -> Self {
-        Principal::from(user_id).into()
+        // The id itself, not `user_id.canister_id()` - this has to round trip back to the same
+        // user, and many users can share a canister.
+        ChatId(user_id.0)
     }
 }
 

--- a/backend/libraries/types/src/community_id.rs
+++ b/backend/libraries/types/src/community_id.rs
@@ -22,7 +22,9 @@ impl From<CommunityId> for CanisterId {
 
 impl From<UserId> for CommunityId {
     fn from(user_id: UserId) -> Self {
-        Principal::from(user_id).into()
+        // The id itself, not `user_id.canister_id()` - this has to round trip back to the same
+        // user, and many users can share a canister.
+        CommunityId(user_id.0)
     }
 }
 

--- a/backend/libraries/types/src/cryptocurrency.rs
+++ b/backend/libraries/types/src/cryptocurrency.rs
@@ -3,6 +3,7 @@ use crate::nns::{Tokens, UserOrAccount};
 use crate::{CanisterId, TimestampNanos, UserId};
 use candid::{CandidType, Principal};
 use ic_ledger_types::{AccountIdentifier, Subaccount};
+use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Deserializer, Serialize};
 use ts_export::ts_export;
 
@@ -182,15 +183,16 @@ impl PendingCryptoTransaction {
     }
 
     pub fn validate_recipient(&self, recipient: UserId) -> bool {
+        // The whole account, not just the owner. Once a canister holds many users the owner alone
+        // is satisfied by a transfer destined for any of them.
+        let account = Account::from(recipient);
         match self {
             PendingCryptoTransaction::NNS(t) => match t.to {
-                UserOrAccount::Account(a) => {
-                    a == AccountIdentifier::new(&recipient.into(), &ic_ledger_types::DEFAULT_SUBACCOUNT)
-                }
+                UserOrAccount::Account(a) => a == AccountIdentifier::from(recipient),
                 UserOrAccount::User(u) => u == recipient,
             },
-            PendingCryptoTransaction::ICRC1(t) => t.to.owner == recipient.into(),
-            PendingCryptoTransaction::ICRC2(t) => t.to.owner == recipient.into(),
+            PendingCryptoTransaction::ICRC1(t) => Account::from(t.to) == account,
+            PendingCryptoTransaction::ICRC2(t) => Account::from(t.to) == account,
         }
     }
 
@@ -554,6 +556,18 @@ pub mod icrc1 {
             Account {
                 owner: value.into(),
                 subaccount: None,
+            }
+        }
+    }
+
+    impl Account {
+        // A user's account. Note the owner is the canister holding the user's data, which is not
+        // the same as the UserId once a canister holds more than one user.
+        pub fn for_user(user_id: UserId) -> Account {
+            let account = icrc_ledger_types::icrc1::account::Account::from(user_id);
+            Account {
+                owner: account.owner,
+                subaccount: account.subaccount,
             }
         }
     }

--- a/backend/libraries/types/src/user.rs
+++ b/backend/libraries/types/src/user.rs
@@ -1,18 +1,87 @@
 use crate::CanisterId;
 use candid::{CandidType, Principal};
+use ic_ledger_types::{AccountIdentifier, Subaccount};
 use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
-use std::ops::Deref;
 use ts_export::ts_export;
 
 #[ts_export]
 #[derive(CandidType, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UserId(CanisterId);
+pub struct UserId(pub(crate) CanisterId);
+
+// Canister ids are a big-endian u64 followed by the IC's canister and opaque class tags, so they
+// are always exactly this long.
+const CANISTER_ID_LEN: usize = 10;
+// Set in the final byte to mark a UserId as carrying an index. The final byte of a well-formed
+// principal is its class tag, and every class tag the IC defines is in 0x01..=0x04, so a byte with
+// the top bit set cannot be one. That leaves the low 7 bits of this byte, plus all 8 bits of the
+// byte before it, to hold the index.
+const INDEXED_TAG: u8 = 0x80;
+pub const MAX_USER_INDEX: u16 = (1 << 15) - 1;
 
 impl UserId {
     pub const fn new(canister_id: CanisterId) -> UserId {
         UserId(canister_id)
+    }
+
+    // A user whose data is held alongside other users' in a single canister is identified by that
+    // canister's leading u64 followed by the user's index within it, the index taking the place of
+    // the canister id's two trailing tag bytes. The result is deliberately not a well-formed
+    // principal, which is exactly what tells it apart from a canister id - see `is_indexed`.
+    pub fn new_indexed(canister_id: CanisterId, index: u16) -> UserId {
+        let bytes = canister_id.as_slice();
+        assert_eq!(bytes.len(), CANISTER_ID_LEN, "Not a canister id: {canister_id}");
+        assert!(index <= MAX_USER_INDEX, "Index {index} is out of range");
+
+        let mut new_bytes = [0; CANISTER_ID_LEN];
+        new_bytes[..8].copy_from_slice(&bytes[..8]);
+        new_bytes[8] = index as u8;
+        new_bytes[9] = INDEXED_TAG | (index >> 8) as u8;
+        UserId(Principal::from_slice(&new_bytes))
+    }
+
+    // The id's own bytes, ie. the user's identity as it goes over the wire. Only equal to the
+    // holding canister's id when that canister holds this user alone, so never use this to address
+    // a canister - `canister_id` does that.
+    pub fn as_principal(&self) -> Principal {
+        self.0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    // The canister which holds this user's data.
+    pub fn canister_id(&self) -> CanisterId {
+        if self.is_indexed() {
+            // Rebuilding the canister id means restoring the two tag bytes the index displaced.
+            let mut bytes = [0x01; CANISTER_ID_LEN];
+            bytes[..8].copy_from_slice(&self.0.as_slice()[..8]);
+            Principal::from_slice(&bytes)
+        } else {
+            self.0
+        }
+    }
+
+    // The user's index within the canister which holds their data. Zero when that canister holds
+    // this user alone.
+    pub fn index(&self) -> u16 {
+        if self.is_indexed() {
+            let bytes = self.0.as_slice();
+            u16::from(bytes[8]) | (u16::from(bytes[9] & !INDEXED_TAG) << 8)
+        } else {
+            0
+        }
+    }
+
+    // A UserId carries an index iff it is canister id length and its final byte is tagged. Every
+    // canister id ends in the opaque class tag, and so do the vanity principals behind
+    // `OPENCHAT_BOT_USER_ID` and `DELETED_USER_ID`; bot and webhook ids are 8 bytes. So all of
+    // those read back as index 0, which is what keeps this backwards compatible.
+    fn is_indexed(&self) -> bool {
+        let bytes = self.0.as_slice();
+        bytes.len() == CANISTER_ID_LEN && bytes[CANISTER_ID_LEN - 1] & INDEXED_TAG != 0
     }
 }
 
@@ -22,18 +91,30 @@ impl From<Principal> for UserId {
     }
 }
 
-impl From<UserId> for CanisterId {
-    fn from(user_id: UserId) -> Self {
-        user_id.0
+impl From<UserId> for Account {
+    fn from(value: UserId) -> Self {
+        // Index 0 must map to the default subaccount, else every existing user's wallet address
+        // would change. Note the owner is the holding canister, never the UserId itself - nobody
+        // can sign for an indexed UserId, so tokens sent there would be unrecoverable.
+        let subaccount = value.index().to_be_bytes();
+        Account {
+            owner: value.canister_id(),
+            subaccount: (subaccount != [0; 2]).then(|| {
+                let mut bytes = [0; 32];
+                bytes[30..].copy_from_slice(&subaccount);
+                bytes
+            }),
+        }
     }
 }
 
-impl From<UserId> for Account {
+impl From<UserId> for AccountIdentifier {
     fn from(value: UserId) -> Self {
-        Account {
-            owner: Principal::from(value),
-            subaccount: None,
-        }
+        let account = Account::from(value);
+        AccountIdentifier::new(
+            &account.owner,
+            &account.subaccount.map_or(ic_ledger_types::DEFAULT_SUBACCOUNT, Subaccount),
+        )
     }
 }
 
@@ -46,14 +127,6 @@ impl Debug for UserId {
 impl Display for UserId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl Deref for UserId {
-    type Target = Principal;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -96,5 +169,96 @@ impl UserType {
 
     pub fn is_3rd_party_bot(&self) -> bool {
         matches!(self, UserType::BotV2 | UserType::Bot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn canister_id() -> CanisterId {
+        CanisterId::from_text("dfdal-2uaaa-aaaaa-qaama-cai").unwrap()
+    }
+
+    #[test]
+    fn canister_id_reads_back_as_index_zero() {
+        let user_id = UserId::new(canister_id());
+
+        assert_eq!(user_id.canister_id(), canister_id());
+        assert_eq!(user_id.index(), 0);
+    }
+
+    // Bot and webhook ids are 8 random bytes, so most of them do not end in the opaque tag. Only
+    // the length check stops them being read as indexed.
+    #[test]
+    fn bot_style_user_id_reads_back_as_index_zero() {
+        for last_byte in [0, 1, 42, 255] {
+            let user_id = UserId::from(Principal::from_slice(&[9, 8, 7, 6, 5, 4, 3, last_byte]));
+
+            assert_eq!(user_id.index(), 0, "last byte {last_byte}");
+            assert_eq!(
+                user_id.canister_id(),
+                Principal::from_slice(&[9, 8, 7, 6, 5, 4, 3, last_byte])
+            );
+        }
+    }
+
+    // These are the byte patterns behind `OPENCHAT_BOT_USER_ID` and `DELETED_USER_ID`. They are
+    // vanity principals whose 9th byte is not the usual 0x01, which is why the trailing pair
+    // cannot be used to tell an indexed UserId from a canister id.
+    #[test]
+    fn vanity_user_ids_read_back_as_index_zero() {
+        for bytes in [
+            [228, 104, 142, 9, 133, 211, 135, 217, 129, 1],
+            [139, 36, 200, 58, 72, 145, 241, 66, 97, 1],
+        ] {
+            let user_id = UserId::from(Principal::from_slice(&bytes));
+
+            assert_eq!(user_id.index(), 0, "{bytes:?}");
+            assert_eq!(user_id.canister_id(), Principal::from_slice(&bytes));
+        }
+    }
+
+    #[test]
+    fn indexed_user_id_round_trips() {
+        for index in [1, 2, 255, 256, 257, 1000, 1024, MAX_USER_INDEX] {
+            let user_id = UserId::new_indexed(canister_id(), index);
+
+            assert_eq!(user_id.canister_id(), canister_id(), "index {index}");
+            assert_eq!(user_id.index(), index);
+            assert_ne!(user_id, UserId::new(canister_id()));
+        }
+    }
+
+    #[test]
+    fn indexed_user_ids_are_unique_across_canisters() {
+        let other = CanisterId::from_text("2ouva-viaaa-aaaaq-aaamq-cai").unwrap();
+
+        assert_ne!(UserId::new_indexed(canister_id(), 1000), UserId::new_indexed(other, 1000));
+    }
+
+    // Only 15 bits are available, the 16th being the tag which marks the id as indexed.
+    #[test]
+    #[should_panic(expected = "Index 32768 is out of range")]
+    fn index_beyond_the_available_bits_is_rejected() {
+        UserId::new_indexed(canister_id(), MAX_USER_INDEX + 1);
+    }
+
+    #[test]
+    fn account_for_unindexed_user_is_unchanged() {
+        let account = Account::from(UserId::new(canister_id()));
+
+        assert_eq!(account.owner, canister_id());
+        assert_eq!(account.subaccount, None);
+    }
+
+    #[test]
+    fn account_for_indexed_user_is_a_subaccount_of_the_holding_canister() {
+        let account = Account::from(UserId::new_indexed(canister_id(), 1000));
+
+        assert_eq!(account.owner, canister_id());
+        let mut expected = [0; 32];
+        expected[30..].copy_from_slice(&1000u16.to_be_bytes());
+        assert_eq!(account.subaccount, Some(expected));
     }
 }

--- a/backend/libraries/types/src/user.rs
+++ b/backend/libraries/types/src/user.rs
@@ -8,7 +8,7 @@ use ts_export::ts_export;
 
 #[ts_export]
 #[derive(CandidType, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UserId(pub(crate) CanisterId);
+pub struct UserId(pub(crate) Principal);
 
 // Canister ids are a big-endian u64 followed by the IC's canister and opaque class tags, so they
 // are always exactly this long.
@@ -21,8 +21,11 @@ const INDEXED_TAG: u8 = 0x80;
 pub const MAX_USER_INDEX: u16 = (1 << 15) - 1;
 
 impl UserId {
-    pub const fn new(canister_id: CanisterId) -> UserId {
-        UserId(canister_id)
+    // The id of a user who is not held alongside others - a canister id where that canister holds
+    // the user alone, and otherwise whatever principal identifies them, eg. a bot or a webhook.
+    // Use `new_indexed` for a user sharing a canister.
+    pub const fn new(principal: Principal) -> UserId {
+        UserId(principal)
     }
 
     // A user whose data is held alongside other users' in a single canister is identified by that

--- a/backend/libraries/types/src/user.rs
+++ b/backend/libraries/types/src/user.rs
@@ -11,8 +11,9 @@ use ts_export::ts_export;
 pub struct UserId(pub(crate) Principal);
 
 // Canister ids are a big-endian u64 followed by the IC's canister and opaque class tags, so they
-// are always exactly this long.
+// are always exactly this long, and always end in exactly these two bytes.
 const CANISTER_ID_LEN: usize = 10;
+const CANISTER_ID_TAG: [u8; 2] = [0x01, 0x01];
 // Set in the final byte to mark a UserId as carrying an index. The final byte of a well-formed
 // principal is its class tag, and every class tag the IC defines is in 0x01..=0x04, so a byte with
 // the top bit set cannot be one. That leaves the low 7 bits of this byte, plus all 8 bits of the
@@ -33,8 +34,14 @@ impl UserId {
     // the canister id's two trailing tag bytes. The result is deliberately not a well-formed
     // principal, which is exactly what tells it apart from a canister id - see `is_indexed`.
     pub fn new_indexed(canister_id: CanisterId, index: u16) -> UserId {
+        // Both the length and the trailing tag bytes, because `canister_id` rebuilds the latter
+        // from scratch. Anything else 10 bytes long - a vanity principal, say - would pass a length
+        // check and then reconstruct as some other canister entirely.
         let bytes = canister_id.as_slice();
-        assert_eq!(bytes.len(), CANISTER_ID_LEN, "Not a canister id: {canister_id}");
+        assert!(
+            bytes.len() == CANISTER_ID_LEN && bytes[8..] == CANISTER_ID_TAG,
+            "Not a canister id: {canister_id}"
+        );
         assert!(index <= MAX_USER_INDEX, "Index {index} is out of range");
 
         let mut new_bytes = [0; CANISTER_ID_LEN];
@@ -59,8 +66,9 @@ impl UserId {
     pub fn canister_id(&self) -> CanisterId {
         if self.is_indexed() {
             // Rebuilding the canister id means restoring the two tag bytes the index displaced.
-            let mut bytes = [0x01; CANISTER_ID_LEN];
+            let mut bytes = [0; CANISTER_ID_LEN];
             bytes[..8].copy_from_slice(&self.0.as_slice()[..8]);
+            bytes[8..].copy_from_slice(&CANISTER_ID_TAG);
             Principal::from_slice(&bytes)
         } else {
             self.0
@@ -245,6 +253,14 @@ mod tests {
     #[should_panic(expected = "Index 32768 is out of range")]
     fn index_beyond_the_available_bits_is_rejected() {
         UserId::new_indexed(canister_id(), MAX_USER_INDEX + 1);
+    }
+
+    // The `OPENCHAT_BOT_USER_ID` bytes: canister id length, but not a canister id, so
+    // `canister_id` would have reconstructed a different principal from it.
+    #[test]
+    #[should_panic(expected = "Not a canister id")]
+    fn vanity_principal_of_canister_id_length_is_rejected() {
+        UserId::new_indexed(Principal::from_slice(&[228, 104, 142, 9, 133, 211, 135, 217, 129, 1]), 1000);
     }
 
     #[test]


### PR DESCRIPTION
Groundwork for the MultiUser canister. A `UserId` can now name both the canister holding a user's data *and* which user it is within that canister, so a single canister can hold many users without changing the wire format.

## The encoding

Canister ids are a big-endian `u64` followed by the two class tag bytes `0x01 0x01`, so an indexed `UserId` puts the index where those tag bytes sit:

```
bytes[0..8] = canister's leading u64
bytes[8]    = index low byte
bytes[9]    = 0x80 | index high 7 bits
```

The final byte of a well-formed principal is its class tag, and every class tag the IC defines is in `0x01..=0x04`. Setting its top bit therefore cannot collide with a real principal, which makes the discriminator a genuine IC invariant rather than a convention. That leaves 15 bits of index — up to 32768 users per canister — with **no reserved index values**. (A raw `u16` index would have left 256 scattered holes: index 1, 257, 513… all end in `0x01` and would read straight back as a canister id.)

Everything that exists today reads back as index 0, which is what makes this backwards compatible:

- canister ids end in the opaque tag
- so do the `OPENCHAT_BOT_USER_ID` and `DELETED_USER_ID` vanity principals — these are why the trailing `0x01 0x01` *pair* can't be the discriminator, since their 9th byte is `0x81`/`0x61`
- bot and webhook ids are 8 bytes, so the length gate excludes them

The Candid type is unchanged — a `UserId` is still `principal` on the wire, and `validate-candid-matches-rust.sh` passes.

## Identity vs. location

Deleting `Deref` and `From<UserId> for CanisterId` forces every caller to say which one it means, now that they're no longer the same thing. 165 sites, each classified by hand:

- **`canister_id()`** — c2c calls, cycle top-ups, canister upgrades, anything addressing a canister
- **`as_principal()`** — `user_id_or_principal` lookups, membership checks, stable memory keys, escrow deposit subaccounts, SNS neuron hotkeys
- **`From<UserId> for Account` / `for AccountIdentifier`** — ledger destinations. Index 0 maps to the default subaccount, so no existing wallet address moves.

## A hole this surfaced

`validate_recipient` compared only the account *owner*, so under a shared canister a transfer to any user in that canister would have validated as being to a specific recipient. It now compares the whole account.

This is a tightening: it rejects a transfer to a non-default subaccount of the recipient, which was previously accepted. Safe because the frontend always sends `subaccount: undefined` for crypto-message recipients (`principalToIcrcAccount` in `chatMappersV2.ts`).

## Not fixed here

Two MultiUser inconsistencies this refactor exposed. Both are no-ops today and resolving them changes wire behaviour, so they belong with the actual migration:

1. **Escrow identity split.** The user canister derives its deposit subaccount from the user's identity but calls `notify_deposit` with `deposited_by: None`, so escrow falls back to `state.env.caller()` — the canister. `swap.offered_by` (set from the `create_swap` caller) has the same problem.
2. **SNS neuron voting.** The gate check looks up neurons by the UserId-as-hotkey, which still works since it's just a stored principal. But voting calls `manage_neuron` as the *caller*, which under MultiUser is the shared canister — so every user in it could vote with each other's neurons.

## Testing

- `cargo check --workspace --all-targets` clean, clippy clean
- All unit tests pass, including new tests pinning the encoding, the round trip, and that no sentinel `UserId` reads as indexed
- Integration tests: **400 passed, 0 failed** against freshly built wasms

🤖 Generated with [Claude Code](https://claude.com/claude-code)