### PR TITLE
Take the user a transfer is for in ledger_utils rather than the sending canister

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 

--- a/backend/canisters/community/impl/src/timer_job_types.rs
+++ b/backend/canisters/community/impl/src/timer_job_types.rs
@@ -11,7 +11,6 @@ use group_chat_core::AddResult;
 use ledger_utils::process_transaction;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
-use types::icrc1::Account;
 use types::{BlobReference, ChannelId, ChatId, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, UserId};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -339,12 +338,11 @@ impl Job for FinalPrizePaymentsJob {
 
 impl Job for MakeTransferJob {
     fn execute(self) {
-        let sender = read_state(|state| Account::from(state.env.canister_id()));
         let pending = self.pending_transaction;
-        ic_cdk::futures::spawn_migratory(make_transfer(pending, sender, self.attempt));
+        ic_cdk::futures::spawn_migratory(make_transfer(pending, self.attempt));
 
-        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: Account, attempt: u32) {
-            if let Err(error) = process_transaction(pending_transaction.clone(), sender, true).await {
+        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, attempt: u32) {
+            if let Err(error) = process_transaction(pending_transaction.clone(), None, true).await {
                 error!(?error, "Transaction failed");
                 if attempt < 50 {
                     mutate_state(|state| {

--- a/backend/canisters/community/impl/src/timer_job_types.rs
+++ b/backend/canisters/community/impl/src/timer_job_types.rs
@@ -11,9 +11,8 @@ use group_chat_core::AddResult;
 use ledger_utils::process_transaction;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
-use types::{
-    BlobReference, CanisterId, ChannelId, ChatId, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, UserId,
-};
+use types::icrc1::Account;
+use types::{BlobReference, ChannelId, ChatId, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, UserId};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum TimerJob {
@@ -340,11 +339,11 @@ impl Job for FinalPrizePaymentsJob {
 
 impl Job for MakeTransferJob {
     fn execute(self) {
-        let sender = read_state(|state| state.env.canister_id());
+        let sender = read_state(|state| Account::from(state.env.canister_id()));
         let pending = self.pending_transaction;
         ic_cdk::futures::spawn_migratory(make_transfer(pending, sender, self.attempt));
 
-        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: CanisterId, attempt: u32) {
+        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: Account, attempt: u32) {
             if let Err(error) = process_transaction(pending_transaction.clone(), sender, true).await {
                 error!(?error, "Transaction failed");
                 if attempt < 50 {

--- a/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
@@ -10,7 +10,7 @@ use oc_error_codes::OCErrorCode;
 use rand::RngExt;
 use tracing::error;
 use types::{
-    CanisterId, CompletedCryptoTransaction, OCResult, PendingCryptoTransaction,
+    CompletedCryptoTransaction, OCResult, PendingCryptoTransaction,
     PrizeClaimResponse::{self, *},
     UserId,
 };
@@ -31,7 +31,7 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
     let prize_amount = prepare_result.transaction.units();
 
     // Transfer the prize to the winner
-    let result = process_transaction(prepare_result.transaction, prepare_result.this_canister_id.into(), true).await;
+    let result = process_transaction(prepare_result.transaction, None, true).await;
 
     match result {
         Ok(Ok(completed_transaction)) => {
@@ -59,7 +59,6 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
 
 struct PrepareResult {
     pub transaction: PendingCryptoTransaction,
-    pub this_canister_id: CanisterId,
     pub user_id: UserId,
 }
 
@@ -97,11 +96,7 @@ fn prepare(args: &Args, state: &mut RuntimeState) -> OCResult<PrepareResult> {
         transaction_time,
     );
 
-    Ok(PrepareResult {
-        this_canister_id: state.env.canister_id(),
-        transaction,
-        user_id,
-    })
+    Ok(PrepareResult { transaction, user_id })
 }
 
 fn commit(args: Args, winner: UserId, transaction: CompletedCryptoTransaction, state: &mut RuntimeState) -> Option<String> {

--- a/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
+++ b/backend/canisters/community/impl/src/updates/c2c_claim_prize.rs
@@ -31,7 +31,7 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
     let prize_amount = prepare_result.transaction.units();
 
     // Transfer the prize to the winner
-    let result = process_transaction(prepare_result.transaction, prepare_result.this_canister_id, true).await;
+    let result = process_transaction(prepare_result.transaction, prepare_result.this_canister_id.into(), true).await;
 
     match result {
         Ok(Ok(completed_transaction)) => {

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 

--- a/backend/canisters/group/impl/src/timer_job_types.rs
+++ b/backend/canisters/group/impl/src/timer_job_types.rs
@@ -9,9 +9,8 @@ use constants::{DAY_IN_MS, MINUTE_IN_MS, NANOS_PER_MILLISECOND, SECOND_IN_MS};
 use ledger_utils::process_transaction;
 use serde::{Deserialize, Serialize};
 use tracing::error;
-use types::{
-    BlobReference, CanisterId, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, TimestampMillis, UserId,
-};
+use types::icrc1::Account;
+use types::{BlobReference, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, TimestampMillis, UserId};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum TimerJob {
@@ -266,11 +265,11 @@ impl Job for FinalPrizePaymentsJob {
 
 impl Job for MakeTransferJob {
     fn execute(self) {
-        let sender = read_state(|state| state.env.canister_id());
+        let sender = read_state(|state| Account::from(state.env.canister_id()));
         let pending = self.pending_transaction.clone();
         ic_cdk::futures::spawn_migratory(make_transfer(pending, sender, self.attempt));
 
-        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: CanisterId, attempt: u32) {
+        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: Account, attempt: u32) {
             if let Err(error) = process_transaction(pending_transaction.clone(), sender, true).await {
                 error!(?error, "Transaction failed");
                 if attempt < 50 {

--- a/backend/canisters/group/impl/src/timer_job_types.rs
+++ b/backend/canisters/group/impl/src/timer_job_types.rs
@@ -9,7 +9,6 @@ use constants::{DAY_IN_MS, MINUTE_IN_MS, NANOS_PER_MILLISECOND, SECOND_IN_MS};
 use ledger_utils::process_transaction;
 use serde::{Deserialize, Serialize};
 use tracing::error;
-use types::icrc1::Account;
 use types::{BlobReference, MessageId, MessageIndex, P2PSwapStatus, PendingCryptoTransaction, TimestampMillis, UserId};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -265,12 +264,11 @@ impl Job for FinalPrizePaymentsJob {
 
 impl Job for MakeTransferJob {
     fn execute(self) {
-        let sender = read_state(|state| Account::from(state.env.canister_id()));
         let pending = self.pending_transaction.clone();
-        ic_cdk::futures::spawn_migratory(make_transfer(pending, sender, self.attempt));
+        ic_cdk::futures::spawn_migratory(make_transfer(pending, self.attempt));
 
-        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, sender: Account, attempt: u32) {
-            if let Err(error) = process_transaction(pending_transaction.clone(), sender, true).await {
+        async fn make_transfer(mut pending_transaction: PendingCryptoTransaction, attempt: u32) {
+            if let Err(error) = process_transaction(pending_transaction.clone(), None, true).await {
                 error!(?error, "Transaction failed");
                 if attempt < 50 {
                     mutate_state(|state| {

--- a/backend/canisters/group/impl/src/updates/c2c_claim_prize.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_claim_prize.rs
@@ -30,7 +30,7 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
     let prize_amount = prepare_result.transaction.units();
 
     // Transfer the prize to the winner
-    let result = process_transaction(prepare_result.transaction, prepare_result.group, true).await;
+    let result = process_transaction(prepare_result.transaction, prepare_result.group.into(), true).await;
 
     match result {
         Ok(Ok(completed_transaction)) => {

--- a/backend/canisters/group/impl/src/updates/c2c_claim_prize.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_claim_prize.rs
@@ -9,7 +9,7 @@ use ledger_utils::{create_pending_transaction, process_transaction};
 use oc_error_codes::OCErrorCode;
 use rand::RngExt;
 use types::{
-    CanisterId, CompletedCryptoTransaction, OCResult, PendingCryptoTransaction,
+    CompletedCryptoTransaction, OCResult, PendingCryptoTransaction,
     PrizeClaimResponse::{self, *},
     UserId,
 };
@@ -30,7 +30,7 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
     let prize_amount = prepare_result.transaction.units();
 
     // Transfer the prize to the winner
-    let result = process_transaction(prepare_result.transaction, prepare_result.group.into(), true).await;
+    let result = process_transaction(prepare_result.transaction, None, true).await;
 
     match result {
         Ok(Ok(completed_transaction)) => {
@@ -57,7 +57,6 @@ async fn c2c_claim_prize_impl(args: Args) -> PrizeClaimResponse {
 
 struct PrepareResult {
     pub transaction: PendingCryptoTransaction,
-    pub group: CanisterId,
     pub user_id: UserId,
 }
 
@@ -94,7 +93,6 @@ fn prepare(args: &Args, state: &mut RuntimeState) -> OCResult<PrepareResult> {
     );
 
     Ok(PrepareResult {
-        group: state.env.canister_id(),
         transaction,
         user_id: args.user_id,
     })

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 
 ### Fixed
 

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ### Fixed
 

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ### Fixed
 

--- a/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
+++ b/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
@@ -55,7 +55,7 @@ async fn submit_proposal_impl(args: Args) -> Response {
         Err(error) => return InternalError(format!("Failed to lookup user: {error:?}")),
     };
 
-    match process_transaction(args.transaction.clone(), this_canister_id).await {
+    match process_transaction(args.transaction.clone(), this_canister_id.into()).await {
         Ok(Ok(_)) => {}
         Ok(Err(error)) => return PaymentFailed(error.error_message),
         Err(error) => return InternalError(format!("{error:?}")),

--- a/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
+++ b/backend/canisters/proposals_bot/impl/src/updates/submit_proposal.rs
@@ -40,7 +40,6 @@ async fn submit_proposal(args: Args) -> Response {
 async fn submit_proposal_impl(args: Args) -> Response {
     let PrepareResult {
         caller,
-        this_canister_id,
         user_index_canister_id,
         neuron_id,
         chat,
@@ -55,7 +54,7 @@ async fn submit_proposal_impl(args: Args) -> Response {
         Err(error) => return InternalError(format!("Failed to lookup user: {error:?}")),
     };
 
-    match process_transaction(args.transaction.clone(), this_canister_id.into()).await {
+    match process_transaction(args.transaction.clone(), None).await {
         Ok(Ok(_)) => {}
         Ok(Err(error)) => return PaymentFailed(error.error_message),
         Err(error) => return InternalError(format!("{error:?}")),
@@ -80,7 +79,6 @@ async fn submit_proposal_impl(args: Args) -> Response {
 
 struct PrepareResult {
     caller: Principal,
-    this_canister_id: CanisterId,
     user_index_canister_id: CanisterId,
     neuron_id: SnsNeuronId,
     chat: MultiUserChat,
@@ -99,7 +97,6 @@ fn prepare(
     ) {
         Ok(neuron_id) => Ok(PrepareResult {
             caller: state.env.caller(),
-            this_canister_id: state.env.canister_id(),
             user_index_canister_id: state.data.user_index_canister_id,
             neuron_id,
             chat: state.data.nervous_systems.get_chat_id(&governance_canister_id).unwrap(),

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Take the sender's full account rather than only its canister id when processing a transfer, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/crypto.rs
+++ b/backend/canisters/user/impl/src/crypto.rs
@@ -1,5 +1,4 @@
 use crate::read_state;
-use types::icrc1::Account;
 use types::{C2CError, CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction, UserId};
 
 pub async fn process_transaction(
@@ -31,5 +30,5 @@ async fn process_transaction_internal(
         UserId::from(state.env.canister_id())
     });
 
-    ledger_utils::process_transaction(transaction, Account::for_user(my_user_id), false).await
+    ledger_utils::process_transaction(transaction, Some(my_user_id), false).await
 }

--- a/backend/canisters/user/impl/src/crypto.rs
+++ b/backend/canisters/user/impl/src/crypto.rs
@@ -1,4 +1,5 @@
 use crate::read_state;
+use types::icrc1::Account;
 use types::{C2CError, CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction, UserId};
 
 pub async fn process_transaction(
@@ -30,5 +31,5 @@ async fn process_transaction_internal(
         UserId::from(state.env.canister_id())
     });
 
-    ledger_utils::process_transaction(transaction, my_user_id.canister_id(), false).await
+    ledger_utils::process_transaction(transaction, Account::for_user(my_user_id), false).await
 }

--- a/backend/libraries/ledger_utils/src/icrc1.rs
+++ b/backend/libraries/ledger_utils/src/icrc1.rs
@@ -9,13 +9,13 @@ use types::{
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    sender: CanisterId,
+    sender: Account,
     retry_if_bad_fee: bool,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
-    let from = Account::from(sender);
-
     let args = TransferArg {
-        from_subaccount: None,
+        // The ledger takes the owner from the caller, so the subaccount is the only part of
+        // `sender` it lets us choose.
+        from_subaccount: sender.subaccount,
         to: transaction.to.into(),
         fee: Some(transaction.fee.into()),
         created_at_time: Some(transaction.created),
@@ -30,7 +30,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            from: from.into(),
+            from: sender.into(),
             to: transaction.to.into(),
             memo: transaction.memo.clone(),
             created: transaction.created,
@@ -41,7 +41,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            from: from.into(),
+            from: sender.into(),
             to: transaction.to.into(),
             memo: transaction.memo,
             created: transaction.created,

--- a/backend/libraries/ledger_utils/src/icrc1.rs
+++ b/backend/libraries/ledger_utils/src/icrc1.rs
@@ -3,19 +3,20 @@ use icrc_ledger_types::icrc1::transfer::TransferError;
 use tracing::error;
 use types::icrc1::Account;
 use types::{
-    C2CError, CanisterId,
+    C2CError, CanisterId, UserId,
     icrc1::{CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction},
 };
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    sender: Account,
+    sender: Option<UserId>,
     retry_if_bad_fee: bool,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
+    let from = Account::for_user(crate::resolve_sender(sender));
+
     let args = TransferArg {
-        // The ledger takes the owner from the caller, so the subaccount is the only part of
-        // `sender` it lets us choose.
-        from_subaccount: sender.subaccount,
+        // The owner is implied by the caller, so only the subaccount goes in the args.
+        from_subaccount: from.subaccount,
         to: transaction.to.into(),
         fee: Some(transaction.fee.into()),
         created_at_time: Some(transaction.created),
@@ -30,7 +31,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            from: sender.into(),
+            from: from.into(),
             to: transaction.to.into(),
             memo: transaction.memo.clone(),
             created: transaction.created,
@@ -41,7 +42,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            from: sender.into(),
+            from: from.into(),
             to: transaction.to.into(),
             memo: transaction.memo,
             created: transaction.created,

--- a/backend/libraries/ledger_utils/src/icrc2.rs
+++ b/backend/libraries/ledger_utils/src/icrc2.rs
@@ -8,18 +8,15 @@ use types::{
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    spender: Account,
+    spender: Option<UserId>,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
-    // The recorded spender is a UserId, which cannot carry an arbitrary subaccount, so it holds the
-    // owner alone. Nothing is lost today because every caller spends from its default subaccount.
-    let spender_user_id = UserId::from(spender.owner);
+    let spender = crate::resolve_sender(spender);
 
     let args = TransferFromArgs {
-        // The ledger takes the spender's owner from the caller, so the subaccount is the only part
-        // of `spender` it lets us choose. Note this picks which approval is spent - `icrc2_approve`
-        // grants to an exact (owner, subaccount) pair, so a non-default subaccount here can only
-        // spend an approval that named it.
-        spender_subaccount: spender.subaccount,
+        // The owner is implied by the caller, so only the subaccount goes in the args. Note this
+        // picks which approval is spent - `icrc2_approve` grants to an exact (owner, subaccount)
+        // pair, so a non-default subaccount here can only spend an approval that named it.
+        spender_subaccount: Account::for_user(spender).subaccount,
         from: transaction.from.into(),
         to: transaction.to.into(),
         fee: Some(transaction.fee.into()),
@@ -35,7 +32,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            spender: spender_user_id,
+            spender,
             from: transaction.from.into(),
             to: transaction.to.into(),
             memo: transaction.memo.clone(),
@@ -55,7 +52,7 @@ pub async fn process_transaction(
                 token_symbol: transaction.token_symbol,
                 amount: transaction.amount,
                 fee: transaction.fee,
-                spender: spender_user_id,
+                spender,
                 from: transaction.from.into(),
                 to: transaction.to.into(),
                 memo: transaction.memo,

--- a/backend/libraries/ledger_utils/src/icrc2.rs
+++ b/backend/libraries/ledger_utils/src/icrc2.rs
@@ -1,16 +1,25 @@
 use icrc_ledger_types::icrc2::transfer_from::TransferFromArgs;
 use tracing::error;
 use types::{
-    C2CError, CanisterId,
+    C2CError, UserId,
+    icrc1::Account,
     icrc2::{CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction},
 };
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    sender: CanisterId,
+    spender: Account,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
+    // The recorded spender is a UserId, which cannot carry an arbitrary subaccount, so it holds the
+    // owner alone. Nothing is lost today because every caller spends from its default subaccount.
+    let spender_user_id = UserId::from(spender.owner);
+
     let args = TransferFromArgs {
-        spender_subaccount: None,
+        // The ledger takes the spender's owner from the caller, so the subaccount is the only part
+        // of `spender` it lets us choose. Note this picks which approval is spent - `icrc2_approve`
+        // grants to an exact (owner, subaccount) pair, so a non-default subaccount here can only
+        // spend an approval that named it.
+        spender_subaccount: spender.subaccount,
         from: transaction.from.into(),
         to: transaction.to.into(),
         fee: Some(transaction.fee.into()),
@@ -26,7 +35,7 @@ pub async fn process_transaction(
             token_symbol: transaction.token_symbol,
             amount: transaction.amount,
             fee: transaction.fee,
-            spender: sender.into(),
+            spender: spender_user_id,
             from: transaction.from.into(),
             to: transaction.to.into(),
             memo: transaction.memo.clone(),
@@ -46,7 +55,7 @@ pub async fn process_transaction(
                 token_symbol: transaction.token_symbol,
                 amount: transaction.amount,
                 fee: transaction.fee,
-                spender: sender.into(),
+                spender: spender_user_id,
                 from: transaction.from.into(),
                 to: transaction.to.into(),
                 memo: transaction.memo,

--- a/backend/libraries/ledger_utils/src/lib.rs
+++ b/backend/libraries/ledger_utils/src/lib.rs
@@ -1,7 +1,6 @@
 use candid::Principal;
 use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Subaccount};
 use sha2::{Digest, Sha256};
-use types::icrc1::Account;
 use types::{
     C2CError, CanisterId, CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction, TimestampNanos, UserId,
 };
@@ -32,7 +31,7 @@ pub fn create_pending_transaction(
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    sender: Account,
+    sender: Option<UserId>,
     retry_if_bad_fee: bool,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
     match transaction {
@@ -47,6 +46,24 @@ pub async fn process_transaction(
             Ok(Err(c)) => Ok(Err(c.into())),
             Err(e) => Err(e),
         },
+    }
+}
+
+// The user this canister is transferring on behalf of, defaulting to the canister itself where
+// there isn't one. The owner is always this canister because the ledger takes it from the caller, so
+// resolving it here rather than accepting it as an argument means the recorded `from` cannot
+// disagree with where the funds actually moved.
+pub(crate) fn resolve_sender(sender: Option<UserId>) -> UserId {
+    let canister_id = ic_cdk::api::canister_self();
+
+    match sender {
+        // Transferring for a user held elsewhere would debit whichever of our own users shares their
+        // index, so refuse rather than move somebody else's funds.
+        Some(user_id) => {
+            assert_eq!(user_id.canister_id(), canister_id, "{user_id} is not held by this canister");
+            user_id
+        }
+        None => UserId::from(canister_id),
     }
 }
 

--- a/backend/libraries/ledger_utils/src/lib.rs
+++ b/backend/libraries/ledger_utils/src/lib.rs
@@ -1,6 +1,7 @@
 use candid::Principal;
 use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Subaccount};
 use sha2::{Digest, Sha256};
+use types::icrc1::Account;
 use types::{
     C2CError, CanisterId, CompletedCryptoTransaction, FailedCryptoTransaction, PendingCryptoTransaction, TimestampNanos, UserId,
 };
@@ -31,7 +32,7 @@ pub fn create_pending_transaction(
 
 pub async fn process_transaction(
     transaction: PendingCryptoTransaction,
-    sender: CanisterId,
+    sender: Account,
     retry_if_bad_fee: bool,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
     match transaction {

--- a/backend/libraries/ledger_utils/src/nns.rs
+++ b/backend/libraries/ledger_utils/src/nns.rs
@@ -1,16 +1,17 @@
-use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Memo, Subaccount, Timestamp, TransferArgs};
+use ic_ledger_types::{AccountIdentifier, Memo, Subaccount, Timestamp, TransferArgs};
 use types::icrc1::Account;
 use types::nns::Tokens;
-use types::{C2CError, CompletedCryptoTransaction, FailedCryptoTransaction};
+use types::{C2CError, CompletedCryptoTransaction, FailedCryptoTransaction, UserId};
 
 pub async fn process_transaction(
     transaction: types::nns::PendingCryptoTransaction,
-    sender: Account,
+    sender: Option<UserId>,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
+    let sender = crate::resolve_sender(sender);
     let memo = transaction.memo.unwrap_or_default();
     let fee = transaction.fee.unwrap_or(Tokens::DEFAULT_FEE);
 
-    let from = AccountIdentifier::new(&sender.owner, &sender.subaccount.map_or(DEFAULT_SUBACCOUNT, Subaccount));
+    let from = AccountIdentifier::from(sender);
     let to = match transaction.to {
         types::nns::UserOrAccount::User(u) => u.into(),
         types::nns::UserOrAccount::Account(a) => a,
@@ -20,9 +21,8 @@ pub async fn process_transaction(
         memo: Memo(memo),
         amount: transaction.amount.into(),
         fee: fee.into(),
-        // The ledger takes the owner from the caller, so the subaccount is the only part of
-        // `sender` it lets us choose.
-        from_subaccount: sender.subaccount.map(Subaccount),
+        // The owner is implied by the caller, so only the subaccount goes in the args.
+        from_subaccount: Account::for_user(sender).subaccount.map(Subaccount),
         to,
         created_at_time: Some(Timestamp {
             timestamp_nanos: transaction.created,

--- a/backend/libraries/ledger_utils/src/nns.rs
+++ b/backend/libraries/ledger_utils/src/nns.rs
@@ -1,16 +1,16 @@
-use crate::default_ledger_account;
-use ic_ledger_types::{Memo, Timestamp, TransferArgs};
+use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Memo, Subaccount, Timestamp, TransferArgs};
+use types::icrc1::Account;
 use types::nns::Tokens;
-use types::{C2CError, CanisterId, CompletedCryptoTransaction, FailedCryptoTransaction};
+use types::{C2CError, CompletedCryptoTransaction, FailedCryptoTransaction};
 
 pub async fn process_transaction(
     transaction: types::nns::PendingCryptoTransaction,
-    sender: CanisterId,
+    sender: Account,
 ) -> Result<Result<CompletedCryptoTransaction, FailedCryptoTransaction>, C2CError> {
     let memo = transaction.memo.unwrap_or_default();
     let fee = transaction.fee.unwrap_or(Tokens::DEFAULT_FEE);
 
-    let from = default_ledger_account(sender);
+    let from = AccountIdentifier::new(&sender.owner, &sender.subaccount.map_or(DEFAULT_SUBACCOUNT, Subaccount));
     let to = match transaction.to {
         types::nns::UserOrAccount::User(u) => u.into(),
         types::nns::UserOrAccount::Account(a) => a,
@@ -20,7 +20,9 @@ pub async fn process_transaction(
         memo: Memo(memo),
         amount: transaction.amount.into(),
         fee: fee.into(),
-        from_subaccount: None,
+        // The ledger takes the owner from the caller, so the subaccount is the only part of
+        // `sender` it lets us choose.
+        from_subaccount: sender.subaccount.map(Subaccount),
         to,
         created_at_time: Some(Timestamp {
             timestamp_nanos: transaction.created,


### PR DESCRIPTION
Stacked on #9259 — review that one first, and this PR's base should be retargeted to `master` once it merges.

`ledger_utils::process_transaction` hardcoded `from_subaccount: None` and took a `CanisterId`, so a transfer could only ever leave the calling canister's default account. Once a canister holds many users their funds live in per-user subaccounts, so the sender has to be able to name one.

### `Option<UserId>`

`None` means the canister itself. That matters because five of the six call sites have no user anywhere near them:

| call site | sender |
|---|---|
| `group/timer_job_types.rs` | the group canister |
| `group/c2c_claim_prize.rs` | the group canister |
| `community/timer_job_types.rs` | the community canister |
| `community/c2c_claim_prize.rs` | the community canister |
| `proposals_bot/submit_proposal.rs` | the proposals_bot canister |
| `user/crypto.rs` | **a user** |

A group paying out a prize is not a user, so making them all mint a `UserId` from their own canister id would be a lie that happens to compile. `None` says what's actually true.

The owner is never taken as an argument, because it was never the caller's to choose — the ledger derives it from the caller. Accepting one would let a caller write an owner the ledger ignores while `CompletedCryptoTransaction.from` reports it, so the record could disagree with where the funds actually moved. `resolve_sender` derives it from `ic_cdk::api::canister_self()` instead — the same fact the ledger uses, so the two cannot diverge. That is exactly what `CanisterEnv::canister_id()` already returns; it is a `LazyCell` over the same call.

### The assert is load-bearing

```rust
Some(user_id) => {
    assert_eq!(user_id.canister_id(), canister_id, "{user_id} is not held by this canister");
    user_id
}
```

A `UserId` held by a *different* canister would keep our own owner but contribute *their* index, so the transfer would debit whichever of our own users happens to share that index — silently moving the wrong user's funds. It traps instead.

### Knock-on simplifications

- ICRC-2 has a real `UserId` in hand, so `spender:` on the record carries the index rather than being flattened to the owner.
- The NNS path is back to `AccountIdentifier::from(sender)`, reusing the conversion in `types` instead of duplicating its body.
- Three canisters no longer need their own id at all: `PrepareResult` loses `group` and `this_canister_id` (×2), and both `MakeTransferJob::execute` impls lose a `read_state`.

### Not in scope

- The nine direct `from_subaccount: None` sites in the user canister that bypass `process_transaction` entirely (`accept_p2p_swap`, `c2c_accept_p2p_swap`, `swap_tokens` ×2, `approve_transfer`, `pay_for_streak_insurance`, `withdraw_btc` ×2, `c2c_charge_user_account`). `approve_transfer` is the awkward one — a per-user approval has to come *from* the user's subaccount.
- The `state.data.owner` check in `crypto.rs`, which still assumes one user per canister.
- Nothing yet tests that a non-zero subaccount reaches `from_subaccount`. `resolve_sender` is a pure function so it is unit-testable; the arg construction around it is not, without extracting it.

### Testing

Every call site resolves to the default subaccount today, so this is a no-op until the first indexed user exists. Clippy and fmt clean; unit tests pass. The crypto integration tests (`send_crypto`, `prize_message`, `tip_message`) — 27 of them — pass locally against freshly built wasms for the final `Option<UserId>` shape, confirming the no-op. They run in CI here too.

No API crate or `.did` file is touched, so the Candid interfaces are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

