### PR TITLE
Support leaving tips from external wallets using ICRC2

### DIFF
--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add optional `from_account` to `tip_message`, so a tip can be taken from an account OpenChat does not control ([#9263](https://github.com/open-chat-labs/open-chat/pull/9263))
+- Add optional `from_account` to `tip_message`, so a tip can be taken using ICRC2 from an account OpenChat does not control ([#9263](https://github.com/open-chat-labs/open-chat/pull/9263))
 
 ### Changed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add optional `from_account` to `tip_message`, so a tip can be taken using ICRC2 from an account OpenChat does not control ([#9263](https://github.com/open-chat-labs/open-chat/pull/9263))
+- Support leaving tips from external wallets using ICRC2 ([#9263](https://github.com/open-chat-labs/open-chat/pull/9263))
 
 ### Changed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Add optional `from_account` to `tip_message`, so a tip can be taken from an account OpenChat does not control ([#9263](https://github.com/open-chat-labs/open-chat/pull/9263))
+
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))

--- a/backend/canisters/user/api/src/updates/tip_message.rs
+++ b/backend/canisters/user/api/src/updates/tip_message.rs
@@ -15,7 +15,7 @@ pub struct Args {
     pub amount: u128,
     pub fee: u128,
     pub decimals: u8,
-    // The account to take the tip from, defaulting to this canister's own. Any other account must
+    // The account the tip is given from, defaulting to this canister's own. Any other account must
     // have approved this canister as spender, since the tip is then pulled via ICRC-2.
     pub from_account: Option<icrc1::Account>,
     pub pin: Option<PinNumberWrapper>,

--- a/backend/canisters/user/api/src/updates/tip_message.rs
+++ b/backend/canisters/user/api/src/updates/tip_message.rs
@@ -1,7 +1,7 @@
 use oc_error_codes::OCError;
 use serde::{Deserialize, Serialize};
 use ts_export::ts_export;
-use types::{CanisterId, Chat, MessageId, MessageIndex, PinNumberWrapper, UserId};
+use types::{CanisterId, Chat, MessageId, MessageIndex, PinNumberWrapper, UserId, icrc1};
 
 #[ts_export(user, tip_message)]
 #[derive(Serialize, Deserialize, Debug)]
@@ -15,6 +15,9 @@ pub struct Args {
     pub amount: u128,
     pub fee: u128,
     pub decimals: u8,
+    // The account to take the tip from, defaulting to this canister's own. Any other account must
+    // have approved this canister as spender, since the tip is then pulled via ICRC-2.
+    pub from_account: Option<icrc1::Account>,
     pub pin: Option<PinNumberWrapper>,
 }
 

--- a/backend/canisters/user/impl/src/updates/tip_message.rs
+++ b/backend/canisters/user/impl/src/updates/tip_message.rs
@@ -105,7 +105,7 @@ fn prepare(args: &mut Args, state: &mut RuntimeState) -> OCResult<(PrepareResult
     } else if args.from_account.is_some_and(|a| LedgerAccount::from(a) == my_user_id.into()) {
         // Pulling from our own account would need an approval we had granted ourselves, so this is
         // always a client bug. Reject it rather than let the ledger fail with an allowance error.
-        Err(OCErrorCode::InvalidRequest.with_message("Tip cannot be taken from the user's own account"))
+        Err(OCErrorCode::InvalidRequest.with_message("`from_account` cannot be the user's own account"))
     } else {
         let now = state.env.now();
         let now_nanos = now * NANOS_PER_MILLISECOND;

--- a/backend/canisters/user/impl/src/updates/tip_message.rs
+++ b/backend/canisters/user/impl/src/updates/tip_message.rs
@@ -5,11 +5,12 @@ use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use chat_events::TipMessageArgs;
 use constants::{MEMO_TIP, NANOS_PER_MILLISECOND};
+use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
 use oc_error_codes::OCErrorCode;
 use serde::Serialize;
 use types::{
     Achievement, CanisterId, Chat, ChatId, CommunityId, EventIndex, OCResult, PendingCryptoTransaction, TimestampNanos, UserId,
-    icrc1,
+    icrc1, icrc2,
 };
 use user_canister::UserCanisterEvent;
 use user_canister::tip_message::{Response::*, *};
@@ -26,15 +27,29 @@ async fn tip_message_impl(mut args: Args) -> Response {
         Err(response) => return Error(response),
     };
 
-    let pending_transfer = PendingCryptoTransaction::ICRC1(icrc1::PendingCryptoTransaction {
-        ledger: args.ledger,
-        token_symbol: args.token_symbol.clone(),
-        amount: args.amount,
-        to: icrc1::Account::for_user(args.recipient),
-        fee: args.fee,
-        memo: Some(MEMO_TIP.to_vec().into()),
-        created: now_nanos,
-    });
+    let pending_transfer = match args.from_account {
+        // The allowance is what authorises this - the ledger only lets us pull from an account which
+        // has approved this canister as spender - so there is nothing for us to check here.
+        Some(from) => PendingCryptoTransaction::ICRC2(icrc2::PendingCryptoTransaction {
+            ledger: args.ledger,
+            token_symbol: args.token_symbol.clone(),
+            amount: args.amount,
+            from,
+            to: icrc1::Account::for_user(args.recipient),
+            fee: args.fee,
+            memo: Some(MEMO_TIP.to_vec().into()),
+            created: now_nanos,
+        }),
+        None => PendingCryptoTransaction::ICRC1(icrc1::PendingCryptoTransaction {
+            ledger: args.ledger,
+            token_symbol: args.token_symbol.clone(),
+            amount: args.amount,
+            to: icrc1::Account::for_user(args.recipient),
+            fee: args.fee,
+            memo: Some(MEMO_TIP.to_vec().into()),
+            created: now_nanos,
+        }),
+    };
     // Make the crypto transfer
     match process_transaction(pending_transfer).await {
         Ok(Ok(_)) => {}
@@ -87,6 +102,10 @@ fn prepare(args: &mut Args, state: &mut RuntimeState) -> OCResult<(PrepareResult
         Err(OCErrorCode::TransferCannotBeZero.into())
     } else if my_user_id == args.recipient {
         Err(OCErrorCode::CannotTipSelf.into())
+    } else if args.from_account.is_some_and(|a| LedgerAccount::from(a) == my_user_id.into()) {
+        // Pulling from our own account would need an approval we had granted ourselves, so this is
+        // always a client bug. Reject it rather than let the ledger fail with an allowance error.
+        Err(OCErrorCode::InvalidRequest.with_message("Tip cannot be taken from the user's own account"))
     } else {
         let now = state.env.now();
         let now_nanos = now * NANOS_PER_MILLISECOND;

--- a/backend/integration_tests/src/client/user.rs
+++ b/backend/integration_tests/src/client/user.rs
@@ -407,6 +407,7 @@ pub mod happy_path {
                 fee,
                 decimals: 8,
                 token_symbol,
+                from_account: None,
                 pin: None,
             },
         );

--- a/backend/integration_tests/src/tip_message_tests.rs
+++ b/backend/integration_tests/src/tip_message_tests.rs
@@ -7,8 +7,8 @@ use constants::{ICP_SYMBOL, ICP_TRANSFER_FEE};
 use pocket_ic::PocketIc;
 use std::ops::Deref;
 use std::time::Duration;
-use testing::rng::{random_from_u128, random_string};
-use types::{Chat, ChatEvent};
+use testing::rng::{random_from_u128, random_principal, random_string};
+use types::{Chat, ChatEvent, icrc1};
 
 #[test]
 fn tip_direct_message_succeeds() {
@@ -219,6 +219,7 @@ fn tip_group_message_retries_if_c2c_call_fails() {
             amount: tip_amount,
             fee: ICP_TRANSFER_FEE,
             decimals: 8,
+            from_account: None,
             pin: None,
         },
     );
@@ -293,6 +294,7 @@ fn tip_channel_message_retries_if_c2c_call_fails() {
             amount: tip_amount,
             fee: ICP_TRANSFER_FEE,
             decimals: 8,
+            from_account: None,
             pin: None,
         },
     );
@@ -317,6 +319,133 @@ fn tip_channel_message_retries_if_c2c_call_fails() {
     assert_eq!(
         *message.tips.first().unwrap(),
         (canister_ids.icp_ledger, vec![(user1.user_id, tip_amount)])
+    );
+}
+
+// A tip taken from an account OpenChat does not control, pulled via ICRC-2 against an allowance
+// that account granted to the tipper's canister. This is how tipping from an external wallet works.
+#[test]
+fn tip_direct_message_from_approved_account_succeeds() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+        ..
+    } = wrapper.env();
+
+    let TestData { user1, user2 } = init_test_data(env, canister_ids, *controller);
+
+    let tip_amount = 1_0000_0000;
+    let external_wallet = random_principal();
+    client::ledger::happy_path::transfer(env, *controller, canister_ids.icp_ledger, external_wallet, 10_000_000_000);
+    // The allowance has to cover the transfer fee too, since that is charged to the `from` account.
+    client::ledger::happy_path::approve(
+        env,
+        external_wallet,
+        canister_ids.icp_ledger,
+        user1.user_id,
+        tip_amount + ICP_TRANSFER_FEE,
+    );
+
+    let user1_balance_before = client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user1.user_id);
+
+    let message_id = random_from_u128();
+    let event_index =
+        client::user::happy_path::send_text_message(env, &user2, user1.user_id, "TEXT", Some(message_id)).event_index;
+
+    tick_many(env, 3);
+
+    let response = client::user::tip_message(
+        env,
+        user1.principal,
+        user1.canister(),
+        &user_canister::tip_message::Args {
+            chat: Chat::Direct(user2.user_id.into()),
+            recipient: user2.user_id,
+            thread_root_message_index: None,
+            message_id,
+            ledger: canister_ids.icp_ledger,
+            token_symbol: ICP_SYMBOL.to_string(),
+            amount: tip_amount,
+            fee: ICP_TRANSFER_FEE,
+            decimals: 8,
+            from_account: Some(external_wallet.into()),
+            pin: None,
+        },
+    );
+    assert!(
+        matches!(response, user_canister::tip_message::Response::Success),
+        "{response:?}"
+    );
+
+    tick_many(env, 3);
+
+    // The tip is attributed to the OpenChat user, not to the account which funded it.
+    let message = client::user::happy_path::events_by_index(env, &user2, user1.user_id, vec![event_index])
+        .events
+        .pop()
+        .map(|e| if let ChatEvent::Message(m) = e.event { *m } else { panic!() })
+        .unwrap();
+
+    assert_eq!(message.tips.len(), 1);
+    assert_eq!(
+        *message.tips.first().unwrap(),
+        (canister_ids.icp_ledger, vec![(user1.user_id, tip_amount)])
+    );
+
+    // The funds came out of the approved account, so the tipper's own balance is untouched.
+    assert_eq!(
+        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user1.user_id),
+        user1_balance_before
+    );
+    assert_eq!(
+        client::ledger::happy_path::balance_of(env, canister_ids.icp_ledger, user2.user_id),
+        tip_amount
+    );
+}
+
+// Spending from our own account would need an approval we had granted ourselves, so it is rejected
+// up front rather than left to fail at the ledger.
+#[test]
+fn tip_from_own_account_is_rejected() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+        ..
+    } = wrapper.env();
+
+    let TestData { user1, user2 } = init_test_data(env, canister_ids, *controller);
+
+    let message_id = random_from_u128();
+    client::user::happy_path::send_text_message(env, &user2, user1.user_id, "TEXT", Some(message_id));
+
+    tick_many(env, 3);
+
+    let response = client::user::tip_message(
+        env,
+        user1.principal,
+        user1.canister(),
+        &user_canister::tip_message::Args {
+            chat: Chat::Direct(user2.user_id.into()),
+            recipient: user2.user_id,
+            thread_root_message_index: None,
+            message_id,
+            ledger: canister_ids.icp_ledger,
+            token_symbol: ICP_SYMBOL.to_string(),
+            amount: 1_0000_0000,
+            fee: ICP_TRANSFER_FEE,
+            decimals: 8,
+            from_account: Some(icrc1::Account::for_user(user1.user_id)),
+            pin: None,
+        },
+    );
+
+    assert!(
+        matches!(response, user_canister::tip_message::Response::Error(_)),
+        "{response:?}"
     );
 }
 

--- a/backend/integration_tests/src/tip_message_tests.rs
+++ b/backend/integration_tests/src/tip_message_tests.rs
@@ -322,7 +322,7 @@ fn tip_channel_message_retries_if_c2c_call_fails() {
     );
 }
 
-// A tip taken from an account OpenChat does not control, pulled via ICRC-2 against an allowance
+// A tip given from an account OpenChat does not control, pulled via ICRC-2 against an allowance
 // that account granted to the tipper's canister. This is how tipping from an external wallet works.
 #[test]
 fn tip_direct_message_from_approved_account_succeeds() {

--- a/frontend/openchat-agent/src/services/user/user.client.ts
+++ b/frontend/openchat-agent/src/services/user/user.client.ts
@@ -190,6 +190,7 @@ import { SingleCanisterMsgpackAgent } from "../canisterAgent/msgpack";
 import type { IChatEventsReader } from "../common/chatEvents";
 import {
     acceptP2PSwapSuccess,
+    addressToIcrcAccount,
     apiChatIdentifier,
     apiCommunityPermissions,
     apiExternalBotPermissions,
@@ -943,6 +944,7 @@ export class UserClient
                 ledger: principalStringToBytes(transfer.ledger),
                 amount: transfer.amountE8s,
                 thread_root_message_index: messageContext.threadRootMessageIndex,
+                from_account: mapOptional(transfer.fromAccount, addressToIcrcAccount),
                 pin,
             },
             tipMessageResponse,

--- a/frontend/openchat-agent/src/typebox.ts
+++ b/frontend/openchat-agent/src/typebox.ts
@@ -7271,6 +7271,7 @@ export const UserTipMessageArgs = /* @__PURE__ */ Type.Object({
     amount: Type.BigInt(),
     fee: Type.BigInt(),
     decimals: Type.Number(),
+    from_account: Type.Optional(AccountICRC1),
     pin: Type.Optional(PinNumberWrapper),
 });
 

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -336,6 +336,9 @@ export type PendingCryptocurrencyTransfer = {
     feeE8s?: bigint;
     memo?: bigint;
     createdAtNanos: bigint;
+    // An ICRC-1 textual account to take the funds from, for spending from a wallet OpenChat does
+    // not control. Left undefined to spend from the user's own canister.
+    fromAccount?: string;
 };
 
 export type FailedCryptocurrencyTransfer = {


### PR DESCRIPTION
`tip_message` built its transfer server-side as ICRC-1 from the user canister's own balance ([tip_message.rs:29](https://github.com/open-chat-labs/open-chat/blob/master/backend/canisters/user/impl/src/updates/tip_message.rs#L29)), so a tip could only ever be funded from the OpenChat wallet. This adds an optional `from_account` to the args which switches it to ICRC-2, pulling from that account instead.

This is the first step towards letting users spend from a wallet OpenChat does not control (Oisy, NFID). The crypto-message paths already accept a client-supplied `PendingCryptoTransaction` and so already support ICRC-2; tipping was the one send path that did not.

### Why an optional account rather than a full transaction

`send_message` takes a whole `CryptoTransaction` from the client, but that shape is wrong here. `tip_message` already takes `ledger`, `token_symbol`, `amount`, `fee` and `decimals` as top-level fields because the c2c args and the chat event need them. Accepting a transaction would duplicate all of those and require cross-validation that they agree — the same awkward checking `send_message_with_transfer.rs` has to do for prize amounts. One optional account avoids it.

### Authorisation

The ledger's allowance is the gate: `icrc2_transfer_from` only succeeds against an account which has approved this canister as spender, so there is nothing extra for us to check. `icrc2_approve` grants to an exact `(owner, subaccount)` pair, and #9260 already resolves the spender subaccount from the caller's `UserId`, so this works unchanged once users are indexed within a shared canister.

Pulling from our own account is rejected up front — it would need an approval we had granted ourselves, so it is always a client bug, and failing here beats an opaque `InsufficientAllowance` from the ledger.

### Scope

Nothing sets the field yet. The frontend threading is included (`fromAccount` on `PendingCryptocurrencyTransfer`, mapped through `user.client.ts`) because that is the field the signer work will set, but there is no wallet-selection UI in this PR — that needs ICRC-25/49 support, which the repo has no tooling for yet.

Not addressed here: P2P swap deposits are also constructed server-side and have the same limitation.

### Compatibility

- No Candid change — `tip_message` is msgpack-only and not in `can.did`.
- Wire-compatible: msgpack serialises structs as maps (`.with_struct_map()`), and an absent `Option` deserialises as `None`, so old clients are unaffected.
- No stable-memory migration — unlike `MakeTransferJob` there is no tip retry job; the fire-and-forget path only serialises the c2c args, after the transfer has succeeded.
- No group/community change. `c2c_tip_message` does not carry a funding account, and attribution is unchanged: `TipMessageArgs.user_id` stays the tipping user, so an externally funded tip still displays as from the OpenChat user.

### Testing

Two integration tests added. `tip_direct_message_from_approved_account_succeeds` funds an external principal, has it approve the tipper's canister for `amount + fee`, tips from it, and asserts the tip is attributed to the OpenChat user while the funds leave the approved account and the tipper's own balance is untouched. `tip_from_own_account_is_rejected` covers the guard.

Clippy and fmt clean.