### PR TITLE
Emit and accept ICRC2 pending crypto transactions in the frontend mappers

### DIFF
--- a/frontend/openchat-agent/src/services/common/chatMappersV2.spec.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappersV2.spec.ts
@@ -1,0 +1,73 @@
+import { Principal } from "@icp-sdk/core/principal";
+import type { PendingCryptocurrencyTransfer } from "@shared";
+import { encodeIcrcAccount } from "@shared";
+import { describe, expect, test } from "vitest";
+import {
+    addressToIcrcAccount,
+    apiPendingCryptoTransaction,
+    formatIcrcAccount,
+    pendingCryptoTransfer,
+} from "./chatMappersV2";
+
+const ledger = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+const recipient = "dfdal-2uaaa-aaaaa-qaama-cai";
+const walletOwner = Principal.selfAuthenticating(new Uint8Array(32).fill(7)).toText();
+const subaccount = new Uint8Array(32);
+subaccount[31] = 5;
+const walletWithSubaccount = encodeIcrcAccount({
+    owner: Principal.fromText(walletOwner),
+    subaccount,
+});
+
+const transfer: PendingCryptocurrencyTransfer = {
+    kind: "pending",
+    ledger,
+    token: "ICP",
+    recipient,
+    amountE8s: 100_000_000n,
+    feeE8s: 10_000n,
+    memo: 123n,
+    createdAtNanos: 1_700_000_000_000_000_000n,
+};
+
+describe("icrc account address mapping", () => {
+    test("round trips an account with no subaccount", () => {
+        expect(formatIcrcAccount(addressToIcrcAccount(walletOwner))).toEqual(walletOwner);
+    });
+
+    test("round trips an account with a subaccount", () => {
+        expect(formatIcrcAccount(addressToIcrcAccount(walletWithSubaccount))).toEqual(
+            walletWithSubaccount,
+        );
+    });
+});
+
+describe("pending crypto transaction mapping", () => {
+    test("emits ICRC1 when there is no fromAccount", () => {
+        const api = apiPendingCryptoTransaction(transfer);
+        expect(api).toHaveProperty("Pending.ICRC1");
+        expect(api).not.toHaveProperty("Pending.ICRC2");
+    });
+
+    test("emits ICRC2 when a fromAccount is set", () => {
+        const api = apiPendingCryptoTransaction({ ...transfer, fromAccount: walletWithSubaccount });
+        expect(api).not.toHaveProperty("Pending.ICRC1");
+        expect(api).toHaveProperty(
+            "Pending.ICRC2.from",
+            addressToIcrcAccount(walletWithSubaccount),
+        );
+    });
+
+    test("an ICRC2 transfer round trips unchanged", () => {
+        const domain = { ...transfer, fromAccount: walletWithSubaccount };
+        const api = apiPendingCryptoTransaction(domain);
+        if (!("Pending" in api)) throw new Error("Expected a pending transaction");
+        expect(pendingCryptoTransfer(api.Pending, recipient)).toEqual(domain);
+    });
+
+    test("an ICRC1 transfer round trips unchanged", () => {
+        const api = apiPendingCryptoTransaction(transfer);
+        if (!("Pending" in api)) throw new Error("Expected a pending transaction");
+        expect(pendingCryptoTransfer(api.Pending, recipient)).toEqual(transfer);
+    });
+});

--- a/frontend/openchat-agent/src/services/common/chatMappersV2.ts
+++ b/frontend/openchat-agent/src/services/common/chatMappersV2.ts
@@ -1,3 +1,4 @@
+import { Principal } from "@icp-sdk/core/principal";
 import type {
     AcceptP2PSwapResponse,
     AccessGate,
@@ -133,6 +134,7 @@ import {
     chatIdentifiersEqual,
     codeToText,
     decodeIcrcAccount,
+    encodeIcrcAccount,
     isAccountIdentifierValid,
     messagePermissionsList,
     nullMembership,
@@ -1221,7 +1223,7 @@ function cryptoTransfer(
     throw new UnsupportedValueError("Unexpected ApiCryptoTransaction type received", value);
 }
 
-function pendingCryptoTransfer(
+export function pendingCryptoTransfer(
     value: TPendingCryptoTransaction,
     recipient: string,
 ): PendingCryptocurrencyTransfer {
@@ -1251,7 +1253,17 @@ function pendingCryptoTransfer(
         };
     }
     if ("ICRC2" in value) {
-        throw new Error("ICRC2 is not supported yet");
+        return {
+            kind: "pending",
+            ledger: principalBytesToString(value.ICRC2.ledger),
+            token: value.ICRC2.token_symbol,
+            recipient,
+            amountE8s: value.ICRC2.amount,
+            feeE8s: value.ICRC2.fee,
+            memo: mapOptional(value.ICRC2.memo, bytesToBigint),
+            createdAtNanos: value.ICRC2.created,
+            fromAccount: formatIcrcAccount(value.ICRC2.from),
+        };
     }
 
     throw new UnsupportedValueError("Unexpected ApiPendingCryptoTransaction type received", value);
@@ -2124,6 +2136,24 @@ export function apiPendingCryptoContent(domain: CryptocurrencyContent): TCryptoC
 
 export function apiPendingCryptoTransaction(domain: CryptocurrencyTransfer): TCryptoTransaction {
     if (domain.kind === "pending") {
+        // A fromAccount means spending from a wallet OpenChat does not control, which the user's
+        // canister pulls from via ICRC-2, so the wallet must have approved it as spender.
+        if (domain.fromAccount !== undefined) {
+            return {
+                Pending: {
+                    ICRC2: {
+                        ledger: principalStringToBytes(domain.ledger),
+                        token_symbol: domain.token,
+                        from: addressToIcrcAccount(domain.fromAccount),
+                        to: principalToIcrcAccount(domain.recipient),
+                        amount: domain.amountE8s,
+                        fee: domain.feeE8s ?? BigInt(0),
+                        memo: mapOptional(domain.memo, bigintToBytes),
+                        created: domain.createdAtNanos,
+                    },
+                },
+            };
+        }
         return {
             Pending: {
                 ICRC1: {
@@ -3011,6 +3041,13 @@ export function addressToIcrcAccount(address: string): AccountICRC1 {
                 ? ([...icrcAccount.subaccount] as NumberArray32)
                 : undefined,
     };
+}
+
+export function formatIcrcAccount(account: AccountICRC1): string {
+    return encodeIcrcAccount({
+        owner: Principal.fromText(principalBytesToString(account.owner)),
+        subaccount: mapOptional(account.subaccount, consolidateBytes),
+    });
 }
 
 export function unitResult(

--- a/frontend/openchat-agent/src/services/user/mappersV2.ts
+++ b/frontend/openchat-agent/src/services/user/mappersV2.ts
@@ -1,4 +1,3 @@
-import { Principal } from "@icp-sdk/core/principal";
 import type {
     Achievement,
     ArchiveChatResponse,
@@ -56,7 +55,6 @@ import type {
 } from "@shared";
 import {
     CommonResponses,
-    encodeIcrcAccount,
     nullMembership,
     ROLE_OWNER,
     toBigInt32,
@@ -64,7 +62,6 @@ import {
     UnsupportedValueError,
 } from "@shared";
 import type {
-    AccountICRC1,
     StreakInsurance as ApiStreakInsurance,
     CompletedCryptoTransactionICRC1,
     CompletedCryptoTransactionNNS,
@@ -118,7 +115,6 @@ import type {
 import {
     bytesToBigint,
     bytesToHexString,
-    consolidateBytes,
     identity,
     mapOptional,
     optionUpdateV2,
@@ -128,6 +124,7 @@ import {
 import {
     chatMetrics,
     completedCryptoTransfer,
+    formatIcrcAccount,
     installedBotDetails,
     mapResult,
     messageEvent,
@@ -929,7 +926,7 @@ function completedIcrc1CryptoWithdrawal(
     return {
         kind: "completed",
         ledger: principalBytesToString(value.ledger),
-        to: value.to !== "Mint" ? formatIcrc1Account(value.to.Account) : "",
+        to: value.to !== "Mint" ? formatIcrcAccount(value.to.Account) : "",
         amountE8s: value.amount,
         feeE8s: value.fee,
         memo: mapOptional(value.memo, bytesToBigint) ?? BigInt(0),
@@ -951,13 +948,6 @@ export function withdrawCryptoResponse(
     }
 
     throw new Error("Unexpected ApiWithdrawCryptocurrencyResponse type received");
-}
-
-function formatIcrc1Account(value: AccountICRC1): string {
-    return encodeIcrcAccount({
-        owner: Principal.fromText(principalBytesToString(value.owner)),
-        subaccount: mapOptional(value?.subaccount, consolidateBytes),
-    });
 }
 
 export function swapTokensSuccess(value: UserSwapTokensSuccessResult): SwapTokensResponse {


### PR DESCRIPTION
`apiPendingCryptoTransaction` hardcoded the ICRC1 variant and silently dropped `fromAccount`, and the inbound pending mapper threw "ICRC2 is not supported yet". Now a pending transfer with a `fromAccount` is sent as ICRC2 - spending from a wallet OpenChat does not control, pulled by the user's canister via an ICRC-2 approval - and inbound ICRC2 transactions map back to the domain type, `fromAccount` included.

The backend already accepts the ICRC2 variant on both the crypto message and prize paths, so this is the last plumbing between the domain type and the wire for those. Nothing in the worker needed changing - the transfer rides inside the message content, which crosses the worker boundary intact.

Also dedupes user/mappersV2's private `formatIcrc1Account` into the new exported `formatIcrcAccount`, and adds round-trip tests for the account encoding and both pending variants.

Stacked on #9265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)