### PR TITLE
Fix WebAuthn COSE key extraction to exclude trailing extension bytes

### DIFF
--- a/frontend/openchat-client/src/utils/androidWebAuthn.ts
+++ b/frontend/openchat-client/src/utils/androidWebAuthn.ts
@@ -1,4 +1,5 @@
 import { WebAuthnIdentity } from "@icp-sdk/core/identity";
+import { authDataToCose } from "./webAuthn";
 import type { WebAuthnKeyFull } from "@shared";
 import borc from "borc";
 import {
@@ -51,7 +52,7 @@ export async function createAndroidWebAuthnPasskeyIdentity(
 
                     const identity = new WebAuthnIdentity(
                         credentialId,
-                        new Uint8Array(authDataToCose(attObject.authData)),
+                        authDataToCose(attObject.authData),
                         credential.authenticatorAttachment,
                     );
 
@@ -165,15 +166,4 @@ export class AndroidWebAuthnPasskeyIdentity extends SignIdentity {
         }
         return new Uint8Array(cbor) as Signature;
     }
-}
-
-// TODO, this is duplicated/copied from the webAuthn.ts
-function authDataToCose(authData: ArrayBuffer): ArrayBuffer {
-    const dataView = new DataView(new ArrayBuffer(2));
-    const idLenBytes = authData.slice(53, 55);
-    [...new Uint8Array(idLenBytes)].forEach((v, i) => dataView.setUint8(i, v));
-    const credentialIdLength = dataView.getUint16(0);
-
-    // Get the public key object.
-    return authData.slice(55 + credentialIdLength);
 }

--- a/frontend/openchat-client/src/utils/webAuthn.spec.ts
+++ b/frontend/openchat-client/src/utils/webAuthn.spec.ts
@@ -1,0 +1,82 @@
+import { authDataToCose } from "./webAuthn";
+
+function hex(s: string): Uint8Array {
+    return new Uint8Array(s.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+}
+
+// A 77 byte ES256 COSE key: {1: 2, 3: -7, -1: 1, -2: x (32 bytes), -3: y (32 bytes)}
+const es256Key = hex(
+    "a50102032620012158" + "20" + "11".repeat(32) + "2258" + "20" + "22".repeat(32),
+);
+
+// An RSA COSE key with 256 byte modulus: {1: 3, 3: -257, -1: n, -2: e}
+const rs256Key = hex("a40103033901002159" + "0100" + "33".repeat(256) + "2243010001");
+
+// CBOR {"credProtect": 3} - the extensions map appended by eg. YubiKeys when the ED flag is set
+const credProtectExtension = hex("a16b6372656450726f7465637403");
+
+function buildAuthData(
+    credentialId: Uint8Array,
+    coseKey: Uint8Array,
+    extensions?: Uint8Array,
+): Uint8Array {
+    const rpIdHash = new Uint8Array(32).fill(0xaa);
+    const flags = new Uint8Array([extensions ? 0xc5 : 0x45]); // UP | UV | AT (| ED)
+    const signCount = new Uint8Array([0, 0, 0, 1]);
+    const aaguid = new Uint8Array(16).fill(0xbb);
+    const idLength = new Uint8Array([credentialId.length >> 8, credentialId.length & 0xff]);
+    const parts = [
+        rpIdHash,
+        flags,
+        signCount,
+        aaguid,
+        idLength,
+        credentialId,
+        coseKey,
+        extensions ?? new Uint8Array(),
+    ];
+    const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+    let offset = 0;
+    for (const p of parts) {
+        out.set(p, offset);
+        offset += p.length;
+    }
+    return out;
+}
+
+describe("authDataToCose", () => {
+    const credentialId = new Uint8Array(48).fill(0xcc);
+
+    test("extracts an ES256 key when there are no extensions", () => {
+        const authData = buildAuthData(credentialId, es256Key);
+        expect(authDataToCose(authData)).toEqual(es256Key);
+    });
+
+    test("excludes the credProtect extensions map which follows the key", () => {
+        const authData = buildAuthData(credentialId, es256Key, credProtectExtension);
+        const key = authDataToCose(authData);
+        expect(key.length).toEqual(77);
+        expect(key).toEqual(es256Key);
+    });
+
+    test("extracts an RSA key with multi-byte CBOR lengths", () => {
+        const authData = buildAuthData(credentialId, rs256Key, credProtectExtension);
+        expect(authDataToCose(authData)).toEqual(rs256Key);
+    });
+
+    test("handles a credential id longer than 255 bytes", () => {
+        const longCredentialId = new Uint8Array(300).fill(0xdd);
+        const authData = buildAuthData(longCredentialId, es256Key, credProtectExtension);
+        expect(authDataToCose(authData)).toEqual(es256Key);
+    });
+
+    test("accepts an ArrayBuffer", () => {
+        const authData = buildAuthData(credentialId, es256Key, credProtectExtension);
+        expect(authDataToCose(authData.buffer.slice(0) as ArrayBuffer)).toEqual(es256Key);
+    });
+
+    test("throws if the key is truncated", () => {
+        const authData = buildAuthData(credentialId, es256Key).slice(0, -10);
+        expect(() => authDataToCose(authData)).toThrow();
+    });
+});

--- a/frontend/openchat-client/src/utils/webAuthn.ts
+++ b/frontend/openchat-client/src/utils/webAuthn.ts
@@ -35,7 +35,7 @@ export async function createWebAuthnIdentity(
 
     const identity = new WebAuthnIdentity(
         credentialId,
-        new Uint8Array(authDataToCose(attObject.authData)),
+        authDataToCose(attObject.authData),
         authenticatorAttachment,
     );
 
@@ -161,12 +161,98 @@ function webAuthnCreationOptions(
     };
 }
 
-function authDataToCose(authData: ArrayBuffer): ArrayBuffer {
-    const dataView = new DataView(new ArrayBuffer(2));
-    const idLenBytes = authData.slice(53, 55);
-    [...new Uint8Array(idLenBytes)].forEach((v, i) => dataView.setUint8(i, v));
-    const credentialIdLength = dataView.getUint16(0);
+/**
+ * Extracts the COSE public key from WebAuthn authenticator data.
+ *
+ * Layout (https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data):
+ *   rpIdHash (32) | flags (1) | signCount (4) | aaguid (16) | credentialIdLength (2) |
+ *   credentialId (credentialIdLength) | credentialPublicKey (COSE, variable) | extensions (CBOR map, optional)
+ *
+ * The public key is a CBOR map of variable length, so we must walk the CBOR structure to find where it
+ * ends rather than taking everything to the end of the buffer. Otherwise, when the authenticator sets the
+ * ED flag (eg. YubiKeys which add a `credProtect` extension), the extensions map would be included in the
+ * stored key, the IC would reject it as malformed, and the user would be locked out of their account.
+ */
+export function authDataToCose(authData: ArrayBuffer | Uint8Array): Uint8Array {
+    const bytes = new Uint8Array(authData);
+    const credentialIdLength = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength,
+    ).getUint16(53);
+    const start = 55 + credentialIdLength;
+    const length = cborItemLength(bytes, start);
+    return bytes.slice(start, start + length);
+}
 
-    // Get the public key object.
-    return authData.slice(55 + credentialIdLength);
+/**
+ * Returns the encoded length in bytes of the CBOR data item starting at `offset`.
+ * Only definite-length items are supported, which is all that CTAP2 canonical CBOR permits.
+ */
+function cborItemLength(bytes: Uint8Array, offset: number): number {
+    if (offset >= bytes.length) {
+        throw new Error("Unexpected end of CBOR data");
+    }
+    const initial = bytes[offset];
+    const majorType = initial >> 5;
+    const additionalInfo = initial & 0x1f;
+
+    let headerLength = 1;
+    let argument: number;
+    if (additionalInfo < 24) {
+        argument = additionalInfo;
+    } else if (additionalInfo <= 27) {
+        const argumentLength = 1 << (additionalInfo - 24);
+        if (offset + 1 + argumentLength > bytes.length) {
+            throw new Error("Unexpected end of CBOR data");
+        }
+        const view = new DataView(bytes.buffer, bytes.byteOffset + offset + 1, argumentLength);
+        switch (argumentLength) {
+            case 1:
+                argument = view.getUint8(0);
+                break;
+            case 2:
+                argument = view.getUint16(0);
+                break;
+            case 4:
+                argument = view.getUint32(0);
+                break;
+            default:
+                argument = Number(view.getBigUint64(0));
+                break;
+        }
+        headerLength += argumentLength;
+    } else {
+        throw new Error("Indefinite length CBOR items are not supported");
+    }
+
+    let length = headerLength;
+    switch (majorType) {
+        case 0: // unsigned int
+        case 1: // negative int
+        case 7: // simple values and floats (argument bytes already counted in the header)
+            break;
+        case 2: // byte string
+        case 3: // text string
+            length += argument;
+            break;
+        case 4: // array
+            for (let i = 0; i < argument; i++) {
+                length += cborItemLength(bytes, offset + length);
+            }
+            break;
+        case 5: // map
+            for (let i = 0; i < argument * 2; i++) {
+                length += cborItemLength(bytes, offset + length);
+            }
+            break;
+        case 6: // tagged item
+            length += cborItemLength(bytes, offset + length);
+            break;
+    }
+
+    if (offset + length > bytes.length) {
+        throw new Error("Unexpected end of CBOR data");
+    }
+    return length;
 }


### PR DESCRIPTION
Fixes the registration half of #9277.

## Problem

`authDataToCose` extracted the public key by slicing from the end of the credential ID to the end of the authenticator data. The COSE key is a variable-length CBOR map, and when the authenticator sets the ED flag the extensions map follows it. YubiKeys registered via Chrome or the Windows WebAuthn API add a `credProtect` extension, so those users had a malformed key stored in the identity canister. The IC then rejects every delegation with `Failed to parse COSE public key` and the user is permanently locked out.

Sign-up appears to work because the initial delegation is signed with a temporary key, so the bad key is only exercised at the next real sign-in.

## Fix

- `authDataToCose` now walks the CBOR structure to find where the COSE map ends and slices exactly that. A small `cborItemLength` helper covers all definite-length major types (indefinite lengths are forbidden by CTAP2 canonical CBOR and throw).
- The Android path imports the shared function instead of carrying its own copy, resolving the existing TODO.
- New `webAuthn.spec.ts` reproduces the reported layout (77-byte ES256 key followed by `{"credProtect": 3}`) and also covers RSA keys with multi-byte lengths, credential IDs over 255 bytes, ArrayBuffer input, and truncated data.

## Scope

This only fixes new registrations. Accounts that already hold a malformed key need a one-off migration in the identity canister, which will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
