### PR TITLE
Fix flaky user_canister_notified_of_community_deleted test

### DIFF
--- a/backend/integration_tests/src/communities/delete_community_tests.rs
+++ b/backend/integration_tests/src/communities/delete_community_tests.rs
@@ -119,6 +119,9 @@ fn user_canister_notified_of_community_deleted() {
             .iter()
             .any(|c| c.community_id == community_id)
     );
+
+    // 11 minutes were added to the clock: this env must not go back to the pool
+    wrapper.discard();
 }
 
 fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds, controller: Principal) -> TestData {
@@ -136,6 +139,15 @@ fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds, controller: Pr
         community_id,
         vec![(user2.user_id, user2.principal), (user3.user_id, user3.principal)],
     );
+
+    // The user canisters learn of the membership asynchronously (community -> local user index ->
+    // user canister), and `user_canister_notified_of_community_deleted` stops user2 and user3
+    // right after this returns. A join event which reaches a stopped canister is rejected and
+    // only retried after a 10 second delay, which never elapses while the clock stands still, so
+    // a user stopped before its join landed would never hold the community and the final
+    // assertion (that user3 still has it) would fail. Wait for the memberships to land first.
+    wait_for_community_membership(env, &user2, community_id);
+    wait_for_community_membership(env, &user3, community_id);
 
     TestData {
         user1,
@@ -162,6 +174,23 @@ fn community_deleted_notifications_failed(env: &mut PocketIc, group_index: Princ
     let response = client::http_request(env, Principal::anonymous(), group_index, &request);
     let metrics: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
     metrics["community_deleted_notifications_failed"].as_u64().unwrap()
+}
+
+// Ticks until the user's canister lists the community, ie. the join event has been delivered
+fn wait_for_community_membership(env: &mut PocketIc, user: &User, community_id: CommunityId) {
+    for _ in 0..20 {
+        let initial_state = client::user::happy_path::initial_state(env, user);
+        if initial_state
+            .communities
+            .summaries
+            .iter()
+            .any(|c| c.community_id == community_id)
+        {
+            return;
+        }
+        env.tick();
+    }
+    panic!("User {} was not notified of joining the community", user.user_id);
 }
 
 // Ticks until the user's canister has processed the community-deleted notification. Ticks don't

--- a/backend/integration_tests/src/communities/delete_community_tests.rs
+++ b/backend/integration_tests/src/communities/delete_community_tests.rs
@@ -119,9 +119,6 @@ fn user_canister_notified_of_community_deleted() {
             .iter()
             .any(|c| c.community_id == community_id)
     );
-
-    // 11 minutes were added to the clock: this env must not go back to the pool
-    wrapper.discard();
 }
 
 fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds, controller: Principal) -> TestData {

--- a/backend/integration_tests/src/delete_group_tests.rs
+++ b/backend/integration_tests/src/delete_group_tests.rs
@@ -80,9 +80,6 @@ fn user_canister_notified_of_group_deleted() {
     // Only retry for 10 minutes so the notification shouldn't have made it to user3's canister
     let initial_state3 = client::user::happy_path::initial_state(env, &user3);
     assert!(initial_state3.group_chats.summaries.iter().any(|c| c.chat_id == group_id));
-
-    // 11 minutes were added to the clock: this env must not go back to the pool
-    wrapper.discard();
 }
 
 fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds) -> TestData {

--- a/backend/integration_tests/src/delete_group_tests.rs
+++ b/backend/integration_tests/src/delete_group_tests.rs
@@ -80,6 +80,9 @@ fn user_canister_notified_of_group_deleted() {
     // Only retry for 10 minutes so the notification shouldn't have made it to user3's canister
     let initial_state3 = client::user::happy_path::initial_state(env, &user3);
     assert!(initial_state3.group_chats.summaries.iter().any(|c| c.chat_id == group_id));
+
+    // 11 minutes were added to the clock: this env must not go back to the pool
+    wrapper.discard();
 }
 
 fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds) -> TestData {
@@ -98,12 +101,33 @@ fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds) -> TestData {
         vec![(user2.user_id, user2.principal), (user3.user_id, user3.principal)],
     );
 
+    // The user canisters learn of the membership asynchronously (group -> local user index -> user
+    // canister), and `user_canister_notified_of_group_deleted` stops user2 and user3 right after
+    // this returns. A join event which reaches a stopped canister is rejected and only retried
+    // after a 10 second delay, which never elapses while the clock stands still, so a user stopped
+    // before its join landed would never hold the group and the final assertion (that user3 still
+    // has it) would fail. Wait for the memberships to land first.
+    wait_for_group_membership(env, &user2, group_id);
+    wait_for_group_membership(env, &user3, group_id);
+
     TestData {
         user1,
         user2,
         user3,
         group_id,
     }
+}
+
+// Ticks until the user's canister lists the group, ie. the join event has been delivered
+fn wait_for_group_membership(env: &mut PocketIc, user: &User, group_id: ChatId) {
+    for _ in 0..20 {
+        let initial_state = client::user::happy_path::initial_state(env, user);
+        if initial_state.group_chats.summaries.iter().any(|c| c.chat_id == group_id) {
+            return;
+        }
+        env.tick();
+    }
+    panic!("User {} was not notified of joining the group", user.user_id);
 }
 
 struct TestData {


### PR DESCRIPTION
## Summary

`user_canister_notified_of_community_deleted` has been the sole failure in the last several red integration test runs on unrelated branches (33609159004, 33439520131, 33411332271, 33085047784, 32954219139, 32890504776), most recently on #9279. It has been patched several times already (latest #9177), each time hardening the waits around the deletion notification. The remaining race is earlier, in the test setup.

## Root cause

`init_test_data` adds user2 and user3 to the community via `happy_path::add_users_to_community`, which ticks once and returns. The user canisters only learn of the membership asynchronously: the community pushes the join to the local user index, which then pushes `UserJoinedCommunityOrChannel` to the user canister, each hop through a zero-delay timer job queue. The test then immediately stops user2 and user3.

If a user canister is stopped before its join event lands, the call is rejected as "is stopped". That is classified as `RetryAfterShortDelay`, i.e. a 10 second delay, which never elapses while the clock stands still. The later `advance_time` calls fire the retry while the canister is still stopped, so it is rejected again. The user therefore never holds the community, and the final assertion (that user3 still has it because the deletion notification was dropped) fails, which is exactly the assertion that fails in CI. user2's wait passes trivially in that case, so nothing earlier catches it.

## Fix

- Wait for user2 and user3 to actually list the community before returning from `init_test_data`, so the canisters are only ever stopped once their membership has landed. The wait panics with a clear message if it never does.
- Apply the same change to `user_canister_notified_of_group_deleted`, which has the identical structure and the same latent race.

## Test plan

- [x] `delete_community_succeeds`, `user_canister_notified_of_community_deleted`, `delete_group_succeeds` and `user_canister_notified_of_group_deleted` pass locally against current master wasms
- [ ] Integration tests CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)