### PR TITLE
Only install the Tauri native libs in jobs which build the Tauri crates

### DIFF
--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -70,6 +70,7 @@ jobs:
               uses: ./.github/workflows/setup-rust
               with:
                   cache: "write"
+                  install-tauri-libs: true
 
             - name: Cache Gradle packages
               uses: actions/cache@v3

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --tests -- -D warnings
+          args: --workspace --exclude open-chat --exclude tauri-plugin-oc --tests -- -D warnings
 
   unit_tests:
     name: run unit tests
@@ -45,4 +45,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude integration_tests
+          args: --workspace --exclude integration_tests --exclude open-chat --exclude tauri-plugin-oc

--- a/.github/workflows/build_caches.yaml
+++ b/.github/workflows/build_caches.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --tests
+          args: --workspace --exclude open-chat --exclude tauri-plugin-oc --tests
 
   # Warms the cache the integration tests restore: the canister wasms, `ic-wasm`, and the debug
   # build of the test crate. Uses the same runner spec as the integration tests so the cached

--- a/.github/workflows/setup-rust/action.yml
+++ b/.github/workflows/setup-rust/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'Which cache to use (jobs sharing a key share a cache)'
     type: string
     default: 'build-debug'
+  install-tauri-libs:
+    description: 'Install the native libs the Tauri crates need (only jobs which build them should set this)'
+    type: boolean
+    default: false
 
 runs:
   using: 'composite'
@@ -26,6 +30,9 @@ runs:
         shared-key: ${{ inputs.shared-key }}
         save-if: ${{ inputs.cache == 'write' }}
 
-    - name: Install additional libs
+    # Only the Tauri crates need these, and the Ubuntu mirror serving them is intermittently very slow
+    # (25+ minutes seen), so jobs which don't build those crates must not pay for them
+    - name: Install Tauri libs
+      if: ${{ inputs.install-tauri-libs == 'true' }}
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+      run: sudo apt-get update && sudo apt-get install -y -o Acquire::Retries=3 libgtk-3-dev libwebkit2gtk-4.1-dev


### PR DESCRIPTION
## Why

Every Rust CI job runs the shared `setup-rust` action, which unconditionally `apt-get install`s `libgtk-3-dev` and `libwebkit2gtk-4.1-dev`. Those packages come from the Azure Ubuntu mirror, which has been intermittently crawling today: a step that normally takes 30s took **26 minutes** on the unit tests job of #9279 and stalled the candid job of #9280 for a similar time.

Only the two Tauri crates (`open-chat` in `frontend/src-tauri` and `tauri-plugin-oc`) need those libs. Neither contains any unit tests, and the only job that actually builds them is the Android release.

## What

- `setup-rust` gains an `install-tauri-libs` input (default `false`). The apt step only runs when it is set, and now passes `-o Acquire::Retries=3`.
- The Android release job sets `install-tauri-libs: true`.
- The backend clippy and unit test jobs, and the debug cache build, pass `--exclude open-chat --exclude tauri-plugin-oc` so they no longer compile the Tauri crates (which is also less work for those jobs).
- The fmt, candid, benchmarks, integration test and pre-release jobs never needed the libs and simply stop installing them.

## Trade-off

Clippy no longer lints the two Tauri crates on backend PRs. They were only ever linted as a side effect of the workspace-wide invocation, and their build is still exercised by the Android release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
