### PR TITLE
Declare the install-tauri-libs input as a string

### DIFF
--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -70,7 +70,7 @@ jobs:
               uses: ./.github/workflows/setup-rust
               with:
                   cache: "write"
-                  install-tauri-libs: true
+                  install-tauri-libs: "true"
 
             - name: Cache Gradle packages
               uses: actions/cache@v3

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -48,8 +48,8 @@ jobs:
             - name: Setup Java
               uses: actions/setup-java@v4
               with:
-                  distribution: "temurin"
-                  java-version: "17"
+                  distribution: 'temurin'
+                  java-version: '17'
 
             - name: Setup Android SDK
               uses: android-actions/setup-android@v3
@@ -69,8 +69,8 @@ jobs:
             - name: Setup Rust
               uses: ./.github/workflows/setup-rust
               with:
-                  cache: "write"
-                  install-tauri-libs: "true"
+                  cache: 'write'
+                  install-tauri-libs: 'true'
 
             - name: Cache Gradle packages
               uses: actions/cache@v3
@@ -99,8 +99,8 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: "20.20.0"
-                  cache: "npm"
+                  node-version: '20.20.0'
+                  cache: 'npm'
                   cache-dependency-path: frontend/package-lock.json
 
             - name: Install frontend dependencies
@@ -110,7 +110,7 @@ jobs:
               uses: baptiste0928/cargo-install@v3
               with:
                   crate: tauri-cli
-                  version: "2.10.0"
+                  version: '2.10.0'
 
             - name: Setup Keystore
               run: |
@@ -175,8 +175,8 @@ jobs:
               env:
                   # Ensure these are passed if needed, though the gradle file uses the debug fallback we set up
                   ANDROID_KEY_STORE_FILE: ${{ env.ANDROID_KEY_STORE_FILE }}
-                  OC_APP_STORE: "false"
-                  OC_OTA_UPDATES: "major"
+                  OC_APP_STORE: 'false'
+                  OC_OTA_UPDATES: 'major'
 
             - name: Clean Target Directory
               run: rm -rf src-tauri/target
@@ -188,8 +188,8 @@ jobs:
               env:
                   # Ensure these are passed if needed, though the gradle file uses the debug fallback we set up
                   ANDROID_KEY_STORE_FILE: ${{ env.ANDROID_KEY_STORE_FILE }}
-                  OC_APP_STORE: "true"
-                  OC_OTA_UPDATES: "patch"
+                  OC_APP_STORE: 'true'
+                  OC_OTA_UPDATES: 'patch'
 
             - name: Upload APKs
               uses: actions/upload-artifact@v4

--- a/.github/workflows/setup-rust/action.yml
+++ b/.github/workflows/setup-rust/action.yml
@@ -8,9 +8,9 @@ inputs:
     type: string
     default: 'build-debug'
   install-tauri-libs:
-    description: 'Install the native libs the Tauri crates need (only jobs which build them should set this)'
-    type: boolean
-    default: false
+    description: 'Set to "true" to install the native libs the Tauri crates need (only jobs which build them should set this)'
+    type: string
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -35,4 +35,4 @@ runs:
     - name: Install Tauri libs
       if: ${{ inputs.install-tauri-libs == 'true' }}
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y -o Acquire::Retries=3 libgtk-3-dev libwebkit2gtk-4.1-dev
+      run: sudo apt-get -o Acquire::Retries=3 update && sudo apt-get -o Acquire::Retries=3 install -y libgtk-3-dev libwebkit2gtk-4.1-dev


### PR DESCRIPTION
Follow-up to #9286 addressing the Copilot review comments there.

- Composite action inputs are always strings, so `install-tauri-libs` is now declared as a string with a `'false'` default rather than a boolean compared against `'true'`.
- The Android release job passes it as an explicit `"true"`.
- `Acquire::Retries=3` now applies to `apt-get update` as well as the install.

No behaviour change for any job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
