### PR TITLE
Add UserId::from_account and remove the owner-only derivations it replaces

### DIFF
--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 - Remove the one-off `post_upgrade` privilege re-sync now that it has run on prod in the 2.0.2046 release ([#9255](https://github.com/open-chat-labs/open-chat/pull/9255))
+- Remove the referral reward payment handling, which has been unreachable since referrals were rewarded in CHIT ([#9289](https://github.com/open-chat-labs/open-chat/pull/9289))
 
 ## [[2.0.2046](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2046-user_index)] - 2026-08-26
 

--- a/backend/canisters/user_index/impl/src/jobs/make_pending_payments.rs
+++ b/backend/canisters/user_index/impl/src/jobs/make_pending_payments.rs
@@ -1,16 +1,11 @@
-use crate::model::pending_payments_queue::{PendingPayment, PendingPaymentReason};
-use crate::{LocalUserIndexEvent, read_state};
-use crate::{RuntimeState, mutate_state};
-use constants::{CHAT_LEDGER_CANISTER_ID, SNS_ROOT_CANISTER_ID};
+use crate::model::pending_payments_queue::PendingPayment;
+use crate::{RuntimeState, mutate_state, read_state};
 use ic_cdk_timers::TimerId;
-use ic_ledger_types::{BlockIndex, Tokens};
 use icrc_ledger_types::icrc1::transfer::TransferArg;
 use ledger_utils::icrc1::make_transfer;
-use local_user_index_canister::OpenChatBotMessageV2;
 use std::cell::Cell;
 use std::time::Duration;
 use tracing::trace;
-use types::{MessageContentInitial, TextContent};
 
 thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
@@ -37,7 +32,6 @@ pub fn run() {
 }
 
 async fn process_payment(pending_payment: PendingPayment) {
-    let reason = pending_payment.reason.clone();
     let args = TransferArg {
         from_subaccount: None,
         to: pending_payment.recipient_account,
@@ -50,46 +44,9 @@ async fn process_payment(pending_payment: PendingPayment) {
     let result = make_transfer(pending_payment.ledger, &args, true).await;
 
     mutate_state(|state| {
-        match result {
-            Ok(Ok(block_index)) => {
-                if matches!(reason, PendingPaymentReason::ReferralReward) {
-                    inform_referrer(&pending_payment, block_index, state);
-                }
-            }
-            Ok(Err(_)) => {}
-            Err(_) => {
-                state.data.pending_payments_queue.push(pending_payment);
-            }
+        if result.is_err() {
+            state.data.pending_payments_queue.push(pending_payment);
         }
         start_job_if_required(state);
     });
-}
-
-fn inform_referrer(pending_payment: &PendingPayment, block_index: BlockIndex, state: &mut RuntimeState) {
-    let user_id = pending_payment.recipient_account.owner.into();
-    let amount = Tokens::from_e8s(pending_payment.amount);
-    let amount_formatted = amount.to_string().trim_end_matches('0').to_string();
-    let symbol = pending_payment.token_symbol.clone();
-    let mut amount_text = format!("{amount_formatted} {symbol}");
-
-    if pending_payment.ledger == CHAT_LEDGER_CANISTER_ID {
-        let link = format!("https://dashboard.internetcomputer.org/sns/{SNS_ROOT_CANISTER_ID}/transaction/{block_index}");
-        amount_text = format!("[{amount_text}]({link})");
-    }
-
-    let content = MessageContentInitial::Text(TextContent {
-        text: format!(
-            "You have received a referral reward of {amount_text}. This is because one of the users you referred has made a Diamond membership payment."
-        ),
-    });
-
-    state.push_event_to_local_user_index(
-        user_id,
-        LocalUserIndexEvent::OpenChatBotMessageV2(Box::new(OpenChatBotMessageV2 {
-            user_id,
-            thread_root_message_id: None,
-            content,
-            mentioned: Vec::new(),
-        })),
-    );
 }

--- a/backend/canisters/user_index/impl/src/model/pending_payments_queue.rs
+++ b/backend/canisters/user_index/impl/src/model/pending_payments_queue.rs
@@ -43,5 +43,4 @@ pub enum PendingPaymentReason {
     Treasury,
     TopUpNeuron,
     Burn,
-    ReferralReward,
 }

--- a/backend/libraries/types/src/cryptocurrency.rs
+++ b/backend/libraries/types/src/cryptocurrency.rs
@@ -156,32 +156,6 @@ impl PendingCryptoTransaction {
         }
     }
 
-    pub fn user_id(&self) -> Option<UserId> {
-        match self {
-            PendingCryptoTransaction::NNS(t) => {
-                if let UserOrAccount::User(u) = t.to {
-                    Some(u)
-                } else {
-                    None
-                }
-            }
-            PendingCryptoTransaction::ICRC1(t) => {
-                if t.to.subaccount.unwrap_or_default() == [0; 32] {
-                    Some(t.to.owner.into())
-                } else {
-                    None
-                }
-            }
-            PendingCryptoTransaction::ICRC2(t) => {
-                if t.to.subaccount.unwrap_or_default() == ic_ledger_types::DEFAULT_SUBACCOUNT.0 {
-                    Some(t.to.owner.into())
-                } else {
-                    None
-                }
-            }
-        }
-    }
-
     pub fn validate_recipient(&self, recipient: UserId) -> bool {
         // The whole account, not just the owner. Once a canister holds many users the owner alone
         // is satisfied by a transfer destined for any of them.

--- a/backend/libraries/types/src/user.rs
+++ b/backend/libraries/types/src/user.rs
@@ -34,18 +34,11 @@ impl UserId {
     // the canister id's two trailing tag bytes. The result is deliberately not a well-formed
     // principal, which is exactly what tells it apart from a canister id - see `is_indexed`.
     pub fn new_indexed(canister_id: CanisterId, index: u16) -> UserId {
-        // Both the length and the trailing tag bytes, because `canister_id` rebuilds the latter
-        // from scratch. Anything else 10 bytes long - a vanity principal, say - would pass a length
-        // check and then reconstruct as some other canister entirely.
-        let bytes = canister_id.as_slice();
-        assert!(
-            bytes.len() == CANISTER_ID_LEN && bytes[8..] == CANISTER_ID_TAG,
-            "Not a canister id: {canister_id}"
-        );
+        assert!(is_canister_id(&canister_id), "Not a canister id: {canister_id}");
         assert!(index <= MAX_USER_INDEX, "Index {index} is out of range");
 
         let mut new_bytes = [0; CANISTER_ID_LEN];
-        new_bytes[..8].copy_from_slice(&bytes[..8]);
+        new_bytes[..8].copy_from_slice(&canister_id.as_slice()[..8]);
         new_bytes[8] = index as u8;
         new_bytes[9] = INDEXED_TAG | (index >> 8) as u8;
         UserId(Principal::from_slice(&new_bytes))
@@ -75,6 +68,29 @@ impl UserId {
         }
     }
 
+    // The user whose wallet this ledger account is - the inverse of `From<UserId> for Account`.
+    // None for an account which is not a user's wallet: one whose subaccount is not of the form
+    // `From<UserId>` produces, or an indexed subaccount of an owner which is not a canister. The
+    // default subaccount maps to the owner itself, whether it is a canister or not, so that the
+    // wallets of bots and other non-canister users resolve too.
+    //
+    // There is no equivalent for `AccountIdentifier`, which is a hash and cannot be inverted.
+    pub fn from_account(account: &Account) -> Option<UserId> {
+        let index = match account.subaccount {
+            None => 0,
+            Some(bytes) if bytes[..30] == [0; 30] => u16::from_be_bytes([bytes[30], bytes[31]]),
+            Some(_) => return None,
+        };
+
+        if index == 0 {
+            Some(UserId(account.owner))
+        } else if index <= MAX_USER_INDEX && is_canister_id(&account.owner) {
+            Some(UserId::new_indexed(account.owner, index))
+        } else {
+            None
+        }
+    }
+
     // The user's index within the canister which holds their data. Zero when that canister holds
     // this user alone.
     pub fn index(&self) -> u16 {
@@ -94,6 +110,14 @@ impl UserId {
         let bytes = self.0.as_slice();
         bytes.len() == CANISTER_ID_LEN && bytes[CANISTER_ID_LEN - 1] & INDEXED_TAG != 0
     }
+}
+
+// Both the length and the trailing tag bytes, because `canister_id` rebuilds the latter from
+// scratch. Anything else 10 bytes long - a vanity principal, say - would pass a length check and
+// then reconstruct as some other canister entirely.
+fn is_canister_id(principal: &Principal) -> bool {
+    let bytes = principal.as_slice();
+    bytes.len() == CANISTER_ID_LEN && bytes[8..] == CANISTER_ID_TAG
 }
 
 impl From<Principal> for UserId {
@@ -279,5 +303,44 @@ mod tests {
         let mut expected = [0; 32];
         expected[30..].copy_from_slice(&1000u16.to_be_bytes());
         assert_eq!(account.subaccount, Some(expected));
+    }
+
+    #[test]
+    fn user_id_round_trips_through_its_account() {
+        let bot = UserId::from(Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]));
+        let mut user_ids = vec![UserId::new(canister_id()), bot];
+        user_ids.extend([1, 255, 256, 1000, MAX_USER_INDEX].map(|i| UserId::new_indexed(canister_id(), i)));
+
+        for user_id in user_ids {
+            assert_eq!(UserId::from_account(&Account::from(user_id)), Some(user_id), "{user_id}");
+        }
+    }
+
+    // The ledger treats an all-zero subaccount as the default one, so both spellings are the same
+    // account and must resolve to the same user.
+    #[test]
+    fn explicit_default_subaccount_resolves_to_the_unindexed_user() {
+        let account = Account { owner: canister_id(), subaccount: Some([0; 32]) };
+
+        assert_eq!(UserId::from_account(&account), Some(UserId::new(canister_id())));
+    }
+
+    #[test]
+    fn account_which_is_not_a_user_wallet_has_no_user_id() {
+        let mut arbitrary = [0; 32];
+        arbitrary[0] = 1;
+        let mut out_of_range = [0; 32];
+        out_of_range[30..].copy_from_slice(&(MAX_USER_INDEX + 1).to_be_bytes());
+        let mut indexed = [0; 32];
+        indexed[31] = 1;
+        let not_a_canister = Principal::from_slice(&[228, 104, 142, 9, 133, 211, 135, 217, 129, 1]);
+
+        for account in [
+            Account { owner: canister_id(), subaccount: Some(arbitrary) },
+            Account { owner: canister_id(), subaccount: Some(out_of_range) },
+            Account { owner: not_a_canister, subaccount: Some(indexed) },
+        ] {
+            assert_eq!(UserId::from_account(&account), None, "{account:?}");
+        }
     }
 }

--- a/backend/libraries/types/src/user.rs
+++ b/backend/libraries/types/src/user.rs
@@ -320,7 +320,10 @@ mod tests {
     // account and must resolve to the same user.
     #[test]
     fn explicit_default_subaccount_resolves_to_the_unindexed_user() {
-        let account = Account { owner: canister_id(), subaccount: Some([0; 32]) };
+        let account = Account {
+            owner: canister_id(),
+            subaccount: Some([0; 32]),
+        };
 
         assert_eq!(UserId::from_account(&account), Some(UserId::new(canister_id())));
     }
@@ -336,9 +339,18 @@ mod tests {
         let not_a_canister = Principal::from_slice(&[228, 104, 142, 9, 133, 211, 135, 217, 129, 1]);
 
         for account in [
-            Account { owner: canister_id(), subaccount: Some(arbitrary) },
-            Account { owner: canister_id(), subaccount: Some(out_of_range) },
-            Account { owner: not_a_canister, subaccount: Some(indexed) },
+            Account {
+                owner: canister_id(),
+                subaccount: Some(arbitrary),
+            },
+            Account {
+                owner: canister_id(),
+                subaccount: Some(out_of_range),
+            },
+            Account {
+                owner: not_a_canister,
+                subaccount: Some(indexed),
+            },
         ] {
             assert_eq!(UserId::from_account(&account), None, "{account:?}");
         }


### PR DESCRIPTION
Follow-up from the subaccount migration audit. Once a canister holds many users, a ledger account's owner is the canister rather than the user, so anything deriving a `UserId` from `owner` alone resolves to the wrong thing.

## `UserId::from_account`

The inverse of `From<UserId> for Account`. Resolves the default subaccount to the owner itself (so bots and other non-canister users still work), an index-shaped subaccount of a canister to the indexed user, and anything else to `None`. The canister-id check `new_indexed` already made is factored out and shared. Tests cover the round trip for unindexed, indexed and bot ids, the explicit all-zero subaccount (which the ledger treats as the default), and the accounts which are not a user's wallet.

There is no equivalent for `AccountIdentifier`, which is a hash.

## Removed, rather than fixed

Both places that derived a `UserId` from `owner` alone turned out to be dead code:

- `PendingCryptoTransaction::user_id()` in `types` has no callers (verified by renaming it and checking the workspace).
- The user index's `PendingPaymentReason::ReferralReward` and `inform_referrer` have not been reachable since referral rewards moved to CHIT in #6250. The variant is dropped from the enum; nothing in stable state can hold it since it was never constructed after that change and the queue drains on each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
