### PR TITLE
Route frontend wallet lookups through the user's ICRC account

### DIFF
--- a/frontend/app/src/components/home/AccountInfo.svelte
+++ b/frontend/app/src/components/home/AccountInfo.svelte
@@ -5,10 +5,12 @@
         cryptoLookup,
         currentUserIdStore,
         currentUserStore,
+        encodeIcrcAccount,
         ICP_SYMBOL,
         Lazy,
         type OneSecTransferFees,
         OpenChat,
+        userIdToIcrcAccount,
     } from "@client";
     import { i18nKey } from "../../i18n/i18n";
     import { _ } from "svelte-i18n";
@@ -68,7 +70,9 @@
         } else if (isOneSecNetwork) {
             return oneSecAddress;
         } else {
-            return $currentUserIdStore;
+            // The user's wallet, which is a subaccount of their canister once a canister holds
+            // many users. For a user alone in their canister this is just their user id.
+            return encodeIcrcAccount(userIdToIcrcAccount($currentUserIdStore));
         }
     });
 

--- a/frontend/app/src/components_mobile/home/AccountInfo.svelte
+++ b/frontend/app/src/components_mobile/home/AccountInfo.svelte
@@ -6,10 +6,12 @@
         cryptoLookup,
         currentUserIdStore,
         currentUserStore,
+        encodeIcrcAccount,
         ICP_SYMBOL,
         Lazy,
         OpenChat,
         type OneSecTransferFees,
+        userIdToIcrcAccount,
     } from "@client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
@@ -66,7 +68,9 @@
         } else if (isOneSecNetwork) {
             return oneSecAddress;
         } else {
-            return $currentUserIdStore;
+            // The user's wallet, which is a subaccount of their canister once a canister holds
+            // many users. For a user alone in their canister this is just their user id.
+            return encodeIcrcAccount(userIdToIcrcAccount($currentUserIdStore));
         }
     });
 

--- a/frontend/openchat-agent/src/services/ckbtcMinter/ckbtcMinter.client.ts
+++ b/frontend/openchat-agent/src/services/ckbtcMinter/ckbtcMinter.client.ts
@@ -1,10 +1,10 @@
 import type { HttpAgent, Identity } from "@icp-sdk/core/agent";
-import { Principal } from "@icp-sdk/core/principal";
 import { CandidCanisterAgent } from "../canisterAgent/candid";
 import { idlFactory, type CkbtcMinterService } from "./candid/idl";
 import { utxo } from "../bitcoin/mappers";
 import type { CkbtcMinterDepositInfo, CkbtcMinterWithdrawalInfo, Utxo } from "@shared";
 import { identity } from "../../utils/mapping";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 
 const MAINNET_CKBTC_MINTER_CANISTER_ID = "mqygn-kiaaa-aaaar-qaadq-cai";
 const TESTNET_CKBTC_MINTER_CANISTER_ID = "ml52i-qqaaa-aaaar-qaaba-cai";
@@ -23,12 +23,11 @@ export class CkbtcMinterClient extends CandidCanisterAgent<CkbtcMinterService> {
     }
 
     getKnownUtxos(userId: string): Promise<Utxo[]> {
+        // The minter derives each BTC address from an (owner, subaccount) pair, so this has to
+        // name the same account the user's canister generated the address for
+        const { owner, subaccount } = userIdToApiIcrcAccount(userId);
         return this.handleQueryResponse(
-            () =>
-                this.service.get_known_utxos({
-                    owner: [Principal.fromText(userId)],
-                    subaccount: [],
-                }),
+            () => this.service.get_known_utxos({ owner: [owner], subaccount }),
             (resp) => resp.map(utxo),
         );
     }

--- a/frontend/openchat-agent/src/services/icpLedgerIndex/icpLedgerIndex.client.ts
+++ b/frontend/openchat-agent/src/services/icpLedgerIndex/icpLedgerIndex.client.ts
@@ -1,7 +1,7 @@
 import type { HttpAgent, Identity } from "@icp-sdk/core/agent";
 import { idlFactory, type IcpLedgerIndexService } from "./candid/idl";
 import { CandidCanisterAgent } from "../canisterAgent/candid";
-import { Principal } from "@icp-sdk/core/principal";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 import { accountTransactions } from "./mappers";
 import type { AccountTransactionResult } from "@shared";
 import { apiOptional } from "../common/chatMappers";
@@ -12,13 +12,13 @@ export class IcpLedgerIndexClient extends CandidCanisterAgent<IcpLedgerIndexServ
         super(identity, agent, canisterId, idlFactory, "IcpLedgerIndex");
     }
 
-    getAccountTransactions(principal: string, fromId?: bigint): Promise<AccountTransactionResult> {
+    getAccountTransactions(userId: string, fromId?: bigint): Promise<AccountTransactionResult> {
         return this.handleQueryResponse(
             () =>
                 this.service.get_account_transactions({
                     max_results: 100n,
                     start: apiOptional(identity, fromId),
-                    account: { owner: Principal.fromText(principal), subaccount: [] },
+                    account: userIdToApiIcrcAccount(userId),
                 }),
             accountTransactions,
         );

--- a/frontend/openchat-agent/src/services/ledger/ledger.client.ts
+++ b/frontend/openchat-agent/src/services/ledger/ledger.client.ts
@@ -1,20 +1,19 @@
 import type { HttpAgent, Identity } from "@icp-sdk/core/agent";
 import { idlFactory, type LedgerService } from "./candid/idl";
 import { CandidCanisterAgent } from "../canisterAgent/candid";
-import { Principal } from "@icp-sdk/core/principal";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 
 export class LedgerClient extends CandidCanisterAgent<LedgerService> {
     constructor(identity: Identity, agent: HttpAgent) {
         super(identity, agent, undefined, idlFactory, "Ledger");
     }
 
-    accountBalance(ledger: string, accountPrincipal: string): Promise<bigint> {
+    accountBalance(ledger: string, userId: string): Promise<bigint> {
         return this.handleQueryResponse(
             () =>
-                this.service.icrc1_balance_of.withOptions({ canisterId: ledger })({
-                    owner: Principal.fromText(accountPrincipal),
-                    subaccount: [],
-                }),
+                this.service.icrc1_balance_of.withOptions({ canisterId: ledger })(
+                    userIdToApiIcrcAccount(userId),
+                ),
             (balance) => {
                 return balance;
             },

--- a/frontend/openchat-agent/src/services/ledgerIndex/ledgerIndex.client.ts
+++ b/frontend/openchat-agent/src/services/ledgerIndex/ledgerIndex.client.ts
@@ -1,7 +1,7 @@
 import type { HttpAgent, Identity } from "@icp-sdk/core/agent";
 import { idlFactory, type LedgerIndexService } from "./candid/idl";
 import { CandidCanisterAgent } from "../canisterAgent/candid";
-import { Principal } from "@icp-sdk/core/principal";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 import { accountTransactions } from "./mappers";
 import type { AccountTransactionResult } from "@shared";
 import { apiOptional } from "../common/chatMappers";
@@ -12,13 +12,13 @@ export class LedgerIndexClient extends CandidCanisterAgent<LedgerIndexService> {
         super(identity, agent, undefined, idlFactory, "LedgerIndex");
     }
 
-    getAccountTransactions(ledgerIndex: string, accountPrincipal: string, fromId?: bigint): Promise<AccountTransactionResult> {
+    getAccountTransactions(ledgerIndex: string, userId: string, fromId?: bigint): Promise<AccountTransactionResult> {
         return this.handleQueryResponse(
             () =>
                 this.service.get_account_transactions.withOptions({ canisterId: ledgerIndex })({
                     max_results: 100n,
                     start: apiOptional(identity, fromId),
-                    account: { owner: Principal.fromText(accountPrincipal), subaccount: [] },
+                    account: userIdToApiIcrcAccount(userId),
                 }),
             accountTransactions,
         );

--- a/frontend/openchat-agent/src/services/ledgerIndex/mappers.ts
+++ b/frontend/openchat-agent/src/services/ledgerIndex/mappers.ts
@@ -9,6 +9,8 @@ import {
     CommonResponses,
     type AccountTransactionResult,
     type AccountTransaction,
+    encodeIcrcAccount,
+    icrcAccountToUserId,
     UnsupportedValueError,
 } from "@shared";
 
@@ -103,6 +105,16 @@ export function memoBytesToString(candid: Uint8Array | number[]): string {
     return [...candid].map((n) => String.fromCharCode(n)).join("");
 }
 
-function account(candid: ApiAccount): string {
-    return candid.owner.toString();
+// The counterparty as the rest of the app names it: a userId where the account is a user's wallet,
+// which is what lets the UI resolve it to that user. Anything else - an exchange's subaccount, say -
+// keeps its full textual encoding rather than being flattened to its owner, since two subaccounts of
+// one owner are different counterparties.
+function account({ owner, subaccount }: ApiAccount): string {
+    const account = {
+        owner,
+        subaccount: optional(subaccount, (bytes) => Uint8Array.from(bytes)),
+    };
+    const userId = icrcAccountToUserId(account);
+
+    return userId ?? encodeIcrcAccount(account);
 }

--- a/frontend/openchat-agent/src/services/oneSecForwarder/oneSecForwarder.client.ts
+++ b/frontend/openchat-agent/src/services/oneSecForwarder/oneSecForwarder.client.ts
@@ -1,8 +1,8 @@
 import type { HttpAgent, Identity } from "@icp-sdk/core/agent";
-import { Principal } from "@icp-sdk/core/principal";
 import { idlFactory, type OneSecForwarderService } from "./candid/idl";
 import { CandidCanisterAgent } from "../canisterAgent/candid";
 import { identity, toVoid } from "../../utils/mapping";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 
 export class OneSecForwarderClient extends CandidCanisterAgent<OneSecForwarderService> {
     constructor(identity: Identity, agent: HttpAgent, canisterId: string) {
@@ -16,14 +16,8 @@ export class OneSecForwarderClient extends CandidCanisterAgent<OneSecForwarderSe
     }
 
     enableForwarding(userId: string): Promise<void> {
-        const args = {
-            icp_account: {
-                ICRC: {
-                    owner: Principal.fromText(userId),
-                    subaccount: [] as [] | [Uint8Array],
-                }
-            }
-        };
+        // Forwarded deposits are paid into this account, so it must be the user's wallet
+        const args = { icp_account: { ICRC: userIdToApiIcrcAccount(userId) } };
 
         return this.handleResponse(
             this.service.enable_forwarding(args),

--- a/frontend/openchat-agent/src/services/oneSecMinter/mappers.ts
+++ b/frontend/openchat-agent/src/services/oneSecMinter/mappers.ts
@@ -20,7 +20,7 @@ import {
     USDT_SYMBOL,
 } from "@shared";
 import { identity, optional } from "../../utils/mapping";
-import { Principal } from "@icp-sdk/core/principal";
+import { userIdToApiIcrcAccount } from "../../utils/icrcAccount";
 
 export function forwardingResponse(
     candid: { Ok: ApiForwardingResponse } | { Err: string },
@@ -65,12 +65,7 @@ export function apiForwardEvmToIcpArgs(
         token: apiToken(tokenSymbol),
         chain: apiEvmChain(chain),
         address,
-        receiver: {
-            ICRC: {
-                owner: Principal.fromText(receiver),
-                subaccount: [] as [],
-            },
-        },
+        receiver: { ICRC: userIdToApiIcrcAccount(receiver) },
     };
 }
 

--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -2983,15 +2983,15 @@ export class OpenChatAgent extends EventTarget {
         return this._dataClient.storageStatus();
     }
 
-    refreshAccountBalance(ledger: string, principal: string): Promise<bigint> {
+    refreshAccountBalance(ledger: string, userId: string): Promise<bigint> {
         if (offline()) return Promise.resolve(0n);
 
-        return this._ledgerClient.accountBalance(ledger, principal);
+        return this._ledgerClient.accountBalance(ledger, userId);
     }
 
     getAccountTransactions(
         ledgerIndex: string,
-        principal: string,
+        userId: string,
         fromId?: bigint,
     ): Promise<AccountTransactionResult> {
         const isNns = this._registryValue?.nervousSystemSummary.some(
@@ -3003,9 +3003,9 @@ export class OpenChatAgent extends EventTarget {
                 this.identity,
                 this._agent,
                 ledgerIndex,
-            ).getAccountTransactions(principal, fromId);
+            ).getAccountTransactions(userId, fromId);
         }
-        return this._ledgerIndexClient.getAccountTransactions(ledgerIndex, principal, fromId);
+        return this._ledgerIndexClient.getAccountTransactions(ledgerIndex, userId, fromId);
     }
 
     getMessagesByMessageIndex(

--- a/frontend/openchat-agent/src/utils/icrcAccount.spec.ts
+++ b/frontend/openchat-agent/src/utils/icrcAccount.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { userIdToApiIcrcAccount } from "./icrcAccount";
+
+describe("userIdToApiIcrcAccount", () => {
+    const canisterId = "dfdal-2uaaa-aaaaa-qaama-cai";
+
+    test("a user alone in their canister is the canister's default account", () => {
+        const account = userIdToApiIcrcAccount(canisterId);
+
+        expect(account.owner.toText()).toBe(canisterId);
+        expect(account.subaccount).toEqual([]);
+    });
+
+    test("an indexed user is a subaccount of the canister holding them", () => {
+        // `UserId::new_indexed(canisterId, 1000)`, per the vector in openchat-shared
+        const account = userIdToApiIcrcAccount("svgk6-q4aaa-aaaaa-qaamo-ray");
+
+        expect(account.owner.toText()).toBe(canisterId);
+        expect(account.subaccount).toHaveLength(1);
+        const subaccount = account.subaccount[0]!;
+        expect(subaccount).toHaveLength(32);
+        expect(Array.from(subaccount.subarray(30))).toEqual([0x03, 0xe8]);
+        expect(subaccount.subarray(0, 30).every((b) => b === 0)).toBe(true);
+    });
+});

--- a/frontend/openchat-agent/src/utils/icrcAccount.ts
+++ b/frontend/openchat-agent/src/utils/icrcAccount.ts
@@ -1,0 +1,20 @@
+import type { Principal } from "@icp-sdk/core/principal";
+import { userIdToIcrcAccount } from "@shared";
+
+export type ApiIcrcAccount = {
+    owner: Principal;
+    subaccount: [] | [Uint8Array];
+};
+
+// The ledger account holding a user's funds, in the shape the candid interfaces take. Every query
+// or instruction which concerns "the user's wallet" - balance, history, deposits being routed to
+// them - has to name this account rather than the bare user id: once a canister holds many users,
+// the user id is not a principal anyone can sign for, and the funds live in a subaccount of the
+// canister. For a user who is alone in their canister the two are the same account.
+//
+// Accepts a plain canister id too (eg. the translations canister's balance), which maps to its
+// default account unchanged.
+export function userIdToApiIcrcAccount(userId: string): ApiIcrcAccount {
+    const { owner, subaccount } = userIdToIcrcAccount(userId);
+    return { owner, subaccount: subaccount === undefined ? [] : [subaccount] };
+}

--- a/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
@@ -1,24 +1,24 @@
 import { Principal } from "@icp-sdk/core/principal";
 import { describe, expect, test } from "vitest";
-import { encodeIcrcAccount, userIdToIcrcAccount } from "./icrcAccount";
+import { encodeIcrcAccount, icrcAccountToUserId, userIdToIcrcAccount } from "./icrcAccount";
+
+const canisterId = "dfdal-2uaaa-aaaaa-qaama-cai";
+
+// Taken from `impl From<UserId> for Account` in backend/libraries/types/src/user.rs by feeding
+// it `UserId::new_indexed(canisterId, index)`. The two implementations have to agree exactly:
+// the account they produce is the spender an external wallet approves, so a mismatch would have
+// the wallet approve an account the user's canister never spends as, and every payment pulled
+// from that wallet would fail as an insufficient allowance.
+const vectors: [number, string, string | undefined][] = [
+    [0, canisterId, undefined],
+    [1, "qp43m-xeaaa-aaaaa-qaama-daa", "01"],
+    [255, "bhdhu-34aaa-aaaaa-qaamp-7aa", "ff"],
+    [256, "5xs3p-c4aaa-aaaaa-qaama-bai", "0100"],
+    [1000, "svgk6-q4aaa-aaaaa-qaamo-ray", "03e8"],
+    [32767, "zf6bn-quaaa-aaaaa-qaamp-77y", "7fff"],
+];
 
 describe("userIdToIcrcAccount", () => {
-    const canisterId = "dfdal-2uaaa-aaaaa-qaama-cai";
-
-    // Taken from `impl From<UserId> for Account` in backend/libraries/types/src/user.rs by feeding
-    // it `UserId::new_indexed(canisterId, index)`. The two implementations have to agree exactly:
-    // the account they produce is the spender an external wallet approves, so a mismatch would have
-    // the wallet approve an account the user's canister never spends as, and every payment pulled
-    // from that wallet would fail as an insufficient allowance.
-    const vectors: [number, string, string | undefined][] = [
-        [0, canisterId, undefined],
-        [1, "qp43m-xeaaa-aaaaa-qaama-daa", "01"],
-        [255, "bhdhu-34aaa-aaaaa-qaamp-7aa", "ff"],
-        [256, "5xs3p-c4aaa-aaaaa-qaama-bai", "0100"],
-        [1000, "svgk6-q4aaa-aaaaa-qaamo-ray", "03e8"],
-        [32767, "zf6bn-quaaa-aaaaa-qaamp-77y", "7fff"],
-    ];
-
     test.each(vectors)("index %i", (_index, userId, subaccountHex) => {
         const account = userIdToIcrcAccount(userId);
 
@@ -52,6 +52,61 @@ describe("userIdToIcrcAccount", () => {
         expect(address.endsWith(".1")).toBe(true);
     });
 });
+
+describe("icrcAccountToUserId", () => {
+    // The inverse has to agree with the forward direction for every index, else a transaction to a
+    // user's wallet would be attributed to the canister holding them rather than to the user, and
+    // every user in one canister would collapse to the same counterparty.
+    test.each(vectors)("index %i round trips", (_index, userId) => {
+        expect(icrcAccountToUserId(userIdToIcrcAccount(userId))).toBe(userId);
+    });
+
+    test("an explicit all-zero subaccount is the unindexed user", () => {
+        const account = { owner: Principal.fromText(canisterId), subaccount: new Uint8Array(32) };
+
+        expect(icrcAccountToUserId(account)).toBe(canisterId);
+    });
+
+    test("a bot id, which is not a canister, is still its own wallet", () => {
+        const botId = Principal.fromUint8Array(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])).toText();
+
+        expect(icrcAccountToUserId({ owner: Principal.fromText(botId) })).toBe(botId);
+    });
+
+    test("an indexed subaccount of an owner which is not a canister is nobody's wallet", () => {
+        const owner = Principal.fromUint8Array(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+
+        expect(icrcAccountToUserId({ owner, subaccount: subaccountOf(1) })).toBeUndefined();
+    });
+
+    test("a subaccount which is not of the indexed form is nobody's wallet", () => {
+        const owner = Principal.fromText(canisterId);
+        const arbitrary = subaccountOf(1);
+        arbitrary[0] = 1;
+
+        expect(icrcAccountToUserId({ owner, subaccount: arbitrary })).toBeUndefined();
+    });
+
+    test("an index beyond the range a UserId can hold is nobody's wallet", () => {
+        const owner = Principal.fromText(canisterId);
+
+        expect(icrcAccountToUserId({ owner, subaccount: subaccountOf(32767) })).not.toBeUndefined();
+        expect(icrcAccountToUserId({ owner, subaccount: subaccountOf(32768) })).toBeUndefined();
+    });
+
+    test("a subaccount of the wrong length is nobody's wallet", () => {
+        const owner = Principal.fromText(canisterId);
+
+        expect(icrcAccountToUserId({ owner, subaccount: new Uint8Array(31) })).toBeUndefined();
+    });
+});
+
+function subaccountOf(index: number): Uint8Array {
+    const subaccount = new Uint8Array(32);
+    subaccount[30] = (index >> 8) & 0xff;
+    subaccount[31] = index & 0xff;
+    return subaccount;
+}
 
 function toHex(bytes: Uint8Array): string {
     return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");

--- a/frontend/openchat-shared/src/utils/icrcAccount.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.ts
@@ -130,6 +130,10 @@ const CANISTER_ID_TAG = [0x01, 0x01];
 // Set in a UserId's final byte to mark it as carrying the user's index within their canister. No
 // class tag the IC defines has the top bit set, so a byte which does cannot be one.
 const INDEXED_TAG = 0x80;
+// Every ICRC-1 subaccount is exactly this long, the index occupying the final two bytes.
+const SUBACCOUNT_LENGTH = 32;
+// The largest index the seven spare bits of a UserId's final byte, plus the byte before it, hold.
+const MAX_USER_INDEX = (1 << 15) - 1;
 
 // The ledger account holding a user's funds, which is also the account their canister spends as
 // when pulling from an external wallet via ICRC-2. Mirrors `impl From<UserId> for Account` in
@@ -145,9 +149,9 @@ export function userIdToIcrcAccount(userId: string): IcrcAccount {
         return { owner: Principal.fromUint8Array(canisterIdBytes(bytes)) };
     }
 
-    const subaccount = new Uint8Array(32);
-    subaccount[30] = (index >> 8) & 0xff;
-    subaccount[31] = index & 0xff;
+    const subaccount = new Uint8Array(SUBACCOUNT_LENGTH);
+    subaccount[SUBACCOUNT_LENGTH - 2] = (index >> 8) & 0xff;
+    subaccount[SUBACCOUNT_LENGTH - 1] = index & 0xff;
 
     return { owner: Principal.fromUint8Array(canisterIdBytes(bytes)), subaccount };
 }
@@ -171,5 +175,56 @@ function userIndex(bytes: Uint8Array): number {
 function isIndexed(bytes: Uint8Array): boolean {
     return (
         bytes.length === CANISTER_ID_LENGTH && (bytes[CANISTER_ID_LENGTH - 1] & INDEXED_TAG) !== 0
+    );
+}
+
+// The user whose wallet this ledger account is - the inverse of `userIdToIcrcAccount`, mirroring
+// `UserId::from_account` in backend/libraries/types/src/user.rs. Undefined for an account which is
+// not a user's wallet: one whose subaccount is not of the form `userIdToIcrcAccount` produces, or
+// an indexed subaccount of an owner which is not a canister. The default subaccount maps to the
+// owner itself, whether or not that is a canister, so the wallets of bots and other non-canister
+// users resolve too.
+//
+// There is no equivalent for the ICP ledger's AccountIdentifier, which is a hash and so cannot be
+// inverted.
+export function icrcAccountToUserId({ owner, subaccount }: IcrcAccount): string | undefined {
+    const index = subaccountIndex(subaccount);
+
+    if (index === undefined) return undefined;
+    if (index === 0) return owner.toText();
+    if (index > MAX_USER_INDEX || !isCanisterId(owner)) return undefined;
+
+    return indexedUserId(owner, index);
+}
+
+// The index a subaccount carries, or undefined if it is not one `userIdToIcrcAccount` produces.
+// Both the default subaccount and an all-zero one mean index 0.
+function subaccountIndex(subaccount: Uint8Array | undefined): number | undefined {
+    if (subaccount === undefined) return 0;
+    if (subaccount.length !== SUBACCOUNT_LENGTH) return undefined;
+    if (!subaccount.subarray(0, SUBACCOUNT_LENGTH - 2).every((b) => b === 0)) return undefined;
+
+    return (subaccount[SUBACCOUNT_LENGTH - 2] << 8) | subaccount[SUBACCOUNT_LENGTH - 1];
+}
+
+// Mirrors `UserId::new_indexed`: the index takes the place of the canister id's two trailing tag
+// bytes, which is what `canisterIdBytes` reverses.
+function indexedUserId(canisterId: Principal, index: number): string {
+    const bytes = new Uint8Array(CANISTER_ID_LENGTH);
+    bytes.set(canisterId.toUint8Array().subarray(0, 8));
+    bytes[8] = index & 0xff;
+    bytes[9] = INDEXED_TAG | (index >> 8);
+    return Principal.fromUint8Array(bytes).toText();
+}
+
+// Both the length and the trailing tag bytes, because `indexedUserId` rebuilds an id from the
+// leading 8 alone. Anything else of canister id length would pass a length check and then come
+// back as some other canister entirely.
+function isCanisterId(principal: Principal): boolean {
+    const bytes = principal.toUint8Array();
+    return (
+        bytes.length === CANISTER_ID_LENGTH &&
+        bytes[8] === CANISTER_ID_TAG[0] &&
+        bytes[9] === CANISTER_ID_TAG[1]
     );
 }


### PR DESCRIPTION
## Summary

Every place the frontend named a user's wallet built the ledger account as `{ owner: userId, subaccount: [] }`. Once a canister holds many users (the upcoming MultiUser canister), a user's wallet is a subaccount of that canister rather than the user id's default account, so the bare user id would point at the wrong account.

- Adds `userIdToApiIcrcAccount` in `openchat-agent/src/utils/icrcAccount.ts`, a thin candid-shaped wrapper over the existing `userIdToIcrcAccount` from `openchat-shared`, which mirrors the backend `From<UserId> for Account` conversion.
- Routes these sites through it: ledger `icrc1_balance_of`, ICRC and ICP ledger index `get_account_transactions`, ckBTC minter `get_known_utxos`, OneSec forwarder `enable_forwarding` destination, OneSec minter `forward_evm_to_icp` receiver.
- The receive screen (`AccountInfo.svelte`, desktop and mobile) shows the ICRC-1 textual encoding of the wallet account instead of the bare user id.

It also handles the response side of the index query. The ICRC transaction mapper reduced every account to its owner, discarding the subaccount, which would have attributed each transaction to the canister holding the user rather than to the user, collapsing every user in one canister to the same counterparty. So this adds `icrcAccountToUserId`, the inverse of `userIdToIcrcAccount` and the frontend mirror of `UserId::from_account` from #9289, and maps each account through it. An account which is not a user's wallet now keeps its full textual encoding rather than being flattened to its owner, since two subaccounts of one owner are different counterparties.

For a user alone in their canister (index 0) every one of these produces exactly the same account, the same displayed address and the same mapped counterparty as before, so this is behaviour-neutral today.

Follows on from #9289 (backend `UserId::from_account`).

## Test plan

- [x] `npm run typecheck:agent` clean
- [x] `npx vitest --run icrcAccount` passes, 23 tests across the shared and agent specs, including a round trip of the two conversions over the vectors taken from the backend
- [x] `npm run lint` clean
- [x] `npm run typecheck` (svelte-check) reports only pre-existing missing-module errors in `signer.ts` and `transcodeWorker.ts`, which this PR does not touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
