### PR TITLE
Fix empty chat on select: backend events trap, cache fallback, diagnostics

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
+- Clamp events queries to the caller's min visible event index instead of trapping when the start index is below it ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
+### Fixed
+
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
+
 ## [[2.0.2045](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2045-community)] - 2026-08-26
 
 ### Changed

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 
+### Fixed
+
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
+
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 
 ### Added

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
+- Clamp events queries to the caller's min visible event index instead of trapping when the start index is below it ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2036](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2036-group)] - 2026-08-20
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Validate the whole recipient account rather than only its owner when sending crypto ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2015](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2015-user)] - 2026-08-13
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Validate the whole recipient account rather than only its owner when sending crypto ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#XXXX](https://github.com/open-chat-labs/open-chat/pull/XXXX))
 
 ## [[2.0.2015](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2015-user)] - 2026-08-13
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Validate the whole recipient account rather than only its owner when sending crypto ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
-- Return no events instead of trapping when an events query's start index is below the caller's min visible event index ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
+- Clamp events queries to the caller's min visible event index instead of trapping when the start index is below it ([#9291](https://github.com/open-chat-labs/open-chat/pull/9291))
 
 ## [[2.0.2015](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2015-user)] - 2026-08-13
 

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -151,6 +151,10 @@ impl ChatEventsList {
             (min_visible_event_index, self.latest_event_index.unwrap_or_default())
         };
 
+        if min > max {
+            return Box::new(std::iter::empty());
+        }
+
         let iter = self.events_map.range(min..=max);
 
         if ascending {
@@ -603,7 +607,7 @@ mod tests {
     use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
     use rand::random;
     use std::mem::size_of;
-    use types::Milliseconds;
+    use types::{Milliseconds, MultiUserChat};
 
     #[test]
     fn enum_size() {
@@ -749,6 +753,30 @@ mod tests {
         assert_eq!(event_indexes, (0..=first.index.into()).rev().collect_vec());
     }
 
+    // A caller whose min visible index is above the requested start (stale client summary,
+    // role change, lapsed membership) must get nothing back rather than a trap
+    #[test]
+    fn scan_descending_below_min_visible_returns_empty() {
+        let events = setup_group_events();
+        let events_reader = events.visible_main_events_reader(50.into());
+
+        let results = events_reader.scan(Some(EventKey::EventIndex(30.into())), false, usize::MAX, usize::MAX, None);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn window_at_min_visible_does_not_panic() {
+        let events = setup_group_events();
+        let events_reader = events.visible_main_events_reader(50.into());
+
+        let results = events_reader.window(EventKey::EventIndex(50.into()), usize::MAX, usize::MAX, None);
+
+        let event_indexes: Vec<usize> = results.iter().map(|e| e.as_event().unwrap().index.into()).collect();
+        assert!(!event_indexes.is_empty());
+        assert!(event_indexes.iter().all(|i| *i >= 50));
+    }
+
     #[test]
     fn window_message_limit() {
         let events = setup_events(None);
@@ -793,6 +821,27 @@ mod tests {
         let event_indexes: Vec<_> = results.into_iter().map(|e| e.as_event().unwrap().index).sorted().collect();
 
         assert_eq!(event_indexes, (46..=70).map(|i| i.into()).collect_vec());
+    }
+
+    // Group chats keep recent events in the in-memory fast map, whose range() traps on an
+    // inverted range, unlike the stable memory map direct chats use
+    fn setup_group_events() -> ChatEvents {
+        let memory = MemoryManager::init(DefaultMemoryImpl::default());
+        stable_memory_map::init(memory.get(MemoryId::new(1)));
+
+        let mut events = ChatEvents::new_group_chat(
+            MultiUserChat::Group(Principal::from_slice(&[1]).into()),
+            "name".to_string(),
+            "description".to_string(),
+            Principal::from_slice(&[2]).into(),
+            None,
+            random(),
+            1,
+        );
+
+        push_events(&mut events, 2);
+
+        events
     }
 
     fn setup_events(events_ttl: Option<Milliseconds>) -> ChatEvents {

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use std::cmp::max;
 use std::collections::hash_map::Entry::Vacant;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
@@ -140,7 +141,9 @@ impl ChatEventsList {
         let (min, max) = if let Some(start) = start {
             if let Some(index) = self.event_index(start) {
                 if ascending {
-                    (index, self.latest_event_index.unwrap_or_default())
+                    // A start below the caller's min visible index (stale client summary, explicit
+                    // link into hidden history) must not expose events they cannot see
+                    (max(index, min_visible_event_index), self.latest_event_index.unwrap_or_default())
                 } else {
                     (min_visible_event_index, index)
                 }
@@ -763,6 +766,29 @@ mod tests {
         let results = events_reader.scan(Some(EventKey::EventIndex(30.into())), false, usize::MAX, usize::MAX, None);
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn scan_ascending_below_min_visible_starts_at_min_visible() {
+        let events = setup_group_events();
+        let events_reader = events.visible_main_events_reader(50.into());
+
+        let results = events_reader.scan(Some(EventKey::EventIndex(30.into())), true, usize::MAX, usize::MAX, None);
+
+        let event_indexes: Vec<usize> = results.iter().map(|e| e.as_event().unwrap().index.into()).collect();
+        assert_eq!(event_indexes[0], 50);
+    }
+
+    #[test]
+    fn window_below_min_visible_returns_only_visible_events() {
+        let events = setup_group_events();
+        let events_reader = events.visible_main_events_reader(50.into());
+
+        let results = events_reader.window(EventKey::EventIndex(30.into()), usize::MAX, usize::MAX, None);
+
+        let event_indexes: Vec<usize> = results.iter().map(|e| e.as_event().unwrap().index.into()).collect();
+        assert!(!event_indexes.is_empty());
+        assert!(event_indexes.iter().all(|i| *i >= 50));
     }
 
     #[test]

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -143,7 +143,10 @@ impl ChatEventsList {
                 if ascending {
                     // A start below the caller's min visible index (stale client summary, explicit
                     // link into hidden history) must not expose events they cannot see
-                    (max(index, min_visible_event_index), self.latest_event_index.unwrap_or_default())
+                    (
+                        max(index, min_visible_event_index),
+                        self.latest_event_index.unwrap_or_default(),
+                    )
                 } else {
                     (min_visible_event_index, index)
                 }

--- a/backend/libraries/chat_events/src/hybrid_map.rs
+++ b/backend/libraries/chat_events/src/hybrid_map.rs
@@ -129,6 +129,11 @@ impl<'a, MSlow: EventsMap> Iter<'a, MSlow> {
         if next_back > map.latest_event_index {
             next_back = map.latest_event_index;
         }
+        // An inverted range (eg. a caller whose min visible index is above the requested start)
+        // is empty; the std BTreeMap backing the fast map traps on it
+        if next > next_back {
+            return Iter::empty(map);
+        }
         Iter {
             map,
             fast_start: if map.fast_enabled() {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3132,11 +3132,25 @@ export class OpenChat {
         if (selectedChat !== undefined) {
             if (!this.#uninstalledBotChat(selectedChat)) {
                 if (messageIndex !== undefined) {
-                    this.loadEventWindow(chatId, messageIndex, undefined, true).then(() => {
-                        if (serverChat !== undefined) {
-                            this.#loadChatDetails(serverChat);
-                        }
-                    });
+                    // The window is anchored on the first unread message, which is
+                    // usually not cached yet, so this is a network round trip even when
+                    // the chat's history is fully cached. If it fails (offline, replica
+                    // behind, gateway error) nothing else loads the chat: no
+                    // loadedMessageWindow is published, the event list never
+                    // initialises, and scroll-driven loading stays gated off. Fall back
+                    // to the cached history so the user is not left staring at an empty
+                    // chat.
+                    this.loadEventWindow(chatId, messageIndex, undefined, true)
+                        .then((loaded) =>
+                            loaded === undefined
+                                ? this.loadPreviousMessages(chatId, undefined, true)
+                                : undefined,
+                        )
+                        .then(() => {
+                            if (serverChat !== undefined) {
+                                this.#loadChatDetails(serverChat);
+                            }
+                        });
                 } else {
                     this.loadPreviousMessages(chatId, undefined, true).then(() => {
                         if (serverChat !== undefined) {
@@ -3388,10 +3402,16 @@ export class OpenChat {
         return threadEventsStore.value.length === 0 ? undefined : threadEventsStore.value[0].index;
     }
 
-    previousThreadMessagesCriteria(thread: ThreadSummary): [number, boolean] {
+    previousThreadMessagesCriteria(thread: ThreadSummary): [number, boolean] | undefined {
         const minLoadedEventIndex = this.earliestLoadedThreadIndex();
         if (minLoadedEventIndex === undefined) {
             return [thread.latestEventIndex, false];
+        }
+        // Thread events start at index 0. Once it is loaded there is nothing
+        // earlier to ask for; a start index of -1 makes the cache iterator
+        // throw ("Start index exceeds bound") and the whole load fails.
+        if (minLoadedEventIndex <= 0) {
+            return undefined;
         }
         return [minLoadedEventIndex - 1, false];
     }
@@ -3409,7 +3429,11 @@ export class OpenChat {
 
         if (threadRootEvent !== undefined && threadRootEvent.event.thread !== undefined) {
             const thread = threadRootEvent.event.thread;
-            const [index, ascending] = this.previousThreadMessagesCriteria(thread);
+            const threadCriteria = this.previousThreadMessagesCriteria(thread);
+            if (threadCriteria === undefined) {
+                return;
+            }
+            const [index, ascending] = threadCriteria;
             return this.loadThreadMessages(
                 chatId,
                 [0, thread.latestEventIndex],

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -665,10 +665,11 @@ export class OpenChat {
     #userLocation: string | undefined;
     #logger: Logger;
     // Diagnostics for the "selected chat renders empty" report. Every path that can leave a
-    // chat empty does so without an error, so record which one fired. One report per reason
-    // and three per session, so a widespread cause cannot flood Rollbar.
-    #emptyChatReports = 0;
-    #emptyChatReasons = new Set<string>();
+    // chat empty does so without an error, so record which one fired. One chat selection is
+    // one incident, and at most three incidents are reported per session so a widespread
+    // cause cannot flood Rollbar.
+    #chatSelectionSeq = 0;
+    #emptyChatIncidents = new Set<number>();
     #lastOnlineDatesPending = new Set<string>();
     #lastOnlineDatesPromise: Promise<Record<string, number>> | undefined;
     #membershipCheck: number | undefined;
@@ -915,37 +916,59 @@ export class OpenChat {
     }
 
     #reportEmptyChat(reason: string, context: Record<string, unknown>): void {
-        if (this.#emptyChatReports >= 3 || this.#emptyChatReasons.has(reason)) return;
-        this.#emptyChatReports++;
-        this.#emptyChatReasons.add(reason);
+        // The logger only sends when online, so an offline report would spend the budget
+        // for nothing
+        if (get(offlineStore)) return;
+        const incident = this.#chatSelectionSeq;
+        if (this.#emptyChatIncidents.size >= 3 && !this.#emptyChatIncidents.has(incident)) {
+            return;
+        }
+        this.#emptyChatIncidents.add(incident);
         const message = `EmptyChatDiagnostic: ${reason}`;
         this.#logger.error(message, new Error(message), context);
     }
 
-    // Fires a few seconds after a chat is selected: if it is still the selected chat and nothing
-    // has been loaded into the event store, report it along with what the selection did.
-    #watchForEmptyChat(chatId: ChatIdentifier, load: { path: string; result: string }): void {
-        window.setTimeout(() => {
-            const chat = chatSummariesStore.value.get(chatId);
-            if (
-                chat === undefined ||
-                chat.latestEventIndex <= 0 ||
-                !chatIdentifiersEqual(chatId, selectedChatIdStore.value) ||
-                serverEventsStore.value.length > 0 ||
-                expiredServerEventRanges.value.length > 0
-            ) {
-                return;
-            }
-            this.#reportEmptyChat("still_empty_after_select", {
-                chatId: chatIdentifierToString(chatId),
-                chatKind: chat.kind,
-                path: load.path,
-                result: load.result,
-                latestEventIndex: chat.latestEventIndex,
-                minVisibleEventIndex: this.earliestAvailableEventIndex(chat),
-                offline: get(offlineStore),
-            });
-        }, 5000);
+    // Runs once the initial load of a selected chat has settled: if it is still the selected
+    // chat and nothing reached the event store, report it along with what the selection did.
+    #checkForEmptyChat(chatId: ChatIdentifier, path: string): void {
+        const chat = chatSummariesStore.value.get(chatId);
+        if (
+            chat === undefined ||
+            chat.latestEventIndex <= 0 ||
+            !chatIdentifiersEqual(chatId, selectedChatIdStore.value) ||
+            this.maskChatMessages(chat) ||
+            serverEventsStore.value.length > 0 ||
+            expiredServerEventRanges.value.length > 0
+        ) {
+            return;
+        }
+        this.#reportEmptyChat("still_empty_after_load", {
+            chatId: chatIdentifierToString(chatId),
+            chatKind: chat.kind,
+            path,
+            latestEventIndex: chat.latestEventIndex,
+            minVisibleEventIndex: this.earliestAvailableEventIndex(chat),
+        });
+    }
+
+    // The initial load is the only thing that loads a freshly selected chat or thread: if it
+    // fails nothing publishes loadedMessageWindow, the event list never initialises, and
+    // scroll-driven loading stays gated off. Load the latest history instead, from a clean
+    // store, since a partially cached window may already have been applied to it.
+    async #fallBackToPreviousMessages(
+        chatId: ChatIdentifier,
+        threadRootEvent?: EventWrapper<Message>,
+    ): Promise<void> {
+        if (threadRootEvent === undefined) {
+            if (!chatIdentifiersEqual(chatId, selectedChatIdStore.value)) return;
+            serverEventsStore.set([]);
+            expiredServerEventRanges.set(new DRange());
+        } else {
+            const context = { chatId, threadRootMessageIndex: threadRootEvent.event.messageIndex };
+            if (!messageContextsEqual(context, selectedThreadIdStore.value)) return;
+            serverThreadEventsStore.set([]);
+        }
+        await this.loadPreviousMessages(chatId, threadRootEvent, true);
     }
 
     logError(message: unknown, error: unknown, ...optionalParams: unknown[]): void {
@@ -2716,6 +2739,9 @@ export class OpenChat {
             .catch(CommonResponses.failure);
 
         if (!isSuccessfulEventsResponse(eventsResponse)) {
+            if (initialLoad) {
+                await this.#fallBackToPreviousMessages(chatId, threadRootEvent);
+            }
             return undefined;
         }
 
@@ -2772,7 +2798,7 @@ export class OpenChat {
                 )
                 .toPromise()
                 .catch((err) => {
-                    if (initialLoad) {
+                    if (initialLoad && !this.maskChatMessages(clientChat)) {
                         this.#reportEmptyChat("window_load_failed", {
                             chatId: chatIdentifierToString(chatId),
                             messageIndex,
@@ -2783,6 +2809,9 @@ export class OpenChat {
                 });
 
             if (!isSuccessfulEventsResponse(eventsResponse)) {
+                if (initialLoad) {
+                    await this.#fallBackToPreviousMessages(chatId);
+                }
                 return undefined;
             }
 
@@ -3128,6 +3157,11 @@ export class OpenChat {
                 }
             }
             chat = chatSummariesStore.value.get(chatId);
+
+            // The user may have moved on while the preview was in flight
+            if (!chatIdentifiersEqual(chatId, selectedChatIdStore.value)) {
+                return;
+            }
         }
 
         if (chat !== undefined) {
@@ -3156,6 +3190,8 @@ export class OpenChat {
             return;
         }
 
+        this.#chatSelectionSeq++;
+
         if (messageIndex === undefined) {
             messageIndex = isPreviewing(clientChat)
                 ? undefined
@@ -3171,17 +3207,22 @@ export class OpenChat {
                     messageIndex = undefined;
                 }
             }
+        }
 
-            // A member who has never read anything gets message 0 as the first unread. In a
-            // chat whose history is hidden from them that message is below their min visible
-            // index, and a window anchored on it fails.
-            if (
-                messageIndex !== undefined &&
-                clientChat.kind !== "direct_chat" &&
-                messageIndex < clientChat.minVisibleMessageIndex
-            ) {
-                messageIndex = undefined;
-            }
+        // A message below the caller's min visible index cannot anchor a window: a member who
+        // has never read anything gets message 0 as their first unread even when the chat's
+        // history is hidden from them, and a link can point into that history. Anchor on the
+        // first visible message instead, if there is one.
+        if (
+            messageIndex !== undefined &&
+            clientChat.kind !== "direct_chat" &&
+            messageIndex < clientChat.minVisibleMessageIndex
+        ) {
+            const latestMessageIndex = clientChat.latestMessage?.event.messageIndex ?? -1;
+            messageIndex =
+                clientChat.minVisibleMessageIndex <= latestMessageIndex
+                    ? clientChat.minVisibleMessageIndex
+                    : undefined;
         }
 
         // TODO - this might belong as a derivation in the selected chat state
@@ -3201,42 +3242,17 @@ export class OpenChat {
         }
         if (selectedChat !== undefined) {
             if (!this.#uninstalledBotChat(selectedChat)) {
-                const load = {
-                    path: messageIndex !== undefined ? "window" : "previous",
-                    result: "pending",
-                };
-                this.#watchForEmptyChat(chatId, load);
-                if (messageIndex !== undefined) {
-                    // The window is anchored on the first unread message, which is
-                    // usually not cached yet, so this is a network round trip even when
-                    // the chat's history is fully cached. If it fails (offline, replica
-                    // behind, gateway error) nothing else loads the chat: no
-                    // loadedMessageWindow is published, the event list never
-                    // initialises, and scroll-driven loading stays gated off. Fall back
-                    // to the cached history so the user is not left staring at an empty
-                    // chat.
-                    this.loadEventWindow(chatId, messageIndex, undefined, true)
-                        .then((loaded) => {
-                            load.result = loaded === undefined ? "window_failed" : "window_ok";
-                            return loaded === undefined
-                                ? this.loadPreviousMessages(chatId, undefined, true).then(
-                                      () => (load.result = "window_failed_fallback_done"),
-                                  )
-                                : undefined;
-                        })
-                        .then(() => {
-                            if (serverChat !== undefined) {
-                                this.#loadChatDetails(serverChat);
-                            }
-                        });
-                } else {
-                    this.loadPreviousMessages(chatId, undefined, true).then(() => {
-                        load.result = "previous_done";
-                        if (serverChat !== undefined) {
-                            this.#loadChatDetails(serverChat);
-                        }
-                    });
-                }
+                const path = messageIndex !== undefined ? "window" : "previous";
+                const load =
+                    messageIndex !== undefined
+                        ? this.loadEventWindow(chatId, messageIndex, undefined, true)
+                        : this.loadPreviousMessages(chatId, undefined, true);
+                load.then(() => {
+                    this.#checkForEmptyChat(chatId, path);
+                    if (serverChat !== undefined) {
+                        this.#loadChatDetails(serverChat);
+                    }
+                });
             }
             if (selectedChat.kind === "direct_chat") {
                 const them = userStore.get(selectedChat.them.userId);
@@ -3526,23 +3542,8 @@ export class OpenChat {
         const criteria = this.#previousMessagesCriteria(serverChat);
 
         const eventsResponse = criteria
-            ? await this.#loadEvents(serverChat, criteria[0], criteria[1])
+            ? await this.#loadEvents(serverChat, criteria[0], criteria[1], initialLoad)
             : undefined;
-
-        if (initialLoad && eventIndexesLoaded(chatId).length === 0) {
-            if (criteria === undefined) {
-                this.#reportEmptyChat("no_previous_criteria", {
-                    chatId: chatIdentifierToString(chatId),
-                    latestEventIndex: serverChat.latestEventIndex,
-                });
-            } else if (!isSuccessfulEventsResponse(eventsResponse)) {
-                this.#reportEmptyChat("previous_load_failed", {
-                    chatId: chatIdentifierToString(chatId),
-                    startIndex: criteria[0],
-                    kind: eventsResponse?.kind,
-                });
-            }
-        }
 
         if (criteria && isSuccessfulEventsResponse(eventsResponse)) {
             this.#fillLoadedEventGaps(serverChat, eventsResponse, criteria[0], criteria[1]);
@@ -3614,6 +3615,7 @@ export class OpenChat {
         serverChat: ChatSummary,
         startIndex: number,
         ascending: boolean,
+        initialLoad = false,
     ): Promise<EventsResponse<ChatEvent>> {
         return this.#worker
             .stream({
@@ -3629,7 +3631,16 @@ export class OpenChat {
             .aggregate(mergeEventStreamResponses, emptyEventsResponse())
             .mapAsync((resp) => this.#handleEventsResponse(serverChat, undefined, resp))
             .toPromise()
-            .catch(CommonResponses.failure);
+            .catch((err) => {
+                if (initialLoad && !this.maskChatMessages(serverChat)) {
+                    this.#reportEmptyChat("previous_load_failed", {
+                        chatId: chatIdentifierToString(serverChat.id),
+                        startIndex,
+                        error: (err as { message?: string })?.message ?? String(err),
+                    });
+                }
+                return CommonResponses.failure();
+            });
     }
 
     #previousMessagesCriteria(serverChat: ChatSummary): [number, boolean] | undefined {
@@ -4221,7 +4232,12 @@ export class OpenChat {
                             };
                         }
                     }
-                } else if (chatIdentifiersEqual(chatId, selectedChatIdStore.value)) {
+                } else if (
+                    serverEventsStore.value.length === 0 &&
+                    chatIdentifiersEqual(chatId, selectedChatIdStore.value)
+                ) {
+                    // Dropping new events while scrolled up is routine; dropping them into an
+                    // empty store means the expired ranges are stale and the chat stays empty
                     const loaded = eventIndexesLoaded(chatId);
                     this.#reportEmptyChat("non_contiguous_dropped", {
                         chatId: chatIdentifierToString(chatId),
@@ -4229,7 +4245,6 @@ export class OpenChat {
                         newTo: newEvents[newEvents.length - 1]?.index,
                         loadedFrom: loaded.length > 0 ? loaded.index(0) : undefined,
                         loadedTo: loaded.length > 0 ? loaded.index(loaded.length - 1) : undefined,
-                        storeEmpty: serverEventsStore.value.length === 0,
                     });
                 }
             } else if (isContiguousInThread({ chatId, threadRootMessageIndex }, newEvents)) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -664,6 +664,11 @@ export class OpenChat {
     #webAuthnKey: WebAuthnKey | undefined = undefined;
     #userLocation: string | undefined;
     #logger: Logger;
+    // Diagnostics for the "selected chat renders empty" report. Every path that can leave a
+    // chat empty does so without an error, so record which one fired. One report per reason
+    // and three per session, so a widespread cause cannot flood Rollbar.
+    #emptyChatReports = 0;
+    #emptyChatReasons = new Set<string>();
     #lastOnlineDatesPending = new Set<string>();
     #lastOnlineDatesPromise: Promise<Record<string, number>> | undefined;
     #membershipCheck: number | undefined;
@@ -907,6 +912,40 @@ export class OpenChat {
         }
 
         this.onCreatedUser(createdUser ?? anonymousUser());
+    }
+
+    #reportEmptyChat(reason: string, context: Record<string, unknown>): void {
+        if (this.#emptyChatReports >= 3 || this.#emptyChatReasons.has(reason)) return;
+        this.#emptyChatReports++;
+        this.#emptyChatReasons.add(reason);
+        const message = `EmptyChatDiagnostic: ${reason}`;
+        this.#logger.error(message, new Error(message), context);
+    }
+
+    // Fires a few seconds after a chat is selected: if it is still the selected chat and nothing
+    // has been loaded into the event store, report it along with what the selection did.
+    #watchForEmptyChat(chatId: ChatIdentifier, load: { path: string; result: string }): void {
+        window.setTimeout(() => {
+            const chat = chatSummariesStore.value.get(chatId);
+            if (
+                chat === undefined ||
+                chat.latestEventIndex <= 0 ||
+                !chatIdentifiersEqual(chatId, selectedChatIdStore.value) ||
+                serverEventsStore.value.length > 0 ||
+                expiredServerEventRanges.value.length > 0
+            ) {
+                return;
+            }
+            this.#reportEmptyChat("still_empty_after_select", {
+                chatId: chatIdentifierToString(chatId),
+                chatKind: chat.kind,
+                path: load.path,
+                result: load.result,
+                latestEventIndex: chat.latestEventIndex,
+                minVisibleEventIndex: this.earliestAvailableEventIndex(chat),
+                offline: get(offlineStore),
+            });
+        }, 5000);
     }
 
     logError(message: unknown, error: unknown, ...optionalParams: unknown[]): void {
@@ -2732,7 +2771,16 @@ export class OpenChat {
                     this.#handleEventsResponse(clientChat, undefined, resp, index > 0),
                 )
                 .toPromise()
-                .catch(CommonResponses.failure);
+                .catch((err) => {
+                    if (initialLoad) {
+                        this.#reportEmptyChat("window_load_failed", {
+                            chatId: chatIdentifierToString(chatId),
+                            messageIndex,
+                            error: (err as { message?: string })?.message ?? String(err),
+                        });
+                    }
+                    return CommonResponses.failure();
+                });
 
             if (!isSuccessfulEventsResponse(eventsResponse)) {
                 return undefined;
@@ -3140,8 +3188,24 @@ export class OpenChat {
         this.#userLookupForMentions = undefined;
 
         const selectedChat = selectedChatSummaryStore.value;
+        if (selectedChat === undefined) {
+            this.#reportEmptyChat("no_selected_chat_summary", {
+                chatId: chatIdentifierToString(chatId),
+                selectedChatId:
+                    selectedChatIdStore.value === undefined
+                        ? undefined
+                        : chatIdentifierToString(selectedChatIdStore.value),
+                summaryStoreDirty: selectedChatSummaryStore.dirty,
+                hasServerChat: serverChat !== undefined,
+            });
+        }
         if (selectedChat !== undefined) {
             if (!this.#uninstalledBotChat(selectedChat)) {
+                const load = {
+                    path: messageIndex !== undefined ? "window" : "previous",
+                    result: "pending",
+                };
+                this.#watchForEmptyChat(chatId, load);
                 if (messageIndex !== undefined) {
                     // The window is anchored on the first unread message, which is
                     // usually not cached yet, so this is a network round trip even when
@@ -3152,11 +3216,14 @@ export class OpenChat {
                     // to the cached history so the user is not left staring at an empty
                     // chat.
                     this.loadEventWindow(chatId, messageIndex, undefined, true)
-                        .then((loaded) =>
-                            loaded === undefined
-                                ? this.loadPreviousMessages(chatId, undefined, true)
-                                : undefined,
-                        )
+                        .then((loaded) => {
+                            load.result = loaded === undefined ? "window_failed" : "window_ok";
+                            return loaded === undefined
+                                ? this.loadPreviousMessages(chatId, undefined, true).then(
+                                      () => (load.result = "window_failed_fallback_done"),
+                                  )
+                                : undefined;
+                        })
                         .then(() => {
                             if (serverChat !== undefined) {
                                 this.#loadChatDetails(serverChat);
@@ -3164,6 +3231,7 @@ export class OpenChat {
                         });
                 } else {
                     this.loadPreviousMessages(chatId, undefined, true).then(() => {
+                        load.result = "previous_done";
                         if (serverChat !== undefined) {
                             this.#loadChatDetails(serverChat);
                         }
@@ -3460,6 +3528,21 @@ export class OpenChat {
         const eventsResponse = criteria
             ? await this.#loadEvents(serverChat, criteria[0], criteria[1])
             : undefined;
+
+        if (initialLoad && eventIndexesLoaded(chatId).length === 0) {
+            if (criteria === undefined) {
+                this.#reportEmptyChat("no_previous_criteria", {
+                    chatId: chatIdentifierToString(chatId),
+                    latestEventIndex: serverChat.latestEventIndex,
+                });
+            } else if (!isSuccessfulEventsResponse(eventsResponse)) {
+                this.#reportEmptyChat("previous_load_failed", {
+                    chatId: chatIdentifierToString(chatId),
+                    startIndex: criteria[0],
+                    kind: eventsResponse?.kind,
+                });
+            }
+        }
 
         if (criteria && isSuccessfulEventsResponse(eventsResponse)) {
             this.#fillLoadedEventGaps(serverChat, eventsResponse, criteria[0], criteria[1]);
@@ -4138,6 +4221,16 @@ export class OpenChat {
                             };
                         }
                     }
+                } else if (chatIdentifiersEqual(chatId, selectedChatIdStore.value)) {
+                    const loaded = eventIndexesLoaded(chatId);
+                    this.#reportEmptyChat("non_contiguous_dropped", {
+                        chatId: chatIdentifierToString(chatId),
+                        newFrom: newEvents[0]?.index,
+                        newTo: newEvents[newEvents.length - 1]?.index,
+                        loadedFrom: loaded.length > 0 ? loaded.index(0) : undefined,
+                        loadedTo: loaded.length > 0 ? loaded.index(loaded.length - 1) : undefined,
+                        storeEmpty: serverEventsStore.value.length === 0,
+                    });
                 }
             } else if (isContiguousInThread({ chatId, threadRootMessageIndex }, newEvents)) {
                 this.#updateServerThreadEventsStore({ chatId, threadRootMessageIndex }, (events) =>

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3123,6 +3123,17 @@ export class OpenChat {
                     messageIndex = undefined;
                 }
             }
+
+            // A member who has never read anything gets message 0 as the first unread. In a
+            // chat whose history is hidden from them that message is below their min visible
+            // index, and a window anchored on it fails.
+            if (
+                messageIndex !== undefined &&
+                clientChat.kind !== "direct_chat" &&
+                messageIndex < clientChat.minVisibleMessageIndex
+            ) {
+                messageIndex = undefined;
+            }
         }
 
         // TODO - this might belong as a derivation in the selected chat state


### PR DESCRIPTION
Android (and web mobile) users have reported opening a chat and seeing no messages even though the history is cached. It clears on reselect, so it is racey and not reproducible on demand. This PR fixes the definite defects found on the way and adds capped diagnostics so the next occurrence names its path in Rollbar.

## Backend (group, community, user via `chat_events`)

`events` and `events_window` trap with `range start is greater than range end in BTreeMap` when the caller's min visible event index is above the requested start. Groups and channels keep the last 200 events in a std `BTreeMap` fast map, which panics on an inverted range; direct chats and threads use only the stable map and return empty. The client's min visible index can lag the canister's: summary updates do not carry it, a role change or lapsed membership moves it, and a member who has never read anything anchors the initial window on message 0. Rollbar #31622, 14 IPs on 2.0.2050.

Fix: treat an inverted range as empty in `HybridMap` `Iter::new` and in `ChatEventsList::iter`. Two tests using a group chat reproduce the exact production panic before the fix. Changelog entries added. This does not have to ship before the website.

## Client

- `#setSelectedChat`: when the initial load is a window anchored on the first unread message and it fails, fall back to `loadPreviousMessages`, which serves the cache. Previously nothing else loaded the chat and the list never initialised.
- Do not anchor the initial window below the chat's `minVisibleMessageIndex`.
- Thread scroll-back: stop asking for event index -1 once index 0 is loaded. The cache iterator threw `Start index exceeds bound` and the whole load failed (Rollbar #31490).

## Diagnostics

`EmptyChatDiagnostic: <reason>` reports via the logger, one per reason and three per session so a widespread cause cannot blow the Rollbar quota. Reasons: `no_selected_chat_summary`, `window_load_failed`, `previous_load_failed`, `no_previous_criteria`, `non_contiguous_dropped`, and `still_empty_after_select` (5 s watchdog with which load path ran and how it ended).

## Verification

- `cargo test -p chat_events`: 52 passed (two new tests red before the fix).
- `cargo fmt --check`, `cargo clippy` clean on `chat_events`.
- Client typecheck clean for `openchat.ts`; client vitest 258 passed. Two suites fail to import on master too (`@icp-sdk/canisters` missing locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ubzbbW779mdWLWbyZqSSn
