### PR TITLE
Fix stuck payment button after deselecting an external wallet

### DIFF
--- a/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
@@ -47,7 +47,7 @@
     }
 
     function accept() {
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the swap amount before we take it. Nothing may
             // be awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the click

--- a/frontend/app/src/components/home/CryptoTransferBuilder.svelte
+++ b/frontend/app/src/components/home/CryptoTransferBuilder.svelte
@@ -118,7 +118,7 @@
         sending = true;
         error = undefined;
 
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the transfer before we make it. Nothing may be
             // awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the click

--- a/frontend/app/src/components/home/P2PSwapContentBuilder.svelte
+++ b/frontend/app/src/components/home/P2PSwapContentBuilder.svelte
@@ -108,7 +108,7 @@
         sending = true;
         error = undefined;
 
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the offer's funds before we take them. Nothing
             // may be awaited before this call - the wallet opens in a popup, which the browser
             // only allows while it is still handling the click

--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -196,7 +196,7 @@
         sending = true;
         error = undefined;
 
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the prize fund before we take it. Nothing may
             // be awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the click

--- a/frontend/app/src/components/home/TipBuilder.svelte
+++ b/frontend/app/src/components/home/TipBuilder.svelte
@@ -174,7 +174,7 @@
 
     function send(e: Event) {
         e.preventDefault();
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the tip before we take it. Nothing may be
             // awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the click

--- a/frontend/app/src/components/home/upgrade/Payment.svelte
+++ b/frontend/app/src/components/home/upgrade/Payment.svelte
@@ -128,7 +128,7 @@
     }
 
     function confirm() {
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the payment before we take it. Nothing may be
             // awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the click

--- a/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
@@ -40,7 +40,7 @@
     }
 
     function accept() {
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the swap amount before we take it. Nothing may
             // be awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the tap

--- a/frontend/app/src/components_mobile/home/MessageEntry.svelte
+++ b/frontend/app/src/components_mobile/home/MessageEntry.svelte
@@ -596,7 +596,7 @@
         if (draft !== undefined) {
             // Never fall through: a send without the approval would silently take the funds from
             // the user's OpenChat account instead of the wallet they chose
-            if (walletApproval === undefined) return;
+            if (walletApproval == null) return;
             // The draft spends from an external wallet, which has to approve us taking the
             // transfer before the message carrying it is sent. Nothing may be awaited before
             // this call - the wallet opens in a popup, which the browser only allows while it is

--- a/frontend/app/src/components_mobile/home/TipBuilder.svelte
+++ b/frontend/app/src/components_mobile/home/TipBuilder.svelte
@@ -150,7 +150,7 @@
 
     function send(e: Event) {
         e.preventDefault();
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the tip before we take it. Nothing may be
             // awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the tap

--- a/frontend/app/src/components_mobile/home/upgrade/Payment.svelte
+++ b/frontend/app/src/components_mobile/home/upgrade/Payment.svelte
@@ -151,7 +151,7 @@
     }
 
     function confirm() {
-        if (approval !== undefined) {
+        if (approval != null) {
             // The wallet has to approve us taking the payment before we take it. Nothing may be
             // awaited before this call - the wallet opens in a popup, which the browser only
             // allows while it is still handling the tap


### PR DESCRIPTION
## Problem

Every payment builder (tips, crypto transfers, prizes, P2P swap create/accept, Diamond upgrade) renders `ExternalWalletApproval` inside `{#if sourceWallet !== undefined}` and keeps a `bind:this` reference to it. Svelte 5 sets a `bind:this` variable to `null`, not `undefined`, when the bound component unmounts (`svelte/src/internal/client/dom/elements/bindings/this.js`), so the guard `if (approval !== undefined)` still passes after the user picks NFID or Oisy and then switches back to the OpenChat wallet.

The click handler then sets its busy flag (`approving` / `sending`) and throws a `TypeError` on `approval.approve()`. The flag is never reset, so the Send/Confirm button stays disabled and nothing is sent.

## Fix

Use `!= null` at each site so both `undefined` (never rendered) and `null` (unmounted) fall through to the internal-wallet path. The mobile `MessageEntry` guard gets the same treatment, since a null approval with a live external-wallet draft would throw at `walletApproval.approve()`.

Users who never open the source wallet selector are unaffected.

## Sites

- `components/home/{TipBuilder,CryptoTransferBuilder,PrizeContentBuilder,P2PSwapContentBuilder,AcceptP2PSwapModal}.svelte`
- `components/home/upgrade/Payment.svelte`
- `components_mobile/home/{TipBuilder,AcceptP2PSwapModal,MessageEntry}.svelte`
- `components_mobile/home/upgrade/Payment.svelte`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
