### PR TITLE
Hide the external wallet selector until the backends support it

### DIFF
--- a/frontend/app/src/components/home/SourceWalletSelector.svelte
+++ b/frontend/app/src/components/home/SourceWalletSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { iconSize, SIGNER_WALLETS, type SignerWallet } from "@client";
+    import { EXTERNAL_WALLETS_ENABLED, iconSize, SIGNER_WALLETS, type SignerWallet } from "@client";
     import ChevronDown from "svelte-material-icons/ChevronDown.svelte";
     import { i18nKey } from "../../i18n/i18n";
     import Menu from "../Menu.svelte";
@@ -18,44 +18,46 @@
     let { wallet = $bindable() }: Props = $props();
 </script>
 
-<div class="source-wallet">
-    <div class="label">
-        <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
-    </div>
-    <MenuIcon centered position={"bottom"} align={"end"}>
-        {#snippet menuIcon()}
-            <div class="trigger">
-                <img
-                    class="wallet-logo"
-                    alt={wallet?.name ?? "OpenChat"}
-                    src={wallet?.logo ?? OPENCHAT_LOGO} />
-                <ChevronDown viewBox={"0 0 24 24"} size={$iconSize} color={"var(--icon-txt)"} />
-            </div>
-        {/snippet}
-        {#snippet menuItems()}
-            <Menu centered>
-                <MenuItem onclick={() => (wallet = undefined)}>
-                    {#snippet icon()}
-                        <img class="wallet-logo" alt="OpenChat" src={OPENCHAT_LOGO} />
-                    {/snippet}
-                    {#snippet text()}
-                        OpenChat
-                    {/snippet}
-                </MenuItem>
-                {#each SIGNER_WALLETS as w (w.id)}
-                    <MenuItem onclick={() => (wallet = w)}>
+{#if EXTERNAL_WALLETS_ENABLED}
+    <div class="source-wallet">
+        <div class="label">
+            <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
+        </div>
+        <MenuIcon centered position={"bottom"} align={"end"}>
+            {#snippet menuIcon()}
+                <div class="trigger">
+                    <img
+                        class="wallet-logo"
+                        alt={wallet?.name ?? "OpenChat"}
+                        src={wallet?.logo ?? OPENCHAT_LOGO} />
+                    <ChevronDown viewBox={"0 0 24 24"} size={$iconSize} color={"var(--icon-txt)"} />
+                </div>
+            {/snippet}
+            {#snippet menuItems()}
+                <Menu centered>
+                    <MenuItem onclick={() => (wallet = undefined)}>
                         {#snippet icon()}
-                            <img class="wallet-logo" alt={w.name} src={w.logo} />
+                            <img class="wallet-logo" alt="OpenChat" src={OPENCHAT_LOGO} />
                         {/snippet}
                         {#snippet text()}
-                            {w.name}
+                            OpenChat
                         {/snippet}
                     </MenuItem>
-                {/each}
-            </Menu>
-        {/snippet}
-    </MenuIcon>
-</div>
+                    {#each SIGNER_WALLETS as w (w.id)}
+                        <MenuItem onclick={() => (wallet = w)}>
+                            {#snippet icon()}
+                                <img class="wallet-logo" alt={w.name} src={w.logo} />
+                            {/snippet}
+                            {#snippet text()}
+                                {w.name}
+                            {/snippet}
+                        </MenuItem>
+                    {/each}
+                </Menu>
+            {/snippet}
+        </MenuIcon>
+    </div>
+{/if}
 
 <style lang="scss">
     .source-wallet {

--- a/frontend/app/src/components_mobile/home/SourceWalletSelector.svelte
+++ b/frontend/app/src/components_mobile/home/SourceWalletSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { SIGNER_WALLETS, type SignerWallet } from "@client";
+    import { EXTERNAL_WALLETS_ENABLED, SIGNER_WALLETS, type SignerWallet } from "@client";
     import { Body, ColourVars, Column, Row, Sheet, Subtitle } from "component-lib";
     import ChevronDown from "svelte-material-icons/ChevronDown.svelte";
     import { i18nKey } from "../../i18n/i18n";
@@ -23,33 +23,35 @@
     }
 </script>
 
-<Row onClick={() => (choosing = true)} width={"hug"} crossAxisAlignment={"center"} gap={"sm"}>
-    <!-- The same size as the balance text alongside, but in the label colour -->
-    <Body colour={"textSecondary"} width={"hug"}>
-        <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
-    </Body>
-    <img class="wallet-logo" alt={wallet?.name ?? "OpenChat"} src={wallet?.logo ?? OPENCHAT_LOGO} />
-    <ChevronDown size={"1.5rem"} color={ColourVars.textSecondary} />
-</Row>
+{#if EXTERNAL_WALLETS_ENABLED}
+    <Row onClick={() => (choosing = true)} width={"hug"} crossAxisAlignment={"center"} gap={"sm"}>
+        <!-- The same size as the balance text alongside, but in the label colour -->
+        <Body colour={"textSecondary"} width={"hug"}>
+            <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
+        </Body>
+        <img class="wallet-logo" alt={wallet?.name ?? "OpenChat"} src={wallet?.logo ?? OPENCHAT_LOGO} />
+        <ChevronDown size={"1.5rem"} color={ColourVars.textSecondary} />
+    </Row>
 
-{#if choosing}
-    <Sheet onDismiss={() => (choosing = false)}>
-        <Column gap={"lg"} padding={"xl"}>
-            <Subtitle fontWeight={"bold"}>
-                <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
-            </Subtitle>
-            <Row onClick={() => choose(undefined)} crossAxisAlignment={"center"} gap={"md"}>
-                <img class="wallet-logo large" alt="OpenChat" src={OPENCHAT_LOGO} />
-                <Body fontWeight={wallet === undefined ? "bold" : "normal"}>OpenChat</Body>
-            </Row>
-            {#each SIGNER_WALLETS as w (w.id)}
-                <Row onClick={() => choose(w)} crossAxisAlignment={"center"} gap={"md"}>
-                    <img class="wallet-logo large" alt={w.name} src={w.logo} />
-                    <Body fontWeight={wallet?.id === w.id ? "bold" : "normal"}>{w.name}</Body>
+    {#if choosing}
+        <Sheet onDismiss={() => (choosing = false)}>
+            <Column gap={"lg"} padding={"xl"}>
+                <Subtitle fontWeight={"bold"}>
+                    <Translatable resourceKey={i18nKey("externalWallet.sourceWallet")} />
+                </Subtitle>
+                <Row onClick={() => choose(undefined)} crossAxisAlignment={"center"} gap={"md"}>
+                    <img class="wallet-logo large" alt="OpenChat" src={OPENCHAT_LOGO} />
+                    <Body fontWeight={wallet === undefined ? "bold" : "normal"}>OpenChat</Body>
                 </Row>
-            {/each}
-        </Column>
-    </Sheet>
+                {#each SIGNER_WALLETS as w (w.id)}
+                    <Row onClick={() => choose(w)} crossAxisAlignment={"center"} gap={"md"}>
+                        <img class="wallet-logo large" alt={w.name} src={w.logo} />
+                        <Body fontWeight={wallet?.id === w.id ? "bold" : "normal"}>{w.name}</Body>
+                    </Row>
+                {/each}
+            </Column>
+        </Sheet>
+    {/if}
 {/if}
 
 <style lang="scss">

--- a/frontend/openchat-client/src/index.ts
+++ b/frontend/openchat-client/src/index.ts
@@ -13,6 +13,7 @@ export { builtinBot } from "./utils/builtinBotCommands";
 export * from "./utils/restrictedContent";
 export {
     ApproveError,
+    EXTERNAL_WALLETS_ENABLED,
     SIGNER_WALLETS,
     SignerConnection,
     type ApproveSpendingArgs,

--- a/frontend/openchat-client/src/utils/signer.ts
+++ b/frontend/openchat-client/src/utils/signer.ts
@@ -23,6 +23,13 @@ export type SignerWallet = {
     logo: string;
 };
 
+// Whether payment flows offer a choice of external wallet at all. The backends read the
+// `from_account` these flows send only once the user, group, community and user_index canisters
+// carrying that support are released; until then an older canister silently ignores the field and
+// pays from the user's OpenChat wallet, which is not what they were just asked to approve.
+// TODO: flip to true (or remove) once those canisters are live on prod
+export const EXTERNAL_WALLETS_ENABLED = false;
+
 // Any wallet implementing ICRC-25/27/29/49 works here - these are just the ones we surface. The
 // endpoints and logos are the ones each wallet publishes via NFID's identitykit.
 export const SIGNER_WALLETS: SignerWallet[] = [


### PR DESCRIPTION
## Problem

The "Source wallet" selector added in #9265, #9264, #9263 and #9271 appears in every payment flow and lets the user pay from NFID or OISY. Choosing one sends `from_account` to the user, group, community and user_index canisters. The versions of those canisters currently released to prod (v2.0.2015-user, v2.0.2036-group, v2.0.2045-community, v2.0.2046-user_index) do not know the field, so they ignore it and pay from the user's OpenChat wallet, immediately after the user approved a payment from a different one. The unused allowance on the external wallet stands for ten minutes.

This blocks releasing the website ahead of those canisters.

## Fix

Add `EXTERNAL_WALLETS_ENABLED` next to `SIGNER_WALLETS` in `openchat-client/src/utils/signer.ts`, off for now, and render both `SourceWalletSelector` components (desktop and mobile) only when it is on. With nothing rendered the bound `sourceWallet` stays `undefined`, so every flow takes the internal-wallet path exactly as before. No call site changes.

Flip the flag once the canisters are live on prod. Marked with a TODO.

## Verification

- `svelte-check` on the app: 0 errors.
- `openchat-client` tsc: only the pre-existing `NetworkInformation` errors in `openchat-shared`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
