### PR TITLE
Skip the required backend checks on frontend-only PRs

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -10,8 +10,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Frontend-only PRs have nothing here to check. The jobs below are required status checks, so
+  # they must still run on every PR (a workflow-level `paths:` filter would leave the checks
+  # pending and the PR unmergeable); instead they skip themselves when nothing they depend on
+  # changed. A skipped job satisfies branch protection.
+  #
+  # The filter must name every input of these jobs, not just Rust sources. The same block lives
+  # in backend.yaml, candid.yaml and benchmarks.yaml; keep the three identical.
+  changes:
+    name: detect backend changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - "**.rs"
+              - "**.toml"
+              - "**.did"
+              - "**/Cargo.lock"
+              - "canbench*.yml"
+              - "scripts/**"
+              - ".github/workflows/**"
+
   fmt:
     name: run fmt
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +49,8 @@ jobs:
 
   clippy:
     name: run clippy
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +67,8 @@ jobs:
 
   unit_tests:
     name: run unit tests
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -10,7 +10,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Frontend-only PRs have nothing here to check. The jobs below are required status checks, so
+  # they must still run on every PR (a workflow-level `paths:` filter would leave the checks
+  # pending and the PR unmergeable); instead they skip themselves when nothing they depend on
+  # changed. A skipped job satisfies branch protection.
+  #
+  # The filter must name every input of these jobs, not just Rust sources. The same block lives
+  # in backend.yaml, candid.yaml and benchmarks.yaml; keep the three identical.
+  changes:
+    name: detect backend changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - "**.rs"
+              - "**.toml"
+              - "**.did"
+              - "**/Cargo.lock"
+              - "canbench*.yml"
+              - "scripts/**"
+              - ".github/workflows/**"
+
   benchmarks:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/canbench-post-comment.yaml
+++ b/.github/workflows/canbench-post-comment.yaml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A frontend-only PR skips the benchmarks job, so there is nothing to download
       - uses: dawidd6/action-download-artifact@v7
         with:
           run_id: ${{ github.event.workflow_run.id }}
+          if_no_artifact_found: ignore
 
       - id: set-benchmarks
         run: bash ./scripts/ci-download-canbench-artifacts.sh
@@ -25,6 +27,7 @@ jobs:
   post-comment:
     runs-on: ubuntu-latest
     needs: [download-results]
+    if: needs.download-results.outputs.pr_number != ''
     strategy:
       matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
     steps:

--- a/.github/workflows/candid.yaml
+++ b/.github/workflows/candid.yaml
@@ -11,8 +11,37 @@ concurrency:
 name: Validate candid files
 
 jobs:
+  # Frontend-only PRs have nothing here to check. The jobs below are required status checks, so
+  # they must still run on every PR (a workflow-level `paths:` filter would leave the checks
+  # pending and the PR unmergeable); instead they skip themselves when nothing they depend on
+  # changed. A skipped job satisfies branch protection.
+  #
+  # The filter must name every input of these jobs, not just Rust sources. The same block lives
+  # in backend.yaml, candid.yaml and benchmarks.yaml; keep the three identical.
+  changes:
+    name: detect backend changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - "**.rs"
+              - "**.toml"
+              - "**.did"
+              - "**/Cargo.lock"
+              - "canbench*.yml"
+              - "scripts/**"
+              - ".github/workflows/**"
+
   candid_syntax:
     name: validate candid syntax
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +57,8 @@ jobs:
 
   candid_matches_rust:
     name: validate candid matches rust
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/ci-download-canbench-artifacts.sh
+++ b/scripts/ci-download-canbench-artifacts.sh
@@ -24,6 +24,15 @@ json_array=${json_array%,}
 # Close the JSON array string
 json_array+="]"
 
+# No artifacts means the benchmarks job was skipped (a frontend-only PR), so there is nothing to
+# post. Leave pr_number empty; the post-comment job checks it and skips.
+if [ ! -e ./pr_number/pr_number ]; then
+  echo "No benchmark artifacts found, nothing to post"
+  echo "matrix={\"benchmark\": []}" >> "$GITHUB_OUTPUT"
+  echo "pr_number=" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
 # Output the benchmarks and PR number to be used by the next job.
 echo "matrix={\"benchmark\": $json_array}" >> "$GITHUB_OUTPUT"
 echo "pr_number=$(cat ./pr_number/pr_number)" >> "$GITHUB_OUTPUT"

--- a/scripts/ci-download-canbench-artifacts.sh
+++ b/scripts/ci-download-canbench-artifacts.sh
@@ -3,6 +3,16 @@ set -Eexuo pipefail
 
 # Identifies the benchmarks provided in the artifacts and outputs them.
 
+# No result artifacts means the benchmarks job was skipped (a frontend-only PR), so there is
+# nothing to post. Leave pr_number empty; the post-comment job checks it and skips. Results
+# without a PR number are a broken upload, and fall through to fail on the missing file below.
+if ! compgen -G "canbench_result_*" > /dev/null; then
+  echo "No benchmark result artifacts found, nothing to post"
+  echo "matrix={\"benchmark\": []}" >> "$GITHUB_OUTPUT"
+  echo "pr_number=" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
 json_array="["
 # Loop through each file with prefix "canbench_result_" in the current directory
 for file in canbench_result_*; do
@@ -24,13 +34,9 @@ json_array=${json_array%,}
 # Close the JSON array string
 json_array+="]"
 
-# No artifacts means the benchmarks job was skipped (a frontend-only PR), so there is nothing to
-# post. Leave pr_number empty; the post-comment job checks it and skips.
 if [ ! -e ./pr_number/pr_number ]; then
-  echo "No benchmark artifacts found, nothing to post"
-  echo "matrix={\"benchmark\": []}" >> "$GITHUB_OUTPUT"
-  echo "pr_number=" >> "$GITHUB_OUTPUT"
-  exit 0
+  echo "Benchmark results were uploaded but the pr_number artifact is missing" >&2
+  exit 1
 fi
 
 # Output the benchmarks and PR number to be used by the next job.


### PR DESCRIPTION
## Problem

`run fmt`, `run clippy`, `run unit tests`, `validate candid syntax`, `validate candid matches rust` and `benchmarks` are required status checks on master, so they run on every PR, including ones that only touch `frontend/`. They cannot simply be given a workflow-level `paths:` filter: a workflow which never starts leaves its checks pending and the PR unmergeable.

## Fix

Each of `backend.yaml`, `candid.yaml` and `benchmarks.yaml` gains a `changes` job which runs [dorny/paths-filter](https://github.com/dorny/paths-filter) against the PR base, and every required job gets `needs: changes` plus `if: needs.changes.outputs.backend == 'true'`. A job skipped by its own `if` reports a `skipped` conclusion, which branch protection accepts, so frontend-only PRs stay mergeable while doing no backend work. Job names are unchanged, so the required-check contexts still match.

The filter is deliberately broad, since under-filtering would silently skip a check that should have run:

```
**.rs, **.toml, **.did, **/Cargo.lock, canbench*.yml, scripts/**, .github/workflows/**
```

`**.toml` covers the Cargo manifests and `rust-toolchain.toml`. Any PR touching one of these paths runs everything exactly as today. The three copies of the block are marked to be kept identical.

`integration_tests.yaml` already uses a `paths:` filter and is not a required check, so it is untouched.

## Post-comment workflow

`Post Canbench results` triggers on every completed Benchmarks run. With the job skipped there are no artifacts, and `dawidd6/action-download-artifact` fails by default when it finds none. It now passes `if_no_artifact_found: ignore`, `ci-download-canbench-artifacts.sh` emits an empty PR number when the artifact is absent, and `post-comment` skips on that.

## Verification

- All four workflow files parse as YAML; the script passes `bash -n`.
- This PR itself touches `.github/workflows/**` and `scripts/**`, so it should run the full backend suite. A follow-up frontend-only PR is the real test of the skip path; #9292 or #9293 rebased on this would do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
