### PR TITLE
Fix main-thread livelock when selecting a chat while a load is in flight

### DIFF
--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -115,6 +115,17 @@
     let destroyed = false;
     let loadingNewMessages = false;
     let loadingPrevMessages = false;
+    // The load currently in flight, from whichever caller started it. A caller
+    // that finds one running must WAIT for it, not return early: the
+    // scrollToMessageIndex recursion treats a true result as "a load happened,
+    // re-check", and its iterations are microtask-only (scrollToIndex, tick,
+    // an instant return). Returning true without awaiting sends it round again
+    // with nothing yielding to the task queue, so the network reply that would
+    // clear the flags never runs — the tab spins at 100% until killed. Seen on
+    // selecting a chat with unread messages while the previous chat's
+    // fire-and-forget load was still in flight (the flags are not reset on a
+    // context switch while the list stays visible).
+    let inflightLoad: Promise<void> | undefined = undefined;
     // After a scroll-triggered load, block further scroll-triggered loads until
     // the gesture fully stops (see trackScrollStop) — prevents runaway loading
     // while momentum keeps the viewport inside a loading threshold.
@@ -718,21 +729,46 @@
         await interruptScroll(-fromBottom);
     }
 
+    // Waits for a load already in progress. Resolves true so callers behave as
+    // if they had loaded; the next check re-evaluates the thresholds.
+    async function awaitInflightLoad(): Promise<boolean> {
+        await inflightLoad?.catch(() => undefined);
+        return true;
+    }
+
+    // Runs the given loads as THE in-flight load and always clears the loading
+    // flags afterwards — a rejection used to leave them stuck true, which
+    // gated every later load and navigation in this chat.
+    async function runLoads(loads: Promise<void>[]): Promise<void> {
+        const load = Promise.all(loads).then(() => undefined);
+        inflightLoad = load;
+        try {
+            await load;
+        } finally {
+            // Only the load that owns the flags may clear them: the hidden-panel
+            // reset can let a newer load start while this one is still in flight.
+            if (inflightLoad === load) {
+                inflightLoad = undefined;
+                loadingPrevMessages = false;
+                loadingNewMessages = false;
+                loadingFromUserScroll = false;
+            }
+        }
+    }
+
     async function loadNewMessagesIfRequired(fromScroll = false): Promise<boolean> {
-        if (loadingNewMessages || loadingPrevMessages) return true;
+        if (loadingNewMessages || loadingPrevMessages) return awaitInflightLoad();
         loadingNewMessages = shouldLoadNewMessages();
         loadingFromUserScroll = loadingNewMessages && fromScroll;
         if (loadingNewMessages) {
-            await loadNew();
-            loadingNewMessages = false;
-            loadingFromUserScroll = false;
+            await runLoads([loadNew()]);
             return true;
         }
         return false;
     }
 
     async function loadMoreIfRequired(fromScroll = false, initialLoad = false): Promise<boolean> {
-        if (loadingPrevMessages || loadingNewMessages) return true;
+        if (loadingPrevMessages || loadingNewMessages) return awaitInflightLoad();
 
         // After a scroll-triggered load of OLDER messages, block further such
         // loads until the gesture fully stops (trackScrollStop clears the flag)
@@ -771,10 +807,7 @@
         if (shouldLoadPrev) {
             loadPromises.push(loadPrev(initialLoad));
         }
-        await Promise.all(loadPromises);
-        loadingPrevMessages = false;
-        loadingNewMessages = false;
-        loadingFromUserScroll = false;
+        await runLoads(loadPromises);
 
         if (
             items.length === preLen &&


### PR DESCRIPTION
## Symptom

Select a chat with unread messages on webtest desktop. Whole tab freezes, one core at 100%, no console errors. Paused call stack: `scrollToMessageIndexInternal` (`ChatEventList.svelte:988`) recursing on itself, `loadingPrevMessages` and `loadingNewMessages` both true, `loadingFromUserScroll` and `requireScrollStop` both false.

## Cause

`loadMoreIfRequired` returned `true` synchronously when another load was in flight. The navigation recursion treats `true` as "a load happened, re-check" and recurses. Every step of that iteration is a microtask (`scrollToIndex`, `tick()`, the instant return). Nothing yields to the task queue, so the network reply that would clear the flags never runs. The loop waits on a flag only the thing it is starving can clear.

The flags are not reset on a context switch while the list stays visible (the effect at line 266 resets `scrollingToMessage` and `navToken` only). So a fire-and-forget load from the previous chat, either the `onLoadedPreviousMessages` follow-up or the `trackScrollStop` timer armed by our own programmatic scroll, is still in flight when the next chat's first-unread navigation runs. Click inside that latency and it wedges. That accounts for every observation: racey, first select only, needs unread (no `messageIndex` means no navigation chain), no user scrolling.

## Fix

One file, `frontend/app/src/components_shared/ChatEventList.svelte`.

- `inflightLoad` holds the current `Promise.all`.
- Busy paths in `loadMoreIfRequired` and `loadNewMessagesIfRequired` await it and then return `true`, so the recursion parks on a real task and re-evaluates the thresholds once the reply lands.
- Flag resets move into a `finally`, so a rejection cannot leave them stuck.
- The reset is guarded on promise identity, because the `!visible` reset can already let two loads overlap and a superseded load must not clear a newer load's flags.

The `EmptyChatDiagnostic` Rollbar reports from #9291 stay for one release. A starved main thread cannot report, so they are looking at a different set of failures.

## Verification

svelte-check: 0 errors. Manual repro: select a short chat, then within about a second select a channel with unread messages. Network throttling widens the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ubzbbW779mdWLWbyZqSSn
