### PR TITLE
Treat a chat whose latest message has expired as fully read

### DIFF
--- a/frontend/app/src/components/home/ChatSummary.svelte
+++ b/frontend/app/src/components/home/ChatSummary.svelte
@@ -18,6 +18,7 @@
         currentUserIdStore,
         favouritesStore,
         iconSize,
+        latestMessageExpired,
         messageFlagsRestricted,
         messagesRead,
         mobileWidth,
@@ -124,10 +125,12 @@
      */
     function updateUnreadCounts(chatSummary: ChatSummary) {
         untrack(() => {
-            unreadMessages = client.unreadMessageCount(
-                chatSummary.id,
-                chatSummary.latestMessage?.event.messageIndex,
-            );
+            unreadMessages = latestMessageExpired(chatSummary)
+                ? 0
+                : client.unreadMessageCount(
+                      chatSummary.id,
+                      chatSummary.latestMessage?.event.messageIndex,
+                  );
             unreadMentions = getUnreadMentionCount(chatSummary);
 
             if (chatSummary.membership.archived && unreadMessages > 0 && !chat.bot) {
@@ -225,7 +228,7 @@
                 : $_("disappearingMessages.disabled");
         }
 
-        if (chatSummary.latestMessage === undefined) {
+        if (chatSummary.latestMessage === undefined || latestMessageExpired(chatSummary)) {
             return "";
         }
 

--- a/frontend/app/src/components_mobile/home/ChatSummary.svelte
+++ b/frontend/app/src/components_mobile/home/ChatSummary.svelte
@@ -26,6 +26,7 @@
         communitiesStore,
         currentUserIdStore,
         favouritesStore,
+        latestMessageExpired,
         messageFlagsRestricted,
         messagesRead,
         notificationsSupported,
@@ -132,10 +133,12 @@
      */
     function updateUnreadCounts(chatSummary: ChatSummary) {
         untrack(() => {
-            unreadMessages = client.unreadMessageCount(
-                chatSummary.id,
-                chatSummary.latestMessage?.event.messageIndex,
-            );
+            unreadMessages = latestMessageExpired(chatSummary)
+                ? 0
+                : client.unreadMessageCount(
+                      chatSummary.id,
+                      chatSummary.latestMessage?.event.messageIndex,
+                  );
 
             unreadMentions = getUnreadMentionCount(chatSummary);
 
@@ -258,7 +261,7 @@
                 : $_("disappearingMessages.disabled");
         }
 
-        if (chatSummary.latestMessage === undefined) {
+        if (chatSummary.latestMessage === undefined || latestMessageExpired(chatSummary)) {
             return "";
         }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -46,6 +46,7 @@ import {
     buildDelegationChain,
     canRetryMessage,
     chatIdentifierToString,
+    latestMessageExpired,
     chatIdentifiersEqual,
     communityIdentifiersEqual,
     communityRoles,
@@ -3200,11 +3201,21 @@ export class OpenChat {
                       clientChat.latestMessage?.event.messageIndex,
                   );
 
-            if (messageIndex !== undefined) {
-                const latestServerMessageIndex = serverChat?.latestMessage?.event.messageIndex ?? 0;
-
-                if (messageIndex > latestServerMessageIndex) {
+            const latestMessageIndex = clientChat.latestMessage?.event.messageIndex;
+            if (messageIndex !== undefined && latestMessageIndex !== undefined) {
+                if (latestMessageExpired(clientChat)) {
+                    // Every unread message has disappeared: nothing to anchor a window on, and
+                    // nothing that could ever be read to clear the unread count. Mark the chat
+                    // read and load the latest events instead.
+                    messagesRead.markReadUpTo({ chatId }, latestMessageIndex);
                     messageIndex = undefined;
+                } else {
+                    const latestServerMessageIndex =
+                        serverChat?.latestMessage?.event.messageIndex ?? 0;
+
+                    if (messageIndex > latestServerMessageIndex) {
+                        messageIndex = undefined;
+                    }
                 }
             }
         }

--- a/frontend/openchat-client/src/state/unread/markRead.ts
+++ b/frontend/openchat-client/src/state/unread/markRead.ts
@@ -5,6 +5,7 @@ import {
     bigIntMax,
     chatIdentifierToString,
     emptyUnreadCounts,
+    latestMessageExpired,
     mergeUnreadCounts,
     type ChatIdentifier,
     type ChatSummary,
@@ -493,10 +494,9 @@ export class MessageReadTracker {
             contribution.chat !== chat ||
             contribution.version !== version
         ) {
-            const unreadMessages = this.unreadMessageCount(
-                chat.id,
-                chat.latestMessage?.event.messageIndex,
-            );
+            const unreadMessages = latestMessageExpired(chat)
+                ? 0
+                : this.unreadMessageCount(chat.id, chat.latestMessage?.event.messageIndex);
             contribution = {
                 chat,
                 version,

--- a/frontend/openchat-shared/src/utils/chat.ts
+++ b/frontend/openchat-shared/src/utils/chat.ts
@@ -339,6 +339,15 @@ export function chatIdentifierToString(chatId: ChatIdentifier): string {
     }
 }
 
+// A chat whose latest message has disappeared has nothing left to read, whatever the
+// read-up-to index says: every earlier message expired first, unless the TTL was shortened
+// after they were sent. The summary keeps the expired message, so the unread count and the
+// preview would otherwise point at messages that no longer exist.
+export function latestMessageExpired(chat: ChatSummary, now = Date.now()): boolean {
+    const expiresAt = chat.latestMessage?.expiresAt;
+    return expiresAt !== undefined && expiresAt < now;
+}
+
 export function contentTypeToPermission(contentType: AttachmentContent["kind"]): MessagePermission {
     switch (contentType) {
         case "image_content":


### PR DESCRIPTION
## Symptom

Select `Recycle Bin` (Windoge98 community, 3 day disappearing messages) on webtest. Chat list shows 17 unread and the preview "Mnshzee199: Guys anyone selling usdt". The chat renders the welcome header and two events from June 2024, no messages, and a 17 pill that jumps nowhere. Reproducible on every select.

## Cause

Not a load failure. From the IndexedDB cache and the canister's own window response for message 577:

| field | value |
|---|---|
| `eventsTTL` | 3 days |
| latest message | index 593, sent 2026-08-18, `expiresAt` 2026-08-21 |
| `readByMeUpTo` | 576 |
| unread | 17, all expired |
| window for 577 | events 58 and 95, expired ranges 59-94, 96-2347, 2348-2460 |

The two rendered events are the only non-expired ones the member can see. The client loaded exactly what the canister returned.

The unread count is `latestMessageIndex - readByMeUpTo`. Neither side knows about expiry. Mark-as-read is driven by rendered message rows, and none render, so the badge is stuck until someone posts. The summary keeps the expired `latestMessage`, so the preview keeps quoting it.

## Fix

- `openchat-shared/src/utils/chat.ts`: `latestMessageExpired(chat)`, true when `latestMessage.expiresAt < now`. Placed in shared rather than client utils: importing client utils from `markRead.ts` creates an import cycle that breaks store init (the spec caught it).
- `markRead.ts` `#unreadContribution`: zero unread when expired. Covers the nav and community badges.
- Both `ChatSummary.svelte`: unread badge zero when expired, preview text suppressed.
- `openchat.ts` `#setSelectedChat`: when a first-unread anchor exists but the latest message has expired, mark read up to the latest message and load latest events instead of anchoring on a message that no longer exists. That syncs `readByMeUpTo` to the server so the badge clears on every device.

## Caveat

Every earlier message expired before the latest one, unless the TTL was *shortened* after older unread messages were sent. That case would mark still-visible messages read unseen. Needs a TTL decrease mid-backlog, and per-message expiry isn't available client-side to guard it precisely.

## Verification

svelte-check: 0 errors. `markRead.spec.ts`: 28/28. Not yet exercised in a browser build.

Unrelated to the livelock in #9295 and to the events trap in #9291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ubzbbW779mdWLWbyZqSSn
