### PR TITLE
Prepare the Android app for the Play Store

### DIFF
--- a/.claude/skills/release-train/SKILL.md
+++ b/.claude/skills/release-train/SKILL.md
@@ -18,8 +18,25 @@ description: OpenChat release train runbook — tagging components, prod-test (i
 2. Unreleased work per component:
    `git log --oneline <last-tag>..master -- backend/canisters/<component>` (frontend for website).
    A component whose only diff is CHANGELOG.md needs no release.
-3. Version numbers are globally sequential across ALL components (next free number, regardless of component). Tag format: `v2.0.NNNN-<component>`, lightweight, at master head:
+3. Canister version numbers are globally sequential across all canister components (next free number, regardless of component). Tag format: `v2.0.NNNN-<component>`, lightweight, at master head:
    `git tag v2.0.NNNN-<component> master && git push origin <tags...>`
+   **The website no longer shares that sequence** (decided 2026-09-04). Its version drives the Android OTA gate, so its bump level is a decision, not the next free number. See step 3a.
+3a. **Website bump level — ASK, do not assume.** The Android app compares its own version against `oc.app/version` and decides over the air whether to update itself. The component that moves decides who gets the release and who has to install a new binary. Getting this wrong ships a feature to Play Store users without Play ever reviewing it.
+
+   Put the question to the developer explicitly, with the diff in hand:
+
+   | Bump | When | Store build | Sideloaded build |
+   |------|------|-------------|------------------|
+   | patch `2.0.2051 → 2.0.2052` | Bug fixes, copy, styling. Nothing a reviewer needs to see. | OTA | OTA |
+   | minor `2.0.2052 → 2.1.0` | A new user-facing feature. Any installed shell can still run it. | Play update | OTA |
+   | major `2.1.0 → 3.0.0` | Web code that now depends on the shell: a new plugin command, a new Rust API, a new permission. Older shells cannot run this bundle. | Play update | New APK |
+
+   `major` means INCOMPATIBLE, not big. A one-line dependency on a new Kotlin command is a major bump. A shell change that no web code calls yet is not a bump at all.
+
+   Checks worth running before answering: `git log <last-website-tag>..master -- frontend/` for user-facing features, and `git log <last-website-tag>..master -- frontend/tauri-plugin-oc frontend/src-tauri` for anything that would make the bundle require a newer shell.
+
+   Full detail in `frontend/tauri-plugin-oc/OTA_UPDATES.md`.
+
 4. Release order is dependency-driven, decided per train. Rule of thumb: a canister must accept a new candid field before anything starts sending it (e.g. video transcode train: storage_bucket → storage_index → website). Website last.
 5. Pushing a tag triggers CI to build and upload wasms to S3 keyed by COMMIT id (`https://openchat-canister-wasms.s3.amazonaws.com/<commit>/<canister>.wasm.gz`). The prod proposal route downloads from there — confirm the CI run finished before prod release.
 
@@ -74,6 +91,17 @@ curl -s https://openchat-canister-wasms.s3.amazonaws.com/<tag commit>/<canister>
 When the developer says the proposal has executed, Claude checks the canister's prod metrics (same checks as Phase 1, `ic` ids) to confirm the new version is live with no obvious errors, before the next component's proposal is submitted.
 
 ### Website
+
+**A major website bump changes the order.** Store and sideloaded users cannot cross a major boundary over the air, and they are not broken by it, they simply freeze on the bundle they already have until a new binary reaches them. So for a major release, get the Android shell out first:
+
+1. Release the canisters as normal.
+2. Build the AAB, submit to Play, wait for approval AND rollout. This is the step whose duration you do not control, so start it early.
+3. Publish the APK for sideloaded users.
+4. Deploy the website last, as always.
+
+That makes a constraint that is otherwise incidental load-bearing: the canisters must be LIVE before the AAB is submitted, because the AAB bundles the new web assets and runs them the moment someone installs, possibly days before the website deploy.
+
+For patch and minor bumps none of this applies. OTA delivers them and the Android shell ships whenever convenient.
 
 Before the prod proposal, deploy the website to **web-test**. Web-test runs against the live prod backend, so do this once the backend canisters in the train are released and up to date on prod. It is the final check that the website is safe to deploy:
 

--- a/.claude/skills/release-train/SKILL.md
+++ b/.claude/skills/release-train/SKILL.md
@@ -99,6 +99,8 @@ When the developer says the proposal has executed, Claude checks the canister's 
 3. Publish the APK for sideloaded users.
 4. Deploy the website last, as always.
 
+This assumes `assetlinks.json` already claims the package with both fingerprints, the upload key and Play's app signing key. It does from the second release onwards. For the FIRST release of a new package name that is not true, and the order is different: nothing may be distributed until the deployed assetlinks lists it. See `frontend/src-tauri/PLAY_STORE_RELEASE.md`.
+
 That makes a constraint that is otherwise incidental load-bearing: the canisters must be LIVE before the AAB is submitted, because the AAB bundles the new web assets and runs them the moment someone installs, possibly days before the website deploy.
 
 For patch and minor bumps none of this applies. OTA delivers them and the Android shell ships whenever convenient.

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -130,8 +130,16 @@ jobs:
                   # match the fingerprint in assetlinks.json. No fallback to a
                   # generated debug key here - that silently produces artifacts
                   # Play rejects and that break App Links and passkeys.
-                  if [ -z "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" ]; then
-                    echo "::error::ANDROID_UPLOAD_KEYSTORE_BASE64 is not set. Add the base64 of the release keystore, plus ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS and ANDROID_KEY_PASSWORD, to the repository secrets."
+                  # All four, not just the keystore: a missing password or
+                  # alias leaves signingProperty returning null and surfaces as
+                  # an opaque gradle signing failure half an hour into the build.
+                  MISSING=""
+                  [ -z "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" ] && MISSING="$MISSING ANDROID_UPLOAD_KEYSTORE_BASE64"
+                  [ -z "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" ] && MISSING="$MISSING ANDROID_KEYSTORE_PASSWORD"
+                  [ -z "${{ secrets.ANDROID_KEY_ALIAS }}" ] && MISSING="$MISSING ANDROID_KEY_ALIAS"
+                  [ -z "${{ secrets.ANDROID_KEY_PASSWORD }}" ] && MISSING="$MISSING ANDROID_KEY_PASSWORD"
+                  if [ -n "$MISSING" ]; then
+                    echo "::error::Missing repository secrets:$MISSING"
                     exit 1
                   fi
 
@@ -197,20 +205,29 @@ jobs:
                   # cannot run. See tauri-plugin-oc/OTA_UPDATES.md.
                   OC_OTA_UPDATES: 'minor'
 
-            - name: Clean Target Directory
-              run: rm -rf src-tauri/target
+            - name: Clean Build Directories
+              # The gradle outputs too, not just the rust target: the AAB is
+              # located by pattern below, and a leftover bundle from the APK
+              # build would be a candidate for it.
+              run: rm -rf src-tauri/target src-tauri/gen/android/app/build
 
             - name: Build Android AAB (Store)
               run: |
                   cargo tauri android build --verbose --aab --target aarch64 armv7 --features store
-                  # Glob rather than hardcode: the bundle path carries the ABI
-                  # flavour and gradle does not honour the APK rename hook here.
-                  AAB=$(find src-tauri/gen/android/app/build/outputs/bundle -name '*.aab' | head -1)
-                  if [ -z "$AAB" ]; then
-                    echo "::error::No .aab was produced"
+
+                  # The universal bundle specifically. Building for two ABIs
+                  # also produces per-flavour bundles, so an unordered match
+                  # could hand Play an arm-only artifact. Insist on exactly one
+                  # rather than picking the first of several.
+                  BUNDLES=src-tauri/gen/android/app/build/outputs/bundle
+                  AABS=$(find "$BUNDLES" -path '*universal*' -name '*.aab' | sort)
+                  COUNT=$(printf '%s\n' "$AABS" | grep -c . || true)
+                  if [ "$COUNT" -ne 1 ]; then
+                    echo "::error::Expected exactly one universal .aab, found $COUNT"
+                    find "$BUNDLES" -name '*.aab' || true
                     exit 1
                   fi
-                  mv "$AAB" ./openchat_${{ env.VERSION }}_store.aab
+                  mv "$AABS" ./openchat_${{ env.VERSION }}_store.aab
               env:
                   OC_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
                   OC_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -227,9 +244,25 @@ jobs:
                     echo "::error::apksigner not found under $ANDROID_HOME/build-tools"
                     exit 1
                   fi
-                  "$APKSIGNER" verify --print-certs "./openchat_${{ env.VERSION }}_full.apk" | grep -i 'SHA-256 digest\|certificate DN'
-                  if "$APKSIGNER" verify --print-certs "./openchat_${{ env.VERSION }}_full.apk" | grep -q 'CN=Android Debug'; then
+                  APK="./openchat_${{ env.VERSION }}_full.apk"
+                  AAB="./openchat_${{ env.VERSION }}_store.aab"
+
+                  "$APKSIGNER" verify --print-certs "$APK" | grep -i 'SHA-256 digest\|certificate DN'
+                  if "$APKSIGNER" verify --print-certs "$APK" | grep -q 'CN=Android Debug'; then
                     echo "::error::APK is debug-signed"
+                    exit 1
+                  fi
+
+                  # apksigner cannot read a bundle, but an AAB is a jar. This is
+                  # the artifact that actually goes to Play, so leaving it
+                  # unchecked would miss the case the APK check exists for.
+                  jarsigner -verify -verbose:summary -certs "$AAB" | grep -i 'CN=\|jar verified' || true
+                  if ! jarsigner -verify "$AAB" | grep -qi 'jar verified'; then
+                    echo "::error::AAB is not signed"
+                    exit 1
+                  fi
+                  if jarsigner -verify -verbose:summary -certs "$AAB" | grep -q 'CN=Android Debug'; then
+                    echo "::error::AAB is debug-signed"
                     exit 1
                   fi
 

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -130,10 +130,15 @@ jobs:
                   # match the fingerprint in assetlinks.json. No fallback to a
                   # generated debug key here - that silently produces artifacts
                   # Play rejects and that break App Links and passkeys.
-                  # Secrets arrive through env, never interpolated into the
-                  # script body: ${{ }} is substituted textually before bash
-                  # parses the line, so a password containing a quote would
-                  # break the test and one containing $( ) would execute.
+                  # Secrets arrive through env, never through GitHub
+                  # expression interpolation into the script body. That
+                  # interpolation is textual and happens before bash parses the
+                  # line, so a password containing a quote would break the test
+                  # and one containing a command substitution would execute.
+                  #
+                  # Do not write an expression here, even in a comment: they are
+                  # evaluated anywhere in the file, and an empty or malformed one
+                  # fails the whole workflow at startup.
                   #
                   # All four are checked, not just the keystore: a missing
                   # password or alias leaves signingProperty returning null and

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -32,6 +32,17 @@ jobs:
                   echo "VERSION=$VERSION" >> $GITHUB_ENV
                   echo "Detected version: $VERSION"
 
+                  # Gradle derives versionCode from this name, so only the
+                  # name is passed. A workflow_dispatch build has no release
+                  # version and falls back to tauri.properties, which keeps
+                  # manual builds visibly distinct from releases.
+                  if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "OC_ANDROID_VERSION_NAME=$VERSION" >> $GITHUB_ENV
+                    echo "Release version: $VERSION"
+                  else
+                    echo "Not a release version, using tauri.properties defaults"
+                  fi
+
             - name: Free Disk Space
               run: |
                   sudo rm -rf /usr/share/dotnet
@@ -114,16 +125,20 @@ jobs:
 
             - name: Setup Keystore
               run: |
-                  mkdir -p ~/.android
-
-                  if [ ! -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
-                    echo "Using provided keystore from secrets..."
-                    echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > ~/.android/debug.keystore
-                  else
-                    echo "No keystore secret found. Generating a temporary debug keystore..."
-                    echo "WARNING: App Links validation (assetlinks.json) will fail because the signature won't match."
-                    keytool -genkey -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+                  # Both artifacts are signed with the same release key: the AAB
+                  # so Play accepts the upload, the APK so hand-installed builds
+                  # match the fingerprint in assetlinks.json. No fallback to a
+                  # generated debug key here - that silently produces artifacts
+                  # Play rejects and that break App Links and passkeys.
+                  if [ -z "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" ]; then
+                    echo "::error::ANDROID_UPLOAD_KEYSTORE_BASE64 is not set. Add the base64 of the release keystore, plus ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS and ANDROID_KEY_PASSWORD, to the repository secrets."
+                    exit 1
                   fi
+
+                  KEYSTORE_PATH="$HOME/openchat-release.jks"
+                  echo "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" | base64 --decode > "$KEYSTORE_PATH"
+                  chmod 600 "$KEYSTORE_PATH"
+                  echo "OC_ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> $GITHUB_ENV
 
             - name: Create Env File
               run: |
@@ -170,43 +185,72 @@ jobs:
 
             - name: Build Android APK (Full)
               run: |
-                  cargo tauri android build --verbose --target aarch64 armv7
+                  cargo tauri android build --verbose --apk --target aarch64 armv7
                   mv src-tauri/gen/android/app/build/outputs/apk/universal/release/openchat-release.apk ./openchat_${{ env.VERSION }}_full.apk
               env:
-                  # Ensure these are passed if needed, though the gradle file uses the debug fallback we set up
-                  ANDROID_KEY_STORE_FILE: ${{ env.ANDROID_KEY_STORE_FILE }}
+                  OC_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+                  OC_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+                  OC_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
                   OC_APP_STORE: 'false'
-                  OC_OTA_UPDATES: 'major'
+                  # Sideloaded builds take feature releases over the air but stop
+                  # at a major bump, which is what marks a bundle an older shell
+                  # cannot run. See tauri-plugin-oc/OTA_UPDATES.md.
+                  OC_OTA_UPDATES: 'minor'
 
             - name: Clean Target Directory
               run: rm -rf src-tauri/target
 
-            - name: Build Android APK (Store)
+            - name: Build Android AAB (Store)
               run: |
-                  cargo tauri android build --verbose --target aarch64 armv7 --features store
-                  mv src-tauri/gen/android/app/build/outputs/apk/universal/release/openchat-release.apk ./openchat_${{ env.VERSION }}_store.apk
+                  cargo tauri android build --verbose --aab --target aarch64 armv7 --features store
+                  # Glob rather than hardcode: the bundle path carries the ABI
+                  # flavour and gradle does not honour the APK rename hook here.
+                  AAB=$(find src-tauri/gen/android/app/build/outputs/bundle -name '*.aab' | head -1)
+                  if [ -z "$AAB" ]; then
+                    echo "::error::No .aab was produced"
+                    exit 1
+                  fi
+                  mv "$AAB" ./openchat_${{ env.VERSION }}_store.aab
               env:
-                  # Ensure these are passed if needed, though the gradle file uses the debug fallback we set up
-                  ANDROID_KEY_STORE_FILE: ${{ env.ANDROID_KEY_STORE_FILE }}
+                  OC_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+                  OC_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+                  OC_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
                   OC_APP_STORE: 'true'
                   OC_OTA_UPDATES: 'patch'
 
-            - name: Upload APKs
+            - name: Verify signing certificate
+              run: |
+                  # Catches a fallback to debug signing, which would be rejected
+                  # by Play and would not match assetlinks.json.
+                  APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner -type f | sort -V | tail -1)
+                  if [ -z "$APKSIGNER" ]; then
+                    echo "::error::apksigner not found under $ANDROID_HOME/build-tools"
+                    exit 1
+                  fi
+                  "$APKSIGNER" verify --print-certs "./openchat_${{ env.VERSION }}_full.apk" | grep -i 'SHA-256 digest\|certificate DN'
+                  if "$APKSIGNER" verify --print-certs "./openchat_${{ env.VERSION }}_full.apk" | grep -q 'CN=Android Debug'; then
+                    echo "::error::APK is debug-signed"
+                    exit 1
+                  fi
+
+            - name: Upload build artifacts
               uses: actions/upload-artifact@v4
               with:
-                  name: android-release-apks
+                  name: android-release-artifacts
                   path: |
                       frontend/openchat_${{ env.VERSION }}_full.apk
-                      frontend/openchat_${{ env.VERSION }}_store.apk
+                      frontend/openchat_${{ env.VERSION }}_store.aab
                   if-no-files-found: error
 
-            - name: Upload APKs to Release
+            # Only the APK. The AAB is for the Play Console and is fetched
+            # from the workflow artifacts above; attaching it to a public
+            # release would just offer people a file they cannot install.
+            - name: Upload APK to Release
               if: github.event_name == 'release'
               uses: softprops/action-gh-release@v2
               with:
                   files: |
                       frontend/openchat_${{ env.VERSION }}_full.apk
-                      frontend/openchat_${{ env.VERSION }}_store.apk
 
             - name: Notify Release
               if: github.event_name == 'release'

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -130,23 +130,33 @@ jobs:
                   # match the fingerprint in assetlinks.json. No fallback to a
                   # generated debug key here - that silently produces artifacts
                   # Play rejects and that break App Links and passkeys.
-                  # All four, not just the keystore: a missing password or
-                  # alias leaves signingProperty returning null and surfaces as
-                  # an opaque gradle signing failure half an hour into the build.
+                  # Secrets arrive through env, never interpolated into the
+                  # script body: ${{ }} is substituted textually before bash
+                  # parses the line, so a password containing a quote would
+                  # break the test and one containing $( ) would execute.
+                  #
+                  # All four are checked, not just the keystore: a missing
+                  # password or alias leaves signingProperty returning null and
+                  # surfaces as an opaque gradle failure half an hour later.
                   MISSING=""
-                  [ -z "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" ] && MISSING="$MISSING ANDROID_UPLOAD_KEYSTORE_BASE64"
-                  [ -z "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" ] && MISSING="$MISSING ANDROID_KEYSTORE_PASSWORD"
-                  [ -z "${{ secrets.ANDROID_KEY_ALIAS }}" ] && MISSING="$MISSING ANDROID_KEY_ALIAS"
-                  [ -z "${{ secrets.ANDROID_KEY_PASSWORD }}" ] && MISSING="$MISSING ANDROID_KEY_PASSWORD"
+                  [ -z "$KEYSTORE_BASE64" ] && MISSING="$MISSING ANDROID_UPLOAD_KEYSTORE_BASE64"
+                  [ -z "$KEYSTORE_PASSWORD" ] && MISSING="$MISSING ANDROID_KEYSTORE_PASSWORD"
+                  [ -z "$KEY_ALIAS" ] && MISSING="$MISSING ANDROID_KEY_ALIAS"
+                  [ -z "$KEY_PASSWORD" ] && MISSING="$MISSING ANDROID_KEY_PASSWORD"
                   if [ -n "$MISSING" ]; then
                     echo "::error::Missing repository secrets:$MISSING"
                     exit 1
                   fi
 
                   KEYSTORE_PATH="$HOME/openchat-release.jks"
-                  echo "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" | base64 --decode > "$KEYSTORE_PATH"
+                  printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
                   chmod 600 "$KEYSTORE_PATH"
                   echo "OC_ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> $GITHUB_ENV
+              env:
+                  KEYSTORE_BASE64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
+                  KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+                  KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+                  KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
 
             - name: Create Env File
               run: |

--- a/frontend/app/assetlinks.json
+++ b/frontend/app/assetlinks.json
@@ -6,6 +6,19 @@
         ],
         "target": {
             "namespace": "android_app",
+            "package_name": "com.oclabs.openchat",
+            "sha256_cert_fingerprints": [
+                "00:F4:D0:31:0A:9F:DC:36:0C:12:5A:1B:BF:F1:70:45:CF:11:A2:BA:44:0E:F8:C8:54:ED:70:9D:2D:44:51:7E"
+            ]
+        }
+    },
+    {
+        "relation": [
+            "delegate_permission/common.get_login_creds",
+            "delegate_permission/common.handle_all_urls"
+        ],
+        "target": {
+            "namespace": "android_app",
             "package_name": "com.oc.app",
             "sha256_cert_fingerprints": [
                 "C5:F5:1D:E2:56:14:54:74:01:9E:5B:5E:11:CF:85:A6:A9:EC:B5:B3:F4:E3:7A:A3:FC:E0:04:05:99:7B:CB:90",

--- a/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
+++ b/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
@@ -1,15 +1,45 @@
 <script lang="ts">
     import { VersionChecker } from "@src/utils/version.svelte";
+    import { appStoreBuild } from "@utils/features";
     import { BodySmall, Button, ColourVars, Column, Overview, Sheet } from "component-lib";
     import { onDestroy } from "svelte";
+    import { openUrl } from "tauri-plugin-oc-api";
     import { i18nKey } from "../i18n/i18n";
     import Progress from "./Progress.svelte";
     import Translatable from "./Translatable.svelte";
 
+    const PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.oclabs.openchat";
+    const DIRECT_DOWNLOAD_URL = "https://github.com/open-chat-labs/open-chat/releases/latest";
+
     let checker = new VersionChecker();
 
     onDestroy(() => checker.stop());
+
+    // A store build can only be updated through the store it came from; a
+    // sideloaded build has to fetch a new APK itself.
+    let upgradeUrl = $derived(appStoreBuild ? PLAY_STORE_URL : DIRECT_DOWNLOAD_URL);
 </script>
+
+{#if checker.versionState.kind === "incompatible"}
+    <Sheet>
+        <Column gap={"xl"} padding={"xxl"}>
+            <Overview colour={"primary"}>Update required</Overview>
+            <BodySmall width={"hug"} fontWeight={"bold"}>
+                <Translatable
+                    resourceKey={i18nKey(
+                        `Version ${checker.versionState.available.toText()} is available, but it needs a newer version of the app than the one you have installed. This one cannot update itself the rest of the way.`,
+                    )} />
+            </BodySmall>
+
+            <Button onClick={() => openUrl({ url: upgradeUrl })} secondary>
+                <Translatable
+                    resourceKey={i18nKey(
+                        appStoreBuild ? "Update from the Play Store" : "Download the latest version",
+                    )} />
+            </Button>
+        </Column>
+    </Sheet>
+{/if}
 
 {#if checker.versionState.kind === "out_of_date"}
     <Sheet>

--- a/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
+++ b/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
@@ -12,14 +12,24 @@
     const DIRECT_DOWNLOAD_URL = "https://github.com/open-chat-labs/open-chat/releases/latest";
 
     let checker = new VersionChecker();
+    let dismissed = $state(false);
 
     onDestroy(() => checker.stop());
 
     // A store build can only be updated through the store it came from; a
     // sideloaded build has to fetch a new APK itself.
     let upgradeUrl = $derived(appStoreBuild ? PLAY_STORE_URL : DIRECT_DOWNLOAD_URL);
+    let upgradeLabel = $derived(
+        appStoreBuild ? "Update from the Play Store" : "Download the latest version",
+    );
 </script>
 
+<!--
+    A major bump: this shell cannot run the new bundle, so there is nothing to
+    dismiss to. Safe to block only because the release-train runbook requires
+    the store update to be live and rolled out BEFORE the website announces a
+    major, so the button always leads somewhere.
+-->
 {#if checker.versionState.kind === "incompatible"}
     <Sheet>
         <Column gap={"xl"} padding={"xxl"}>
@@ -32,10 +42,31 @@
             </BodySmall>
 
             <Button onClick={() => openUrl({ url: upgradeUrl })} secondary>
+                <Translatable resourceKey={i18nKey(upgradeLabel)} />
+            </Button>
+        </Column>
+    </Sheet>
+{/if}
+
+<!--
+    A minor bump on a store build. The app works perfectly well on what it has;
+    the new version is simply waiting on review, and the store listing may show
+    nothing at all for days. Passing onDismiss is what makes SheetWrapper honour
+    the drag handle, backdrop and Escape.
+-->
+{#if checker.versionState.kind === "store_update_available" && !dismissed}
+    <Sheet onDismiss={() => (dismissed = true)}>
+        <Column gap={"xl"} padding={"xxl"}>
+            <Overview colour={"primary"}>Update available</Overview>
+            <BodySmall width={"hug"} fontWeight={"bold"}>
                 <Translatable
                     resourceKey={i18nKey(
-                        appStoreBuild ? "Update from the Play Store" : "Download the latest version",
+                        `Version ${checker.versionState.available.toText()} is available. This one keeps working in the meantime.`,
                     )} />
+            </BodySmall>
+
+            <Button onClick={() => openUrl({ url: upgradeUrl })} secondary>
+                <Translatable resourceKey={i18nKey(upgradeLabel)} />
             </Button>
         </Column>
     </Sheet>

--- a/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
+++ b/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
@@ -12,10 +12,34 @@
     const DIRECT_DOWNLOAD_URL = "https://github.com/open-chat-labs/open-chat/releases/latest";
 
     let checker = new VersionChecker();
-    // Keyed by version, not a boolean: the poller keeps running so a release
-    // can be rolled back and a different one announced later, and that one
-    // should be shown rather than swallowed by an earlier dismissal.
-    let dismissedVersion = $state<string | undefined>(undefined);
+
+    // Persisted, and keyed by version rather than a boolean.
+    //
+    // Persisted because review and staged rollout take days, and component
+    // state would put the sheet back on every cold start for the whole of it.
+    // Keyed by version because the poller keeps running, so a release can be
+    // rolled back and a different one announced later; that one should be
+    // shown rather than swallowed by the earlier dismissal.
+    const DISMISSED_KEY = "oc_dismissed_update_version";
+
+    let dismissedVersion = $state<string | undefined>(readDismissed());
+
+    function readDismissed(): string | undefined {
+        try {
+            return localStorage.getItem(DISMISSED_KEY) ?? undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    function dismiss(version: string) {
+        dismissedVersion = version;
+        try {
+            localStorage.setItem(DISMISSED_KEY, version);
+        } catch {
+            // Storage unavailable just means it reappears next launch.
+        }
+    }
 
     onDestroy(() => checker.stop());
 
@@ -59,7 +83,7 @@
 -->
 {#if checker.versionState.kind === "store_update_available" && checker.versionState.available.toText() !== dismissedVersion}
     {@const available = checker.versionState.available.toText()}
-    <Sheet onDismiss={() => (dismissedVersion = available)}>
+    <Sheet onDismiss={() => dismiss(available)}>
         <Column gap={"xl"} padding={"xxl"}>
             <Overview colour={"primary"}>Update available</Overview>
             <BodySmall width={"hug"} fontWeight={"bold"}>

--- a/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
+++ b/frontend/app/src/components_mobile/NativeUpgradeBanner.svelte
@@ -12,7 +12,10 @@
     const DIRECT_DOWNLOAD_URL = "https://github.com/open-chat-labs/open-chat/releases/latest";
 
     let checker = new VersionChecker();
-    let dismissed = $state(false);
+    // Keyed by version, not a boolean: the poller keeps running so a release
+    // can be rolled back and a different one announced later, and that one
+    // should be shown rather than swallowed by an earlier dismissal.
+    let dismissedVersion = $state<string | undefined>(undefined);
 
     onDestroy(() => checker.stop());
 
@@ -54,8 +57,9 @@
     nothing at all for days. Passing onDismiss is what makes SheetWrapper honour
     the drag handle, backdrop and Escape.
 -->
-{#if checker.versionState.kind === "store_update_available" && !dismissed}
-    <Sheet onDismiss={() => (dismissed = true)}>
+{#if checker.versionState.kind === "store_update_available" && checker.versionState.available.toText() !== dismissedVersion}
+    {@const available = checker.versionState.available.toText()}
+    <Sheet onDismiss={() => (dismissedVersion = available)}>
         <Column gap={"xl"} padding={"xxl"}>
             <Overview colour={"primary"}>Update available</Overview>
             <BodySmall width={"hug"} fontWeight={"bold"}>

--- a/frontend/app/src/components_mobile/home/user_profile/About.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/About.svelte
@@ -13,6 +13,7 @@
         Subtitle,
     } from "component-lib";
     import { publish, type OpenChat } from "@client";
+    import { isAndroidTauriApp } from "@shared";
     import { toastStore } from "@src/stores/toast";
     import { clearCrashLog, formatCrashLog } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
@@ -36,7 +37,9 @@
     let shellVersion = $state<string | undefined>(undefined);
 
     onMount(() => {
-        if (client.isNativeApp()) {
+        // Android only, matching VersionChecker. iOS has no OTA path, so its
+        // shell and web versions cannot diverge and the row would be noise.
+        if (isAndroidTauriApp()) {
             getShellVersion()
                 .then((v) => (shellVersion = v))
                 .catch(() => (shellVersion = undefined));

--- a/frontend/app/src/components_mobile/home/user_profile/About.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/About.svelte
@@ -16,17 +16,32 @@
     import { toastStore } from "@src/stores/toast";
     import { clearCrashLog, formatCrashLog } from "@utils/errorPostmortem";
     import { navigate } from "@utils/navigation";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import ChevronRight from "svelte-material-icons/ChevronRight.svelte";
-    import { openUrl } from "tauri-plugin-oc-api";
+    import { getShellVersion, openUrl } from "tauri-plugin-oc-api";
     import SlidingPageContent from "../SlidingPageContent.svelte";
 
     type OnClick = { kind: "route"; url: string } | { kind: "action"; action: () => void };
 
     const client = getContext<OpenChat>("client");
 
+    // The web version currently running, which after an OTA update is the
+    // downloaded bundle rather than the one the shell shipped with.
     //@ts-ignore
     let version = window.OC_WEBSITE_VERSION;
+
+    // The version of the installed binary. Only differs from `version` once an
+    // OTA update has been applied, and knowing which is which matters when
+    // reading a crash report.
+    let shellVersion = $state<string | undefined>(undefined);
+
+    onMount(() => {
+        if (client.isNativeApp()) {
+            getShellVersion()
+                .then((v) => (shellVersion = v))
+                .catch(() => (shellVersion = undefined));
+        }
+    });
 
     let crashLogTaps = 0;
     let crashLogTapTimer: number | undefined = undefined;
@@ -89,6 +104,11 @@
             <BodySmall fontWeight={"bold"} align={"center"} colour={"textSecondary"}
                 >Android / {version}</BodySmall
             >
+            {#if shellVersion !== undefined}
+                <BodySmall align={"center"} colour={"textSecondary"}
+                    >Shell / {shellVersion}</BodySmall
+                >
+            {/if}
         </div>
         <div class="line"></div>
         <Container direction={"vertical"} gap={"xl"}>

--- a/frontend/app/src/utils/version.svelte.ts
+++ b/frontend/app/src/utils/version.svelte.ts
@@ -64,6 +64,7 @@ export class VersionChecker {
                 };
 
                 let unsubscribe: UnlistenFn | undefined;
+                let downloaded = false;
 
                 try {
                     // listen out for download progress
@@ -83,6 +84,7 @@ export class VersionChecker {
                         };
                         console.log("Native update failed or was not needed");
                     } else {
+                        downloaded = true;
                         if (this.#versionState.kind === "out_of_date") {
                             this.#versionState.downloadProgress = 100;
                         }
@@ -93,11 +95,26 @@ export class VersionChecker {
                     return;
                 } finally {
                     unsubscribe?.();
+                    // Only resume polling if there is still something polling
+                    // could achieve. Once the bundle is on disk the user has to
+                    // restart, and nothing the poller learns changes that: the
+                    // running JS still reports the old client version, so the
+                    // next tick would re-enter this branch, reset the progress
+                    // bar to zero, call download_update again, and get back
+                    // false because the cache already matches the server -
+                    // which this code reads as failure. A finished download and
+                    // its restart prompt would turn into "update failed" 60
+                    // seconds later.
+                    //
+                    // A failure does resume, so a transient one retries.
+                    //
                     // Must reassign: #poller still points at the instance
-                    // stopped above, so dropping this would leave the live
-                    // poller unreachable - stop() and onDestroy would both
+                    // stopped above, so dropping the result would leave the
+                    // live poller unreachable - stop() and onDestroy would both
                     // act on the dead one while it kept firing.
-                    this.#poller = this.#startPoller(false);
+                    if (!downloaded) {
+                        this.#poller = this.#startPoller(false);
+                    }
                 }
             } else if (sv.isGreaterThan(this.#clientVersion)) {
                 // Newer, but across a boundary the strategy will not cross.

--- a/frontend/app/src/utils/version.svelte.ts
+++ b/frontend/app/src/utils/version.svelte.ts
@@ -100,16 +100,19 @@ export class VersionChecker {
                     this.#poller = this.#startPoller(false);
                 }
             } else if (sv.isGreaterThan(this.#clientVersion)) {
-                // Newer, but across a boundary the strategy will not cross. No
-                // amount of polling changes that - only a new binary does - so
-                // stop asking and tell the user.
+                // Newer, but across a boundary the strategy will not cross.
                 //
                 // Whether this shell could have run the bundle is a separate
                 // question from whether the strategy allowed it: "minor" is
                 // exactly the test for "same major", i.e. no new native code
                 // needed.
+                //
+                // The poller deliberately keeps running. A bad release can be
+                // rolled back, and that is the case this state must recover
+                // from: stopping here would leave the app showing an update
+                // prompt for a version that no longer exists until the user
+                // killed and relaunched it.
                 const runnable = this.#clientVersion.canUpdateTo(sv, "minor");
-                this.#poller?.stop();
                 this.#versionState = runnable
                     ? { kind: "store_update_available", available: sv }
                     : { kind: "incompatible", available: sv };

--- a/frontend/app/src/utils/version.svelte.ts
+++ b/frontend/app/src/utils/version.svelte.ts
@@ -15,11 +15,20 @@ type VersionState =
     | { kind: "unknown" }
     | { kind: "up_to_date" }
     | { kind: "failed_update"; available: Version; error: unknown }
-    // A newer version exists but the OTA strategy refuses it, so the user is
-    // stuck on what they have until they install a new binary. See
-    // tauri-plugin-oc/OTA_UPDATES.md: for a store build that means any feature
-    // release, for a sideloaded build only a major one.
+    // A newer version exists but the OTA strategy refuses it. Two different
+    // situations, and conflating them walls users out of a working app:
+    //
+    // "incompatible" - a major bump. This shell genuinely cannot run the new
+    // bundle, and per the release-train runbook the store update is already
+    // live by the time the website announces a major, so sending the user
+    // there works.
+    //
+    // "store_update_available" - a minor bump on a store build. Any shell can
+    // run it; it is held back only so Play reviews the feature. The Play
+    // listing may show nothing for days while review and staged rollout run,
+    // so this must not block anything.
     | { kind: "incompatible"; available: Version }
+    | { kind: "store_update_available"; available: Version }
     | { kind: "out_of_date"; available: Version; downloadProgress: number };
 
 export class VersionChecker {
@@ -84,16 +93,28 @@ export class VersionChecker {
                     return;
                 } finally {
                     unsubscribe?.();
-                    this.#startPoller(false);
+                    // Must reassign: #poller still points at the instance
+                    // stopped above, so dropping this would leave the live
+                    // poller unreachable - stop() and onDestroy would both
+                    // act on the dead one while it kept firing.
+                    this.#poller = this.#startPoller(false);
                 }
             } else if (sv.isGreaterThan(this.#clientVersion)) {
                 // Newer, but across a boundary the strategy will not cross. No
                 // amount of polling changes that - only a new binary does - so
                 // stop asking and tell the user.
+                //
+                // Whether this shell could have run the bundle is a separate
+                // question from whether the strategy allowed it: "minor" is
+                // exactly the test for "same major", i.e. no new native code
+                // needed.
+                const runnable = this.#clientVersion.canUpdateTo(sv, "minor");
                 this.#poller?.stop();
-                this.#versionState = { kind: "incompatible", available: sv };
+                this.#versionState = runnable
+                    ? { kind: "store_update_available", available: sv }
+                    : { kind: "incompatible", available: sv };
                 console.log(
-                    `Server version (${sv.toText()}) cannot be applied over the air to client version (${this.#clientVersion.toText()}) under strategy "${this.#strategy}"`,
+                    `Server version (${sv.toText()}) cannot be applied over the air to client version (${this.#clientVersion.toText()}) under strategy "${this.#strategy}" (runnable by this shell: ${runnable})`,
                 );
             } else {
                 this.#versionState = { kind: "up_to_date" };

--- a/frontend/app/src/utils/version.svelte.ts
+++ b/frontend/app/src/utils/version.svelte.ts
@@ -35,6 +35,9 @@ export class VersionChecker {
     #clientVersion = Version.parse(import.meta.env.OC_WEBSITE_VERSION);
     #versionState = $state<VersionState>({ kind: "unknown" });
     #strategy: OTAUpdateStrategy = import.meta.env.OC_OTA_UPDATES;
+    // stop() can land while download_update is still awaiting, and the finally
+    // below would then start a fresh poller that nothing is left to stop.
+    #stopped = false;
     #poller = this.#startPoller(true);
 
     get versionState() {
@@ -42,6 +45,7 @@ export class VersionChecker {
     }
 
     #startPoller(immediate: boolean) {
+        if (this.#stopped) return;
         // this should only operate if we are in the android app and the ota strategy is not set to none
         if (!isAndroidTauriApp() || this.#strategy === "none") {
             this.#versionState = { kind: "up_to_date" };
@@ -115,6 +119,8 @@ export class VersionChecker {
                     if (!downloaded) {
                         this.#poller = this.#startPoller(false);
                     }
+                    // #startPoller returns undefined once stopped, so a
+                    // component destroyed mid-download leaves nothing running.
                 }
             } else if (sv.isGreaterThan(this.#clientVersion)) {
                 // Newer, but across a boundary the strategy will not cross.
@@ -154,6 +160,7 @@ export class VersionChecker {
     }
 
     stop() {
+        this.#stopped = true;
         this.#poller?.stop();
     }
 }

--- a/frontend/app/src/utils/version.svelte.ts
+++ b/frontend/app/src/utils/version.svelte.ts
@@ -15,7 +15,12 @@ type VersionState =
     | { kind: "unknown" }
     | { kind: "up_to_date" }
     | { kind: "failed_update"; available: Version; error: unknown }
-    | { kind: "out_of_date"; compatible: boolean; available: Version; downloadProgress: number };
+    // A newer version exists but the OTA strategy refuses it, so the user is
+    // stuck on what they have until they install a new binary. See
+    // tauri-plugin-oc/OTA_UPDATES.md: for a store build that means any feature
+    // release, for a sideloaded build only a major one.
+    | { kind: "incompatible"; available: Version }
+    | { kind: "out_of_date"; available: Version; downloadProgress: number };
 
 export class VersionChecker {
     #clientVersion = Version.parse(import.meta.env.OC_WEBSITE_VERSION);
@@ -45,7 +50,6 @@ export class VersionChecker {
 
                 this.#versionState = {
                     kind: "out_of_date",
-                    compatible: true,
                     available: sv,
                     downloadProgress: 0,
                 };
@@ -82,6 +86,15 @@ export class VersionChecker {
                     unsubscribe?.();
                     this.#startPoller(false);
                 }
+            } else if (sv.isGreaterThan(this.#clientVersion)) {
+                // Newer, but across a boundary the strategy will not cross. No
+                // amount of polling changes that - only a new binary does - so
+                // stop asking and tell the user.
+                this.#poller?.stop();
+                this.#versionState = { kind: "incompatible", available: sv };
+                console.log(
+                    `Server version (${sv.toText()}) cannot be applied over the air to client version (${this.#clientVersion.toText()}) under strategy "${this.#strategy}"`,
+                );
             } else {
                 this.#versionState = { kind: "up_to_date" };
                 console.log(

--- a/frontend/src-tauri/IOS_PORT_STATUS.md
+++ b/frontend/src-tauri/IOS_PORT_STATUS.md
@@ -44,9 +44,11 @@ proper Apple Developer account exists.
   Before the production account is set up, INVESTIGATE: ask the team whether
   any OpenChat/DFINITY-era Apple developer account ever existed and check old
   credentials. If a stranger holds it there is no Apple reclaim process for
-  bundle ids (only for app names) and the production iOS id will have to
-  differ from Android's `com.oc.app`. Either way, do NOT register the
-  intended final id under the interim team (that would burn it too).
+  bundle ids (only for app names). This is now moot for parity: Android moved
+  off `com.oc.app` to `com.oclabs.openchat` on 2026-09-04 for the Play Store
+  submission, so the production iOS id can match Android. Either way, do NOT
+  register the intended final id under the interim team (that would burn it
+  too).
 - Interim dev builds use **`com.oclabs.openchat.dev`** (set in
   `tauri.ios.conf.json` + `gen/apple/project.yml`); the oc.app AASA lists only
   that app id (#9242 — the `A468T66XSK.com.oc.app` entry was dropped as it can

--- a/frontend/src-tauri/PLAY_STORE_RELEASE.md
+++ b/frontend/src-tauri/PLAY_STORE_RELEASE.md
@@ -50,9 +50,10 @@ Android treats the renamed app as unrelated software, so those installs:
   the same account, and both apps will ring
 
 Nothing in the app can fix this, because the code deciding it is already on the
-device. Migration has to be announced, and the new APK link published where those
-users will see it. Until that happens, expect duplicate notifications from anyone
-running both.
+device. **Decision (2026-09-04): handle it with an announcement**, published where
+those users will see it, carrying the new APK link and telling people to uninstall
+the old app rather than run both. Expect duplicate notifications from anyone who
+ignores that until they do.
 
 Removing the `com.oc.app` client from `google-services.json` would stop the
 duplicates by silently killing push for everyone still on the old build. Do not.

--- a/frontend/src-tauri/PLAY_STORE_RELEASE.md
+++ b/frontend/src-tauri/PLAY_STORE_RELEASE.md
@@ -33,7 +33,13 @@ bundle is uploaded. The order is therefore:
 4. Deploy the website so `https://oc.app/.well-known/assetlinks.json` serves it.
 5. Verify on a device installed from Play: deep links open in the app, and
    passkey sign-in completes.
-6. Only then promote to production.
+6. Only then promote to production, and only then publish the APK.
+
+Step 6 covers both channels deliberately. Nothing carrying the new package name
+should reach a user before the deployed `assetlinks.json` lists it, or that user
+installs an app with no App Links and no passkeys and has to wait for a website
+deploy to fix it. That includes the hand-distributed APK, whose own fingerprint
+is already in the file but whose package name is not claimed until it deploys.
 
 `com.oc.app` keeps its own entry with the old fingerprints so existing sideloaded
 installs are unaffected.
@@ -43,11 +49,23 @@ installs are unaffected.
 Builds before the rename are `com.oc.app` with `OC_OTA_UPDATES=major` compiled in.
 Android treats the renamed app as unrelated software, so those installs:
 
-- keep applying web updates over the air indefinitely, so they stay usable
+- keep applying web updates over the air indefinitely, so they stay usable until
+  the first major release
+- **break at the first major release.** They have `OC_OTA_UPDATES=major` compiled
+  in, meaning "take anything newer", and they poll the same
+  `oc.app/downloads/full-<version>.zip`. So they will download a bundle that by
+  definition requires a newer shell, and no APK will ever again carry that
+  package name for them to get one from. The strategy that protects the new
+  sideloaded build (`minor`) is not on those devices.
 - never receive native fixes again, since no APK will ever have that package name
 - see none of the update prompts added for the new package
 - will, if the user also installs the new app, hold a second valid FCM token for
   the same account, and both apps will ring
+
+The break is not hypothetical and it has a deadline: it lands the day a major
+website version is published. Either the migration is announced and taken up well
+before then, or the first major bundle must not be published at
+`downloads/full-<version>.zip` where the old app will find it.
 
 Nothing in the app can fix this, because the code deciding it is already on the
 device. **Decision (2026-09-04): handle it with an announcement**, published where

--- a/frontend/src-tauri/PLAY_STORE_RELEASE.md
+++ b/frontend/src-tauri/PLAY_STORE_RELEASE.md
@@ -1,0 +1,58 @@
+# Play Store release
+
+Package `com.oclabs.openchat`, Computism Play Console account.
+
+The build produces two artifacts from one release key (`~/keys/openchat-upload.jks`
+locally, `ANDROID_UPLOAD_KEYSTORE_BASE64` and friends in CI):
+
+- `openchat_<version>_full.apk` — hand-distributed, `OC_OTA_UPDATES=minor`
+- `openchat_<version>_store.aab` — uploaded to Play, `OC_OTA_UPDATES=patch`
+
+A device can hold only one of them. They carry different signatures once Play
+re-signs the bundle, so moving between the two channels needs an uninstall.
+
+## Blocking: assetlinks after the first upload
+
+Play App Signing is mandatory for new apps. Google re-signs every download with
+an app signing key it generates, so **the certificate on an installed Play build
+is not the one in `frontend/app/assetlinks.json` today**. That file currently
+lists the upload key.
+
+Until it lists Google's, Play-installed builds have no App Links and, because the
+statement also claims `get_login_creds`, **no passkeys**. Passkey sign-in is the
+main route for these users, so this is a day-one break, not a cosmetic gap.
+
+It cannot be fixed in advance: the app signing key does not exist until the first
+bundle is uploaded. The order is therefore:
+
+1. Upload the AAB to an internal testing track.
+2. Play Console → Setup → App integrity → read the **app signing key** SHA-256
+   (not the upload key, which is also shown there).
+3. Add it to the `com.oclabs.openchat` entry in `frontend/app/assetlinks.json`,
+   keeping the upload key fingerprint so hand-distributed APKs keep working.
+4. Deploy the website so `https://oc.app/.well-known/assetlinks.json` serves it.
+5. Verify on a device installed from Play: deep links open in the app, and
+   passkey sign-in completes.
+6. Only then promote to production.
+
+`com.oc.app` keeps its own entry with the old fingerprints so existing sideloaded
+installs are unaffected.
+
+## Sideloaded installs on the old package
+
+Builds before the rename are `com.oc.app` with `OC_OTA_UPDATES=major` compiled in.
+Android treats the renamed app as unrelated software, so those installs:
+
+- keep applying web updates over the air indefinitely, so they stay usable
+- never receive native fixes again, since no APK will ever have that package name
+- see none of the update prompts added for the new package
+- will, if the user also installs the new app, hold a second valid FCM token for
+  the same account, and both apps will ring
+
+Nothing in the app can fix this, because the code deciding it is already on the
+device. Migration has to be announced, and the new APK link published where those
+users will see it. Until that happens, expect duplicate notifications from anyone
+running both.
+
+Removing the `com.oc.app` client from `google-services.json` would stop the
+duplicates by silently killing push for everyone still on the old build. Do not.

--- a/frontend/src-tauri/gen/android/.gitignore
+++ b/frontend/src-tauri/gen/android/.gitignore
@@ -14,6 +14,7 @@ build
 .cxx
 local.properties
 key.properties
+keystore.properties
 
 /.tauri
 

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.File
 import java.util.Properties
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -16,24 +17,92 @@ val tauriProperties = Properties().apply {
     }
 }
 
+// Release signing.
+//
+// Reads gen/android/keystore.properties (gitignored - it holds the password),
+// overridable by OC_ANDROID_* env vars so CI can inject the key from secrets.
+//
+// The APK handed out from oc.app and the AAB uploaded to Play are signed with
+// the SAME key. Its SHA-256 must appear in frontend/app/assetlinks.json or the
+// installed app loses App Links AND passkeys (the statement claims
+// get_login_creds).
+//
+// No keystore at all falls back to debug signing, so a fresh clone can still
+// build a release locally. A keystore that is CONFIGURED but absent is a hard
+// failure: falling through to debug signing there produces an artifact Play
+// rejects outright, and one that no device will accept as an update over a
+// properly signed build (INSTALL_FAILED_UPDATE_INCOMPATIBLE, fixable only by
+// uninstalling, which wipes the account's local data). CI supplies the keystore
+// and fails before the build if the secret is missing.
+val keystoreDir = rootProject.projectDir
+val keystoreProperties = Properties().apply {
+    val propFile = File(keystoreDir, "keystore.properties")
+    if (propFile.exists()) propFile.inputStream().use { load(it) }
+}
+fun signingProperty(name: String, env: String): String? =
+    System.getenv(env)?.takeIf { it.isNotBlank() }
+        ?: keystoreProperties.getProperty(name)?.takeIf { it.isNotBlank() }
+
+// A relative storeFile resolves against the directory holding the properties file.
+val releaseKeystore = signingProperty("storeFile", "OC_ANDROID_KEYSTORE_PATH")
+    ?.let { path -> File(path).takeIf { it.isAbsolute } ?: File(keystoreDir, path) }
+    ?.also { if (!it.exists()) throw GradleException("Android keystore not found: $it") }
+
+// Release version, passed in by CI as the tag's version (e.g. 2.0.2051).
+//
+// Play requires versionCode to increase on every upload and never allows a
+// value to be reused, so it is DERIVED from the name rather than supplied
+// separately - the two can then never disagree.
+//
+// major*1000000 + minor*10000 + patch stays monotonic across the version bumps
+// the OTA convention relies on: 2.0.2051 -> 2002051, then 2.1.0 -> 2010000,
+// then 3.0.0 -> 3000000. Taking the patch component alone would send 2051 -> 0
+// on a minor bump and Play would reject the upload. Tauri's own formula
+// (major*1000000 + minor*1000 + patch) caps patch at 999 and cannot express an
+// OpenChat version at all, which is why every APK so far has been stuck at 1000.
+//
+// Unset for local and manual builds, which fall back to tauri.properties.
+val releaseVersionName: String? =
+    System.getenv("OC_ANDROID_VERSION_NAME")?.takeIf { it.isNotBlank() }
+
+val releaseVersionCode: Int? = releaseVersionName?.let { name ->
+    val parts = name.split(".")
+    if (parts.size != 3) {
+        throw GradleException("OC_ANDROID_VERSION_NAME is not major.minor.patch: $name")
+    }
+    val (major, minor, patch) = parts.map {
+        it.toIntOrNull()
+            ?: throw GradleException("OC_ANDROID_VERSION_NAME is not major.minor.patch: $name")
+    }
+    if (minor > 99 || patch > 9999) {
+        throw GradleException(
+            "Version $name overflows the versionCode formula (minor <= 99, patch <= 9999)")
+    }
+    major * 1_000_000 + minor * 10_000 + patch
+}
+
 android {
     compileSdk = 36
-    namespace = "com.oc.app"
+    namespace = "com.oclabs.openchat"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        applicationId = "com.oc.app"
+        applicationId = "com.oclabs.openchat"
         minSdk = 24
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
-        versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
+        versionCode = releaseVersionCode
+            ?: tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
+        versionName = releaseVersionName
+            ?: tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }
     
     signingConfigs {
-        create("debugRelease") {
-            storeFile = file(System.getProperty("user.home") + "/.android/debug.keystore")
-            storePassword = "android"
-            keyAlias = "androiddebugkey"
-            keyPassword = "android"
+        if (releaseKeystore != null) {
+            create("release") {
+                storeFile = releaseKeystore
+                storePassword = signingProperty("storePassword", "OC_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = signingProperty("keyAlias", "OC_ANDROID_KEY_ALIAS")
+                keyPassword = signingProperty("keyPassword", "OC_ANDROID_KEY_PASSWORD")
+            }
         }
     }
 
@@ -51,7 +120,10 @@ android {
             }
         }
         getByName("release") {
-            signingConfig = signingConfigs.getByName("debugRelease")
+            // The real release key when it is configured (see above), debug
+            // otherwise so a local release build still works without it.
+            signingConfig = signingConfigs.findByName("release")
+                ?: signingConfigs.getByName("debug")
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -74,9 +74,14 @@ val releaseVersionCode: Int? = releaseVersionName?.let { name ->
         it.toIntOrNull()
             ?: throw GradleException("OC_ANDROID_VERSION_NAME is not major.minor.patch: $name")
     }
-    if (minor > 99 || patch > 9999) {
+    // toIntOrNull accepts a leading minus, and the formula silently overflows
+    // Int somewhere above major 2147. Both produce a negative versionCode that
+    // Play rejects at upload, long after the build. The upper bound also keeps
+    // the result under Play's own ceiling of 2100000000.
+    if (major !in 0..2000 || minor !in 0..99 || patch !in 0..9999) {
         throw GradleException(
-            "Version $name overflows the versionCode formula (minor <= 99, patch <= 9999)")
+            "Version $name is out of range for the versionCode formula " +
+                "(major 0..2000, minor 0..99, patch 0..9999)")
     }
     major * 1_000_000 + minor * 10_000 + patch
 }
@@ -98,10 +103,21 @@ android {
     signingConfigs {
         if (releaseKeystore != null) {
             create("release") {
+                // Named up front rather than left null. A keystore.properties
+                // missing one line otherwise builds a signing config full of
+                // nulls and fails deep inside AGP, saying nothing about which
+                // property was absent. CI checks its secrets; this is the same
+                // guarantee for a local build.
+                fun required(name: String, env: String): String =
+                    signingProperty(name, env)
+                        ?: throw GradleException(
+                            "Signing is configured but '$name' is missing. Set it in " +
+                                "$keystoreDir/keystore.properties or pass $env.")
+
                 storeFile = releaseKeystore
-                storePassword = signingProperty("storePassword", "OC_ANDROID_KEYSTORE_PASSWORD")
-                keyAlias = signingProperty("keyAlias", "OC_ANDROID_KEY_ALIAS")
-                keyPassword = signingProperty("keyPassword", "OC_ANDROID_KEY_PASSWORD")
+                storePassword = required("storePassword", "OC_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = required("keyAlias", "OC_ANDROID_KEY_ALIAS")
+                keyPassword = required("keyPassword", "OC_ANDROID_KEY_PASSWORD")
             }
         }
     }

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -22,10 +22,12 @@ val tauriProperties = Properties().apply {
 // Reads gen/android/keystore.properties (gitignored - it holds the password),
 // overridable by OC_ANDROID_* env vars so CI can inject the key from secrets.
 //
-// The APK handed out from oc.app and the AAB uploaded to Play are signed with
-// the SAME key. Its SHA-256 must appear in frontend/app/assetlinks.json or the
-// installed app loses App Links AND passkeys (the statement claims
-// get_login_creds).
+// This key signs both artifacts, but only the APK still carries it once
+// installed: Play App Signing re-signs the AAB with a key Google holds, so a
+// Play install presents a DIFFERENT certificate. assetlinks.json therefore has
+// to list both fingerprints, this one for hand-installed APKs and Google's for
+// Play installs, or the affected channel loses App Links and, because the
+// statement claims get_login_creds, passkeys. See PLAY_STORE_RELEASE.md.
 //
 // No keystore at all falls back to debug signing, so a fresh clone can still
 // build a release locally. A keystore that is CONFIGURED but absent is a hard

--- a/frontend/src-tauri/gen/android/app/google-services.json
+++ b/frontend/src-tauri/gen/android/app/google-services.json
@@ -1,29 +1,48 @@
 {
-  "project_info": {
-    "project_number": "1054285567366",
-    "project_id": "dev-ivan-open-chat",
-    "storage_bucket": "dev-ivan-open-chat.firebasestorage.app"
-  },
-  "client": [
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:1054285567366:android:31c89679fc3f2bb6630807",
-        "android_client_info": {
-          "package_name": "com.oc.app"
-        }
-      },
-      "oauth_client": [],
-      "api_key": [
+    "project_info": {
+        "project_number": "1054285567366",
+        "project_id": "dev-ivan-open-chat",
+        "storage_bucket": "dev-ivan-open-chat.firebasestorage.app"
+    },
+    "client": [
         {
-          "current_key": "AIzaSyDTYAOHW4I8W2WSe7JkmbX8ZjIL5CyGbZY"
+            "client_info": {
+                "mobilesdk_app_id": "1:1054285567366:android:31c89679fc3f2bb6630807",
+                "android_client_info": {
+                    "package_name": "com.oc.app"
+                }
+            },
+            "oauth_client": [],
+            "api_key": [
+                {
+                    "current_key": "AIzaSyDTYAOHW4I8W2WSe7JkmbX8ZjIL5CyGbZY"
+                }
+            ],
+            "services": {
+                "appinvite_service": {
+                    "other_platform_oauth_client": []
+                }
+            }
+        },
+        {
+            "client_info": {
+                "mobilesdk_app_id": "1:1054285567366:android:05e19d20ea9a2669630807",
+                "android_client_info": {
+                    "package_name": "com.oclabs.openchat"
+                }
+            },
+            "oauth_client": [],
+            "api_key": [
+                {
+                    "current_key": "AIzaSyDTYAOHW4I8W2WSe7JkmbX8ZjIL5CyGbZY"
+                }
+            ],
+            "services": {
+                "appinvite_service": {
+                    "other_platform_oauth_client": []
+                }
+            }
         }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": []
-        }
-      }
-    }
-  ],
-  "configuration_version": "1"
+    ],
+    "configuration_version": "1"
 }

--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -100,7 +100,7 @@
         </provider>
 
         <service
-            android:name="com.oc.app.OpenChatNotificationService"
+            android:name="com.oclabs.openchat.OpenChatNotificationService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.oc.app
+package com.oclabs.openchat
 
 import android.content.Intent
 import android.os.Build

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/MyApplication.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/MyApplication.kt
@@ -1,4 +1,4 @@
-package com.oc.app
+package com.oclabs.openchat
 
 import android.app.Application
 import android.util.Log

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/NotificationDismissReceiver.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/NotificationDismissReceiver.kt
@@ -1,4 +1,4 @@
-package com.oc.app
+package com.oclabs.openchat
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/OpenChatNotificationService.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/com/oclabs/openchat/OpenChatNotificationService.kt
@@ -1,4 +1,4 @@
-package com.oc.app
+package com.oclabs.openchat
 
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService

--- a/frontend/src-tauri/gen/android/app/src/main/res/xml/shortcuts.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/res/xml/shortcuts.xml
@@ -5,8 +5,8 @@
         instances tagged with the SHARE_TARGET category will surface in the
         Direct Share row of the system share sheet.
     -->
-    <share-target android:targetClass="com.oc.app.MainActivity">
+    <share-target android:targetClass="com.oclabs.openchat.MainActivity">
         <data android:mimeType="*/*" />
-        <category android:name="com.oc.app.category.SHARE_TARGET" />
+        <category android:name="com.oclabs.openchat.category.SHARE_TARGET" />
     </share-target>
 </shortcuts>

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,42 +1,49 @@
 {
-    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-    "productName": "OpenChat",
-    "version": "0.1.0",
-    "identifier": "com.oc.app",
-    "build": {
-        "beforeDevCommand": "npm run dev:mobile",
-        "devUrl": "http://localhost:5001",
-        "beforeBuildCommand": "echo 'BUILDING ANDROID APK' && npm run android:release",
-        "frontendDist": "../app/build"
-    },
-    "app": {
-        "windows": [],
-        "security": {
-            "csp": null,
-            "assetProtocol": {
-                "enable": true,
-                "scope": ["**"]
-            }
-        }
-    },
-    "bundle": {
-        "active": true,
-        "targets": "all",
-        "iOS": {
-            "developmentTeam": "A468T66XSK",
-            "minimumSystemVersion": "16.0"
-        },
-        "icon": [
-            "icons/32x32.png",
-            "icons/128x128.png",
-            "icons/128x128@2x.png",
-            "icons/icon.icns",
-            "icons/icon.ico"
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "productName": "OpenChat",
+  "version": "0.1.0",
+  "identifier": "com.oclabs.openchat",
+  "build": {
+    "beforeDevCommand": "npm run dev:mobile",
+    "devUrl": "http://localhost:5001",
+    "beforeBuildCommand": "echo 'BUILDING ANDROID APK' && npm run android:release",
+    "frontendDist": "../app/build"
+  },
+  "app": {
+    "windows": [],
+    "security": {
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "**"
         ]
-    },
-    "plugins": {
-        "deep-link": {
-            "mobile": [{ "schema": "openchat", "host": "oc.app" }]
-        }
+      }
     }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "iOS": {
+      "developmentTeam": "A468T66XSK",
+      "minimumSystemVersion": "16.0"
+    },
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ]
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "schema": "openchat",
+          "host": "oc.app"
+        }
+      ]
+    }
+  }
 }

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,49 +1,42 @@
 {
-  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "OpenChat",
-  "version": "0.1.0",
-  "identifier": "com.oclabs.openchat",
-  "build": {
-    "beforeDevCommand": "npm run dev:mobile",
-    "devUrl": "http://localhost:5001",
-    "beforeBuildCommand": "echo 'BUILDING ANDROID APK' && npm run android:release",
-    "frontendDist": "../app/build"
-  },
-  "app": {
-    "windows": [],
-    "security": {
-      "csp": null,
-      "assetProtocol": {
-        "enable": true,
-        "scope": [
-          "**"
-        ]
-      }
-    }
-  },
-  "bundle": {
-    "active": true,
-    "targets": "all",
-    "iOS": {
-      "developmentTeam": "A468T66XSK",
-      "minimumSystemVersion": "16.0"
+    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+    "productName": "OpenChat",
+    "version": "0.1.0",
+    "identifier": "com.oclabs.openchat",
+    "build": {
+        "beforeDevCommand": "npm run dev:mobile",
+        "devUrl": "http://localhost:5001",
+        "beforeBuildCommand": "echo 'BUILDING ANDROID APK' && npm run android:release",
+        "frontendDist": "../app/build"
     },
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ]
-  },
-  "plugins": {
-    "deep-link": {
-      "mobile": [
-        {
-          "schema": "openchat",
-          "host": "oc.app"
+    "app": {
+        "windows": [],
+        "security": {
+            "csp": null,
+            "assetProtocol": {
+                "enable": true,
+                "scope": ["**"]
+            }
         }
-      ]
+    },
+    "bundle": {
+        "active": true,
+        "targets": "all",
+        "iOS": {
+            "developmentTeam": "A468T66XSK",
+            "minimumSystemVersion": "16.0"
+        },
+        "icon": [
+            "icons/32x32.png",
+            "icons/128x128.png",
+            "icons/128x128@2x.png",
+            "icons/icon.icns",
+            "icons/icon.ico"
+        ]
+    },
+    "plugins": {
+        "deep-link": {
+            "mobile": [{ "schema": "openchat", "host": "oc.app" }]
+        }
     }
-  }
 }

--- a/frontend/tauri-plugin-oc/OTA_UPDATES.md
+++ b/frontend/tauri-plugin-oc/OTA_UPDATES.md
@@ -30,10 +30,35 @@ air. The check is performed in the frontend before any download begins.
 
 The type is `OTAUpdateStrategy = "none" | "patch" | "minor" | "major"`.
 
-The idea is that a **major** version bump may require native code changes
-(new Kotlin commands, Rust API changes, etc.) that can't be delivered OTA. By
-setting the strategy to `"minor"` or `"patch"`, the app will refuse to OTA
-across a major boundary and instead wait for an APK update from the store.
+### What each level means
+
+The strategy only works if the version number is bumped deliberately, so the
+components carry fixed meanings. Note that `major` does NOT mean "big". It means
+**incompatible**: web code an already-installed shell cannot run.
+
+| Bump | Meaning | Store build | Sideloaded build |
+|------|---------|-------------|------------------|
+| patch | Bug fixes, copy, styling. Nothing a reviewer needs to see. | OTA | OTA |
+| minor | A new user-facing feature. Any existing shell can run it. | Play update | OTA |
+| major | Web code that requires shell changes: a new plugin command, a new Rust API, a new permission. Older shells cannot run this bundle. | Play update | New APK |
+
+So the store build ships with `OC_OTA_UPDATES=patch` and the sideloaded build
+with `minor`.
+
+Two consequences worth being explicit about.
+
+A shell change on its own bumps nothing. What forces a major bump is the web
+layer starting to DEPEND on a shell capability. Add a Kotlin command that no
+frontend code calls yet and every existing install is still fine.
+
+A one-line shell dependency is still a major bump, however small the diff. The
+size of the change is irrelevant; the question is only whether an installed
+shell can run the new bundle.
+
+Getting this wrong in the permissive direction means shipping a feature to store
+users without Play ever seeing it. Getting it wrong in the other direction means
+users sitting on a stale build waiting for a store update they don't need. The
+release-train skill asks about this at tag time rather than trusting memory.
 
 The strategy is evaluated by `Version.canUpdateTo(server, strategy)` in the
 frontend. The Rust side always downloads if `server > current` — the gating
@@ -62,7 +87,7 @@ The `VersionChecker` is only active when `OC_APP_TYPE === "android"` and
 │                                                         │
 │  update_manager.rs                                      │
 │    ├── get_server_version  → GET /version               │
-│    ├── get_bundled_version → reads "version" asset file │
+│    ├── get_shell_version   → reads "version" asset file │
 │    ├── get_cached_version  → reads version.json in cache│
 │    ├── check_for_updates   → compares & downloads       │
 │    └── download_and_install→ fetches zip, extracts      │
@@ -137,12 +162,13 @@ cached). The user must update via the Play Store to get across the boundary.
 
 | Source | Location | Notes |
 |--------|----------|-------|
-| **Bundled version** | `build/version` asset file | Written by rollup build from `OC_WEBSITE_VERSION` env var. Has `v` prefix (e.g. `v2.0.1973`), stripped when parsed. |
+| **Shell version** | `build/version` asset file | Written by rollup build from `OC_WEBSITE_VERSION` env var. Has `v` prefix (e.g. `v2.0.1973`), stripped when parsed. |
 | **Cached version** | `<app_data>/updates/version.json` | Written after successful OTA extraction. No `v` prefix. |
 | **Server version** | `https://oc.app/version` | JSON `{"version": "2.0.1975"}` |
 | **Client version (JS)** | `import.meta.env.OC_WEBSITE_VERSION` | Baked into JS at build time. After OTA, the cached JS has the updated value. |
 | **OTA strategy** | `import.meta.env.OC_OTA_UPDATES` | Build-time env var. One of `"none"`, `"patch"`, `"minor"`, `"major"`. |
-| **tauri.conf.json** | `"version": "0.1.0"` | **NOT used.** This is a stale placeholder. Do not rely on it. |
+| **Android versionName / versionCode** | APK/AAB manifest | Set by CI from `OC_ANDROID_VERSION_NAME` (the release tag version). versionCode is derived as `major*1000000 + minor*10000 + patch`. Equals the shell version above, since both come from the same tag. |
+| **tauri.conf.json** | `"version": "0.1.0"` | **NOT used** for any of the above. A stale placeholder. Do not rely on it. |
 
 ## Cache Directory Layout
 
@@ -201,14 +227,14 @@ Selected at compile time via the `store` cargo feature flag.
 ## Gotchas & Lessons Learned
 
 1. **`tauri.conf.json` version is stale.** It says `0.1.0` and is never updated.
-   Always read the bundled version from the `version` asset file.
+   Always read the shell version from the `version` asset file.
 
 2. **`Access-Control-Allow-Origin: *` breaks passkeys.** The Android Credential
    Manager rejects WebAuthn assertions when the origin header is a wildcard.
    Always use the specific origin `https://tauri.localhost`.
 
 3. **Stale cached files persist across installs of the same package.** If you're
-   testing OTA, clear app data (`adb shell pm clear com.oc.app`) to reset.
+   testing OTA, clear app data (`adb shell pm clear com.oclabs.openchat`) to reset.
    Uninstalling also clears the data.
 
 4. **The scheme handler cannot be `"oc"` or any other custom scheme.** Using a

--- a/frontend/tauri-plugin-oc/OTA_UPDATES.md
+++ b/frontend/tauri-plugin-oc/OTA_UPDATES.md
@@ -247,9 +247,14 @@ Selected at compile time via the `store` cargo feature flag.
    until the app restarts (which is the intended flow — the user is prompted to
    restart).
 
-6. **The frontend may call `download_update` more than once** due to the poller
-   timing. The Rust side is idempotent — if the server version matches the
-   cached version, it returns `false` without re-downloading.
+6. **`download_update` returning `false` is ambiguous.** It means both "the
+   download failed" and "nothing to do, the cache already matches the server",
+   and the frontend reads it as failure either way. That is why `VersionChecker`
+   stops polling once a download has completed and is waiting for a restart:
+   the running JS still reports the pre-download client version, so the next
+   tick would re-enter the download branch, reset the progress bar, get `false`
+   back, and turn a finished download into "update failed". Polling does resume
+   after a genuine failure, so a transient one retries.
 
 7. **`RestartApp.kt` does `exitProcess(0)`** followed by
    `startActivity(mainIntent)`. This fully kills the process so the `OnceLock`

--- a/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
+++ b/frontend/tauri-plugin-oc/android/src/main/java/Constants.kt
@@ -9,7 +9,7 @@ const val OC_TAG_NOT = "OC_TAG_NOT"
 // Category that links dynamic ShortcutInfoCompat instances to the
 // <share-target> declared in res/xml/shortcuts.xml. Shortcuts tagged
 // with this category appear in the Direct Share row of the share sheet.
-const val SHARE_TARGET_CATEGORY = "com.oc.app.category.SHARE_TARGET"
+const val SHARE_TARGET_CATEGORY = "com.oclabs.openchat.category.SHARE_TARGET"
 
 // All share-target shortcuts use this prefix on their ID, so we can
 // distinguish them from other dynamic shortcuts (e.g. notification
@@ -20,4 +20,4 @@ const val SHARE_SHORTCUT_ID_PREFIX = "share_"
 // via a Direct Share shortcut. We use a custom key (rather than
 // Intent.EXTRA_SHORTCUT_ID) because Android sets that to the shortcut's
 // own id (e.g. "share_<chatId>"), and we want the bare chat id.
-const val EXTRA_CHAT_ID = "com.oc.app.extra.CHAT_ID"
+const val EXTRA_CHAT_ID = "com.oclabs.openchat.extra.CHAT_ID"

--- a/frontend/tauri-plugin-oc/build.rs
+++ b/frontend/tauri-plugin-oc/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "release_notifications",
     "minimize_app",
     "get_server_version",
+    "get_shell_version",
     "download_update",
     "restart_app",
     "load_recent_media",

--- a/frontend/tauri-plugin-oc/guest-js/commands/getShellVersion.ts
+++ b/frontend/tauri-plugin-oc/guest-js/commands/getShellVersion.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core'
+
+// The version of the web assets compiled into the installed binary, i.e. the
+// version of the shell itself. Unlike window.OC_WEBSITE_VERSION this does not
+// change when an OTA update is applied, so the two together tell you which
+// native code is running underneath which web code.
+export async function getShellVersion(): Promise<string | undefined> {
+  return await invoke<string | null>('plugin:oc|get_shell_version').then((v) => v ?? undefined);
+}

--- a/frontend/tauri-plugin-oc/guest-js/index.ts
+++ b/frontend/tauri-plugin-oc/guest-js/index.ts
@@ -1,6 +1,7 @@
 export { clearAllNotifications } from "./commands/clearAllNotifications";
 export { deleteFcmToken } from "./commands/deleteFcmToken";
 export { getFcmToken } from "./commands/getFcmToken";
+export { getShellVersion } from "./commands/getShellVersion";
 export { minimizeApp } from "./commands/minimizeApp";
 export { openUrl } from "./commands/openUrl";
 export { releaseNotifications } from "./commands/releaseNotifications";

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/commands/get_shell_version.toml
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/commands/get_shell_version.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-shell-version"
+description = "Enables the get_shell_version command without any pre-configured scope."
+commands.allow = ["get_shell_version"]
+
+[[permission]]
+identifier = "deny-get-shell-version"
+description = "Denies the get_shell_version command without any pre-configured scope."
+commands.deny = ["get_shell_version"]

--- a/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
+++ b/frontend/tauri-plugin-oc/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@ Default permissions for the plugin
 - `allow-release-notifications`
 - `allow-minimize-app`
 - `allow-get-server-version`
+- `allow-get-shell-version`
 - `allow-download-update`
 - `allow-restart-app`
 - `allow-load-recent-media`
@@ -293,6 +294,32 @@ Enables the get_server_version command without any pre-configured scope.
 <td>
 
 Denies the get_server_version command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:allow-get-shell-version`
+
+</td>
+<td>
+
+Enables the get_shell_version command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`oc:deny-get-shell-version`
+
+</td>
+<td>
+
+Denies the get_shell_version command without any pre-configured scope.
 
 </td>
 </tr>

--- a/frontend/tauri-plugin-oc/permissions/default.toml
+++ b/frontend/tauri-plugin-oc/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-release-notifications",
     "allow-minimize-app",
     "allow-get-server-version",
+    "allow-get-shell-version",
     "allow-download-update",
     "allow-restart-app",
     "allow-load-recent-media",

--- a/frontend/tauri-plugin-oc/permissions/schemas/schema.json
+++ b/frontend/tauri-plugin-oc/permissions/schemas/schema.json
@@ -415,6 +415,18 @@
           "markdownDescription": "Denies the get_server_version command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_shell_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-shell-version",
+          "markdownDescription": "Enables the get_shell_version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_shell_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-shell-version",
+          "markdownDescription": "Denies the get_shell_version command without any pre-configured scope."
+        },
+        {
           "description": "Enables the load_recent_media command without any pre-configured scope.",
           "type": "string",
           "const": "allow-load-recent-media",
@@ -571,10 +583,10 @@
           "markdownDescription": "Denies the update_chat_shortcuts command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-export-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-get-shell-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-export-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-export-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-sign-in`\n- `allow-sign-up`\n- `allow-registerListener`\n- `allow-removeListener`\n- `allow-get-fcm-token`\n- `allow-show-notification`\n- `allow-svelte-ready`\n- `allow-release-notifications`\n- `allow-minimize-app`\n- `allow-get-server-version`\n- `allow-get-shell-version`\n- `allow-download-update`\n- `allow-restart-app`\n- `allow-load-recent-media`\n- `allow-enable-viewport-resize`\n- `allow-disable-viewport-resize`\n- `allow-save-media`\n- `allow-export-media`\n- `allow-update-chat-shortcuts`\n- `allow-get-pending-deep-link`\n- `allow-get-pending-notification-tap`\n- `allow-clear-all-notifications`\n- `allow-delete-fcm-token`"
         }
       ]
     }

--- a/frontend/tauri-plugin-oc/src/bundle_manager.rs
+++ b/frontend/tauri-plugin-oc/src/bundle_manager.rs
@@ -41,6 +41,10 @@ where
     // Lazily load cached assets into memory on first request
     let cache = memory_cache.get_or_init(|| {
         let um = update_manager::UpdateManager::new(handle.clone());
+        // Before anything is loaded: a cache left behind by a store update is
+        // older than the assets this binary ships with, and serving it would
+        // pin the webview to the previous release. See discard_cache_if_stale.
+        um.discard_cache_if_stale();
         um.get_cache_dir()
             .map(|dir| load_cache_into_memory(&dir))
             .unwrap_or_default()

--- a/frontend/tauri-plugin-oc/src/commands.rs
+++ b/frontend/tauri-plugin-oc/src/commands.rs
@@ -72,6 +72,14 @@ pub(crate) async fn load_recent_media<R: Runtime>(
 }
 
 #[command]
+pub(crate) async fn get_shell_version<R: Runtime>(
+    app: AppHandle<R>,
+) -> std::result::Result<Option<String>, String> {
+    let manager = update_manager::UpdateManager::new(app);
+    Ok(manager.get_shell_version().map(|v| v.to_string()))
+}
+
+#[command]
 pub(crate) async fn get_server_version<R: Runtime>(
     app: AppHandle<R>,
 ) -> std::result::Result<String, String> {

--- a/frontend/tauri-plugin-oc/src/lib.rs
+++ b/frontend/tauri-plugin-oc/src/lib.rs
@@ -50,6 +50,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         commands::minimize_app,
         commands::restart_app,
         commands::get_server_version,
+        commands::get_shell_version,
         commands::download_update,
         commands::load_recent_media,
         commands::enable_viewport_resize,

--- a/frontend/tauri-plugin-oc/src/update_manager.rs
+++ b/frontend/tauri-plugin-oc/src/update_manager.rs
@@ -61,6 +61,50 @@ impl<R: Runtime> UpdateManager<R> {
         None
     }
 
+    /// Delete the OTA cache when it is no longer newer than the shell.
+    ///
+    /// A Play or APK update replaces the binary but Android keeps app data, so
+    /// a cache written before the update survives it and can be OLDER than the
+    /// assets the new shell ships with. The scheme handler serves the cache
+    /// whenever version.json exists, without comparing, which pins the webview
+    /// to the stale bundle permanently:
+    ///
+    ///   shell 2.1.0 installed -> OTA to 2.1.1 -> website goes to 2.2.0 -> user
+    ///   updates from Play to shell 2.2.0 -> webview still serves 2.1.1.
+    ///
+    /// check_for_updates compares max(shell, cached) against the server and
+    /// sees nothing to do, while the running JS reports 2.1.1 and asks the user
+    /// to update again, forever. Across a major bump it is worse: the shell is
+    /// new enough but the JS believes it is not, so the blocking "update
+    /// required" sheet appears on a device that has already done everything
+    /// asked of it, and only clearing app data recovers.
+    ///
+    /// Equal counts as stale: the shell's own copy is authoritative, and
+    /// keeping a redundant cache only risks this again later.
+    pub fn discard_cache_if_stale(&self) {
+        // No shell version means no basis for comparison - keep the cache
+        // rather than discard something that might be the newer of the two.
+        let (Some(cached), Some(shell)) = (self.get_cached_version(), self.get_shell_version())
+        else {
+            return;
+        };
+
+        if cached > shell {
+            return;
+        }
+
+        if let Some(dir) = self.get_cache_dir()
+            && dir.exists()
+        {
+            match fs::remove_dir_all(&dir) {
+                Ok(()) => println!("Discarded OTA cache {cached} superseded by shell {shell}"),
+                // Failing to delete is survivable: the next launch tries again,
+                // and load_cache_into_memory is only reached through this call.
+                Err(e) => eprintln!("Failed to discard stale OTA cache: {e}"),
+            }
+        }
+    }
+
     /// The version of the web assets compiled into the installed binary, which
     /// is what identifies the shell itself. It never changes without a
     /// reinstall. Distinct from `get_cached_version`, which is the most recent

--- a/frontend/tauri-plugin-oc/src/update_manager.rs
+++ b/frontend/tauri-plugin-oc/src/update_manager.rs
@@ -71,13 +71,11 @@ impl<R: Runtime> UpdateManager<R> {
         {
             return Version::parse(info.version.trim_start_matches('v')).ok();
         }
-        // Fallback to package info
-        self.app_handle
-            .package_info()
-            .version
-            .to_string()
-            .parse()
-            .ok()
+        // No fallback to package_info(): that reads tauri.conf.json's version,
+        // a stale "0.1.0" placeholder unrelated to the shipped web assets. This
+        // value exists to tell a crash report which shell is running, and a
+        // confident wrong answer is worse than none.
+        None
     }
 
     pub async fn get_server_version(&self) -> Result<Version, Box<dyn std::error::Error>> {

--- a/frontend/tauri-plugin-oc/src/update_manager.rs
+++ b/frontend/tauri-plugin-oc/src/update_manager.rs
@@ -61,7 +61,11 @@ impl<R: Runtime> UpdateManager<R> {
         None
     }
 
-    pub fn get_bundled_version(&self) -> Option<Version> {
+    /// The version of the web assets compiled into the installed binary, which
+    /// is what identifies the shell itself. It never changes without a
+    /// reinstall. Distinct from `get_cached_version`, which is the most recent
+    /// bundle downloaded over the air.
+    pub fn get_shell_version(&self) -> Option<Version> {
         if let Some(asset) = self.app_handle.asset_resolver().get("version".to_string())
             && let Ok(info) = serde_json::from_slice::<ServerVersion>(&asset.bytes)
         {
@@ -87,17 +91,17 @@ impl<R: Runtime> UpdateManager<R> {
     pub async fn check_for_updates(&self) -> Result<bool, Box<dyn std::error::Error>> {
         let server_version = self.get_server_version().await?;
 
-        let bundled_version = self
-            .get_bundled_version()
+        let shell_version = self
+            .get_shell_version()
             .unwrap_or_else(|| Version::parse("0.0.0").unwrap());
         let cached_version = self
             .get_cached_version()
             .unwrap_or_else(|| Version::parse("0.0.0").unwrap());
 
-        let current_version = if cached_version > bundled_version {
+        let current_version = if cached_version > shell_version {
             cached_version.clone()
         } else {
-            bundled_version.clone()
+            shell_version.clone()
         };
 
         if server_version > current_version {


### PR DESCRIPTION
Renames the package, replaces debug signing with a real release key, makes CI produce a store-ready AAB, and gives the OTA version gate a meaning it did not previously have.

## Package name

`com.oc.app` → `com.oclabs.openchat`. `gen/android` is checked into git and hand-edited, so tauri does not regenerate it and every reference had to move by hand: `applicationId` and `namespace`, the Kotlin package directory and its four package declarations, the notification service class in the manifest, the share-target class and category, the plugin's category and extra-key constants, `google-services.json` and `assetlinks.json`.

`namespace` has to equal `applicationId` because `IntentsManager` resolves `"$packageName.MainActivity"` by reflection. The FileProvider authority is built from `${applicationId}` and follows on its own. iOS is unaffected, `tauri.ios.conf.json` overrides the identifier.

`google-services.json` is the real project-level file from Firebase (`dev-ivan-open-chat`) and carries clients for both the old and new package names, so push keeps working for existing sideloaded installs.

## Signing

Release builds were signed with `~/.android/debug.keystore`, whose password is the public string `android`. Play rejects debug certificates outright.

Gradle now reads `gen/android/keystore.properties` (gitignored) with `OC_ANDROID_*` environment overrides for CI. No keystore configured falls back to debug so a fresh clone still builds; a keystore configured but missing is a hard failure, because silently falling through to debug produces an artifact Play rejects and that no device will accept as an update over a real build.

`assetlinks.json` now claims two packages: `com.oc.app` keeps the old fingerprints so existing installs retain App Links and passkeys, and `com.oclabs.openchat` carries the new release key.

## CI

One APK (full, sideloaded) and one AAB (store) rather than two APKs, both signed with the same key. The keystore step fails when the secret is absent instead of generating a throwaway debug key, and an apksigner check fails the build if the APK ends up debug-signed. Only the APK is attached to the GitHub release; the AAB is a workflow artifact for manual upload to Play.

**New repository secrets required:** `ANDROID_UPLOAD_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`. Already set. The old `ANDROID_KEYSTORE_BASE64` is now unused and can be deleted once a build has run green.

## Versioning and the OTA gate

Every release so far has been `2.0.NNNN`, and the store build's `patch` strategy means same major and minor, so the gate has never blocked anything. A whole feature would have reached Play Store users over the air without review.

The version components now carry fixed meanings, with major meaning **incompatible** rather than big:

| Bump | Meaning | Store build | Sideloaded build |
|------|---------|-------------|------------------|
| patch | Bug fixes, copy, styling | OTA | OTA |
| minor | A feature; any installed shell can run it | Play update | OTA |
| major | Web code that needs a newer shell | Play update | New APK |

The sideloaded build moves from `major` to `minor` accordingly, which is what `OTA_UPDATES.md` already said it should be.

versionCode is derived from `OC_ANDROID_VERSION_NAME` as `major*1000000 + minor*10000 + patch` so it stays monotonic across a minor bump. Taking the patch component alone would send 2051 → 0 on `2.1.0` and Play would reject the upload. Tauri's own formula caps patch at 999 and cannot express an OpenChat version at all, which is why every APK so far has shipped as versionCode 1000.

The website version also leaves the globally-sequential canister numbering, since its bump level is now a decision rather than the next free number.

## Telling the user they are stuck

A blocked update left `VersionChecker` reporting `up_to_date`, which is a lie, and the `out_of_date` state's `compatible` flag was only ever set `true`. There are now two states. A major bump gives `incompatible`, a blocking sheet, safe only because the runbook requires the store update live before the website announces a major. A minor bump on a store build gives `store_update_available`, a dismissible sheet, because the app works fine and the Play listing may show nothing for days. Both keep polling so a rolled-back release recovers in session, and the dismissal is persisted in localStorage keyed by version.

`get_bundled_version` is renamed `get_shell_version`, since it sits next to `get_cached_version` which does mean the most recent bundle. It is exposed as a plugin command so About can show the shell version alongside the running web version, which after an OTA are not the same thing.

The release-train skill now asks for the website bump level at tag time and documents the ordering a major bump requires: canisters live, then Play approval and rollout, then the APK, then the website.

## Verification

- `gradlew signingReport` confirms `universalRelease` uses `Config: release` with SHA-256 matching `assetlinks.json`
- Merged manifest checked for all four version cases: unset → 1000/0.1.0, `2.0.2051` → 2002051, `2.1.0` → 2010000, `3.0.0` → 3000000; malformed input fails loudly
- `processUniversalReleaseGoogleServices` emits the new `google_app_id`
- `svelte-check` 0 errors, plugin `cargo build` clean

Not yet exercised end to end. A `workflow_dispatch` run is the next step, which tests the new secrets, the AAB build and the apksigner check.

## Still outstanding

After the first Play upload, Google's app signing key SHA-256 has to be added to `com.oclabs.openchat` in `assetlinks.json` and the website deployed, otherwise Play-installed builds get no App Links and no passkeys.

iOS has no OTA and `VersionChecker` is still gated on `isAndroidTauriApp()`, so the incompatible state cannot arise there. The App Store URL needs adding when that app exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA
