### PR TITLE
Add the Play app signing key to assetlinks

### DIFF
--- a/frontend/app/assetlinks.json
+++ b/frontend/app/assetlinks.json
@@ -8,7 +8,8 @@
             "namespace": "android_app",
             "package_name": "com.oclabs.openchat",
             "sha256_cert_fingerprints": [
-                "00:F4:D0:31:0A:9F:DC:36:0C:12:5A:1B:BF:F1:70:45:CF:11:A2:BA:44:0E:F8:C8:54:ED:70:9D:2D:44:51:7E"
+                "00:F4:D0:31:0A:9F:DC:36:0C:12:5A:1B:BF:F1:70:45:CF:11:A2:BA:44:0E:F8:C8:54:ED:70:9D:2D:44:51:7E",
+                "9E:58:CB:EF:52:0F:9C:00:1C:7B:87:AE:2E:0B:D4:99:A6:4A:8B:B1:85:FA:13:D0:78:09:70:7A:E0:48:AE:D0"
             ]
         }
     },


### PR DESCRIPTION
Play App Signing re-signs every download with a key Google holds, so an install from the Play Store presents a different certificate than the APK we distribute ourselves. Until both are claimed, one of the two channels has no App Links and, because the statement also claims `get_login_creds`, no passkeys.

Read from Play Console → Protected with Play → Play Store protection → Protect app signing key → Manage Play app signing, after the first bundle upload. That page's **Upload key certificate** row reads `00:F4:D0:...:51:7E`, matching our own keystore, which is what identifies the other fingerprint as Google's rather than ours.

| Fingerprint | Covers |
|---|---|
| `00:F4:D0:…:51:7E` | the APK distributed from GitHub releases |
| `9E:58:CB:…:AE:D0` | installs from the Play Store |

Both are needed; neither replaces the other. `com.oc.app` keeps its own entry with the old fingerprints so pre-rename sideloads are unaffected.

**This must be deployed before anything carrying `com.oclabs.openchat` reaches a user**, the hand-distributed APK included. See `frontend/src-tauri/PLAY_STORE_RELEASE.md`.

After deploying, verify on a device installed from the internal testing track that deep links open in the app and passkey sign-in completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA