### PR TITLE
Set the sideloaded OTA strategy where it actually takes effect

### DIFF
--- a/frontend/app/rollup-plugin-android-bundle.mjs
+++ b/frontend/app/rollup-plugin-android-bundle.mjs
@@ -97,7 +97,17 @@ async function writeBundleZip(
     version,
     store,
 ) {
-    const ota = store ? "patch" : "major";
+    // This is the authoritative OTA strategy for anything delivered over the air.
+    // The value compiled into a shell is only a default: `override` in
+    // rollup.config.mjs emits `(window.OC_CONFIG?.KEY ?? <compiled>)`, and this
+    // injection sets window.OC_CONFIG, so the zip wins from the first update
+    // onwards. Changing OC_OTA_UPDATES in the Android workflow alone has no
+    // effect past a client's first OTA.
+    //
+    // "minor" for the sideloaded channel, not "major": major marks a bundle an
+    // installed shell cannot run, and taking one over the air is exactly the
+    // failure this gate exists to prevent. See tauri-plugin-oc/OTA_UPDATES.md.
+    const ota = store ? "patch" : "minor";
     const zipFile = store
         ? path.join(downloadDir, `store-${version}.zip`)
         : path.join(downloadDir, `full-${version}.zip`);

--- a/frontend/tauri-plugin-oc/OTA_UPDATES.md
+++ b/frontend/tauri-plugin-oc/OTA_UPDATES.md
@@ -45,6 +45,15 @@ components carry fixed meanings. Note that `major` does NOT mean "big". It means
 So the store build ships with `OC_OTA_UPDATES=patch` and the sideloaded build
 with `minor`.
 
+**Where that value actually comes from.** `override` in `rollup.config.mjs` compiles
+`import.meta.env.OC_OTA_UPDATES` to `(window.OC_CONFIG?.OC_OTA_UPDATES ?? "<build-time value>")`,
+and `rollup-plugin-android-bundle.mjs` injects `window.OC_CONFIG` into the `index.html`
+inside each OTA zip. So the build-time value only governs a shell's own bundled assets,
+i.e. a fresh install; from a client's first over-the-air update onwards the zip's value
+wins. The two must agree, and the zip is the one that matters. The plugin skips this
+injection entirely when `OC_APP_TYPE` is `android` or `ios`, which is why an APK build
+keeps its compiled value.
+
 Two consequences worth being explicit about.
 
 A shell change on its own bumps nothing. What forces a major bump is the web


### PR DESCRIPTION
Found while verifying the 2.0.2052 prod deploy.

The `full-` and `store-` OTA zips are byte-identical across all 553 asset files. Only `index.html` differs:

```
full :  window.OC_CONFIG={OC_MOBILE_LAYOUT:"v2", OC_APP_STORE: "false", OC_OTA_UPDATES: "major"}
store:  window.OC_CONFIG={OC_MOBILE_LAYOUT:"v2", OC_APP_STORE: "true",  OC_OTA_UPDATES: "patch"}
```

`override` in `rollup.config.mjs:70` compiles `import.meta.env.OC_OTA_UPDATES` to `(window.OC_CONFIG?.OC_OTA_UPDATES ?? "<build-time value>")`. **The injection wins.**

## What that means

#9297 set `OC_OTA_UPDATES: 'minor'` for the full build in `android_release.yaml`. The bundle plugin skips injection when `OC_APP_TYPE=android`, so an APK keeps its compiled value — correct on a fresh install. But from the first over-the-air update onwards the zip's `index.html` takes over and the strategy silently reverts to `major`.

So the protection #9297 was meant to add does not survive a client's first OTA.

Nothing is visibly broken today, because no major version has ever been published. It would have failed at precisely the moment it was designed for: a sideloaded client pulling in a bundle its shell cannot run, which is the same failure mode documented for orphaned `com.oc.app` installs.

## Change

`const ota = store ? "patch" : "minor"` in `rollup-plugin-android-bundle.mjs`, plus a note in `OTA_UPDATES.md` recording the precedence — the compiled value reads like the source of truth and isn't, which is how I got this wrong in the first place.

The store channel already agreed (`patch` both places); only the sideloaded channel disagreed.

## Timing

Takes effect on the next website release, since that is what builds the zips. Not urgent — it only matters at the first major bump — but it should be in well before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA