### PR TITLE
Drop the unused Firebase Analytics dependency

### DIFF
--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -184,6 +184,12 @@ dependencies {
     implementation("com.google.android.material:material:1.13.0")
 
     // Firebase
+    //
+    // Analytics is deliberately absent. Nothing in the app ever called it, but declaring the
+    // dependency merged AD_ID, ACCESS_ADSERVICES_AD_ID, ACCESS_ADSERVICES_ATTRIBUTION and
+    // BIND_GET_INSTALL_REFERRER_SERVICE into the manifest, which Play reads as the app
+    // declaring use of the advertising ID. Do not add it back without deciding what that
+    // means for the data safety declaration. Messaging does not depend on it.
     implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
     implementation("com.google.firebase:firebase-messaging")
     implementation("com.google.firebase:firebase-common") 

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -185,7 +185,6 @@ dependencies {
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
-    implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-messaging")
     implementation("com.google.firebase:firebase-common") 
     


### PR DESCRIPTION
Play flagged the app as declaring use of the advertising ID:

> Your manifest file includes the com.google.android.gms.permission.AD_ID permission. This means that your app declares the use of advertising ID.

The permission was never ours. Nothing in the Kotlin has ever called Firebase Analytics, but declaring the dependency merged four permissions into the manifest:

```
com.google.android.gms.permission.AD_ID
android.permission.ACCESS_ADSERVICES_AD_ID
android.permission.ACCESS_ADSERVICES_ATTRIBUTION
com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE
```

Removing the dependency beats the two alternatives. Answering "yes" would declare a data collection that does not happen. Stripping the permission with `tools:node="remove"` would leave an unused analytics SDK in the binary that still has to be accounted for on the data safety form.

## Verified

Re-ran the manifest merge with the dependency removed. All four permissions are gone. Messaging is untouched:

```
com.google.firebase.provider.FirebaseInitProvider
com.google.firebase.messaging.FirebaseMessagingService
com.google.firebase.MESSAGING_EVENT
com.oclabs.openchat.OpenChatNotificationService
com.google.android.c2dm.permission.RECEIVE
```

No measurement or analytics components survive the merge. FCM does not depend on Analytics.

Remaining permissions after the change are all ones we actually use: INTERNET, CAMERA, RECORD_AUDIO, MODIFY_AUDIO_SETTINGS, READ_MEDIA_*, READ_EXTERNAL_STORAGE (maxSdkVersion 32), RECEIVE_BOOT_COMPLETED, WAKE_LOCK, POST_NOTIFICATIONS, USE_BIOMETRIC, USE_FINGERPRINT, ACCESS_NETWORK_STATE, c2dm RECEIVE.

## Note

This needs a new Android build to take effect, so the bundle currently on the internal testing track still carries AD_ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA