### PR TITLE
Document how a shell-only Android release gets a version number

### DIFF
--- a/.claude/skills/release-train/SKILL.md
+++ b/.claude/skills/release-train/SKILL.md
@@ -37,6 +37,13 @@ description: OpenChat release train runbook — tagging components, prod-test (i
 
    Full detail in `frontend/tauri-plugin-oc/OTA_UPDATES.md`.
 
+3b. **Android and website versions share one sequence, but not one release.** The Android `versionName` is the version of the web assets the shell bundles, and `versionCode` is derived from it (`major*1000000 + minor*10000 + patch`), so an Android build always consumes a number.
+
+   A **shell-only release** — native dependency removed, permission dropped, Kotlin fix nothing calls yet — is a **patch**, because no web code behaves differently and there is no compatibility signal to send. Tag `v2.0.NNNN-android` with no matching `-website` tag, and the website's next release takes NNNN+1. Website versions do not have to be contiguous.
+
+   **The trap:** never let a website release reuse a number an Android build has claimed. Apps bundling that version see `server == client` and silently refuse a genuine update, permanently. Before picking a website number, check the android tags too:
+   `git tag --list "v2.0.*-android" | sort -t. -k3 -n | tail -3`
+
 4. Release order is dependency-driven, decided per train. Rule of thumb: a canister must accept a new candid field before anything starts sending it (e.g. video transcode train: storage_bucket → storage_index → website). Website last.
 5. Pushing a tag triggers CI to build and upload wasms to S3 keyed by COMMIT id (`https://openchat-canister-wasms.s3.amazonaws.com/<commit>/<canister>.wasm.gz`). The prod proposal route downloads from there — confirm the CI run finished before prod release.
 

--- a/frontend/tauri-plugin-oc/OTA_UPDATES.md
+++ b/frontend/tauri-plugin-oc/OTA_UPDATES.md
@@ -64,6 +64,36 @@ A one-line shell dependency is still a major bump, however small the diff. The
 size of the change is irrelevant; the question is only whether an installed
 shell can run the new bundle.
 
+### Shell-only releases
+
+A release that changes only native code — a dependency removed, a permission
+dropped, a Kotlin fix nothing calls yet — is a **patch**. There is no
+compatibility signal to send, because no web code behaves differently.
+
+That leaves a practical problem: `versionCode` is derived from the version name,
+which is the website's version, so a shell-only release has no number of its own.
+It cannot reuse the last one, since Play requires `versionCode` to increase, and
+there is no reason to cut a website release just to move a number.
+
+**Take the next number in the sequence and let the website skip it.** Tag
+`v2.0.NNNN-android` with no matching `-website` tag; the website's next release
+takes NNNN+1. Website versions are their own line and do not have to be
+contiguous, exactly like the canister sequence.
+
+The app then bundles assets labelled NNNN while the server still serves NNNN-1.
+`isGreaterThan` is false, so `VersionChecker` reports up to date and does nothing
+until the website passes it.
+
+> **Never let a website release reuse a number an Android build has claimed.**
+> Every app bundling that version would see `server == client` and silently
+> refuse a genuine update, permanently. An Android release consumes a number from
+> the shared sequence whether or not a website release accompanies it.
+
+One consequence worth knowing: tagging master head means the APK bundles whatever
+frontend code has landed since the last website release, so a shell-only build can
+ship web code the website has not served yet. That is normal and resolves at the
+next website deploy.
+
 Getting this wrong in the permissive direction means shipping a feature to store
 users without Play ever seeing it. Getting it wrong in the other direction means
 users sitting on a stale build waiting for a store update they don't need. The


### PR DESCRIPTION
Second gap in the versioning scheme found in use rather than in design. The first was that the OTA strategy lives in the zip rather than the shell (#9301). This one surfaced while deciding how to version #9302, which removes an unused native dependency and changes no web code at all.

## The bump level

A shell-only change is a **patch**. `major` means a bundle an installed shell cannot run, and a native change nothing depends on is invisible to every line of web code, so there is no compatibility signal to send. The instinct to call it major is understandable and wrong — `OTA_UPDATES.md` already said "a shell change on its own bumps nothing", it just never said what to do instead.

## The actual problem

`versionCode` is derived from `versionName`, which is the website's version, so a shell-only release has no number of its own. It cannot reuse the last one, since Play requires `versionCode` to increase, and cutting a website release purely to move a number is silly.

**Take the next number in the sequence and let the website skip it.** Tag `v2.0.NNNN-android` with no matching `-website` tag; the website's next release takes NNNN+1. Website versions are their own line and need not be contiguous, exactly like the canister sequence.

The app then bundles assets labelled NNNN while the server still serves NNNN-1, so `isGreaterThan` is false and `VersionChecker` sits quiet until the website passes it.

## The trap

Never let a website release reuse a number an Android build has claimed. Every app bundling that version would see `server == client` and silently refuse a genuine update, permanently — the same shape as the empty-chat bug, but with no recovery. The release-train skill now says to check the android tags before choosing a website number:

```
git tag --list "v2.0.*-android" | sort -t. -k3 -n | tail -3
```

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA