### PR TITLE
Remove the shop from the landing page menus

### DIFF
--- a/frontend/app/src/components/landingpages/MenuItems.svelte
+++ b/frontend/app/src/components/landingpages/MenuItems.svelte
@@ -16,11 +16,6 @@
 <div class="menu-items">
     <div class="nav">
         <div class="menu-item">
-            <a href={"https://openchat.myspreadshop.com"} target="_blank" rel="noreferrer">
-                Shop
-            </a>
-        </div>
-        <div class="menu-item">
             <Link selected={$locationStore === "/features"} mode={"menu"} path="features"
                 >Features</Link
             >

--- a/frontend/app/src/components/landingpages/MobileMenuItems.svelte
+++ b/frontend/app/src/components/landingpages/MobileMenuItems.svelte
@@ -17,7 +17,6 @@
     import Blog from "svelte-material-icons/PostOutline.svelte";
     import Road from "svelte-material-icons/RoadVariant.svelte";
     import Security from "svelte-material-icons/Security.svelte";
-    import Shopping from "svelte-material-icons/ShoppingOutline.svelte";
     import Menu from "../Menu.svelte";
     import MenuItem from "../MenuItem.svelte";
 
@@ -39,21 +38,6 @@
 </script>
 
 <Menu>
-    <MenuItem>
-        {#snippet icon()}
-            <Shopping size={$iconSize} color={"var(--icon-inverted-txt)"} />
-        {/snippet}
-        {#snippet text()}
-            <a
-                class="link"
-                href={"https://openchat.myspreadshop.com"}
-                target="_blank"
-                rel="noreferrer"
-            >
-                Shop
-            </a>
-        {/snippet}
-    </MenuItem>
     <MenuItem selected={$locationStore === "/features"} onclick={() => navigate("/features")}>
         {#snippet icon()}
             <InformationOutline size={$iconSize} color={"var(--icon-inverted-txt)"} />


### PR DESCRIPTION
Nobody has ever bought anything from it, so it is a nav slot spent on noise.

Removed from both `MenuItems.svelte` (desktop) and `MobileMenuItems.svelte` (mobile menu), along with the now-unused `ShoppingOutline` icon import. No references to `myspreadshop.com` remain anywhere in the frontend.

The shop itself is untouched — this only stops linking to it, so any existing link still works.

`svelte-check` clean. The summary warning count shifts by two because dropping the icon import changes which files get compiled; the per-file warning set is byte-identical before and after, and errors stay at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA