### PR TITLE
Bind ICPSwap's withdrawToSubaccount

### DIFF
--- a/backend/external_canisters/icpswap_swap_pool/api/src/updates/mod.rs
+++ b/backend/external_canisters/icpswap_swap_pool/api/src/updates/mod.rs
@@ -1,3 +1,4 @@
 pub mod deposit;
 pub mod swap;
 pub mod withdraw;
+pub mod withdraw_to_subaccount;

--- a/backend/external_canisters/icpswap_swap_pool/api/src/updates/withdraw_to_subaccount.rs
+++ b/backend/external_canisters/icpswap_swap_pool/api/src/updates/withdraw_to_subaccount.rs
@@ -1,0 +1,15 @@
+use crate::ICPSwapResult;
+use candid::{CandidType, Nat};
+use serde::Deserialize;
+
+// Like `withdraw`, but the pool transfers to the given subaccount of the caller rather than to
+// the caller's default account.
+#[derive(CandidType, Deserialize)]
+pub struct Args {
+    pub token: String,
+    pub amount: Nat,
+    pub fee: Nat,
+    pub subaccount: Vec<u8>,
+}
+
+pub type Response = ICPSwapResult<Nat>;

--- a/backend/external_canisters/icpswap_swap_pool/c2c_client/src/lib.rs
+++ b/backend/external_canisters/icpswap_swap_pool/c2c_client/src/lib.rs
@@ -8,3 +8,4 @@ generate_candid_c2c_call!(quote);
 generate_candid_c2c_call!(deposit);
 generate_candid_c2c_call!(swap);
 generate_candid_c2c_call!(withdraw);
+generate_candid_c2c_call!(withdraw_to_subaccount, withdrawToSubaccount);


### PR DESCRIPTION
Item 3 of the multi-user canister prep: once a canister holds many users, each user's wallet is a subaccount of it, so swap output must land in that subaccount rather than the canister's default account.

## Changes
- **ICPSwap pool binding**: adds `withdrawToSubaccount` (`{ token, amount, fee, subaccount }`, transfers to `{ owner = caller, subaccount }`). It is present in `icpswap-v3-service` main but not in the public docs.

The single-user canister is untouched. Its wallet is its default account, so it keeps calling plain `withdraw`, and the swap input side keeps `from_subaccount: None`.

## Deferred to the multi-user canister
- Using the new binding on the withdraw path (including the platform-operator recovery endpoint) and spending swap input from the user's subaccount.
- Taco has no receiver option; its output lands in the canister's default account and needs a sweep into the user's subaccount.
- `withdrawToSubaccount` should be confirmed live on the mainnet pools before it is first called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
