### PR TITLE
Accept ICRC-1 textual accounts when saving a crypto recipient

### DIFF
--- a/backend/canisters/user/impl/src/updates/save_crypto_account.rs
+++ b/backend/canisters/user/impl/src/updates/save_crypto_account.rs
@@ -3,8 +3,9 @@ use crate::{RuntimeState, execute_update};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use ic_ledger_types::AccountIdentifier;
-use ic_principal::Principal;
+use icrc_ledger_types::icrc1::account::Account;
 use oc_error_codes::OCErrorCode;
+use std::str::FromStr;
 use types::OCResult;
 use user_canister::save_crypto_account::*;
 
@@ -21,9 +22,7 @@ fn save_crypto_account_impl(mut args: Args, state: &mut RuntimeState) -> OCResul
     args.name.truncate(25);
     args.account = args.account.trim().to_string();
 
-    let valid = Principal::from_text(&args.account).is_ok() || AccountIdentifier::from_hex(&args.account).is_ok();
-
-    if valid {
+    if is_valid_account(&args.account) {
         let name_lowercase = args.name.to_lowercase();
         for named_account in state.data.saved_crypto_accounts.iter_mut() {
             if named_account.account == args.account {
@@ -38,5 +37,43 @@ fn save_crypto_account_impl(mut args: Args, state: &mut RuntimeState) -> OCResul
         Ok(())
     } else {
         Err(OCErrorCode::InvalidRequest.into())
+    }
+}
+
+// Either an ICRC-1 textual account, which covers a bare principal as well as an account with a
+// subaccount such as another user's wallet, or an ICP ledger account identifier.
+fn is_valid_account(text: &str) -> bool {
+    Account::from_str(text).is_ok() || AccountIdentifier::from_hex(text).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use types::UserId;
+
+    #[test]
+    fn principal_is_valid() {
+        assert!(is_valid_account("2vxsx-fae"));
+    }
+
+    #[test]
+    fn icrc1_account_with_subaccount_is_valid() {
+        let canister_id = Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 1, 1]);
+        let account = Account::from(UserId::new_indexed(canister_id, 7));
+        assert!(account.subaccount.is_some());
+        assert!(is_valid_account(&account.to_string()));
+    }
+
+    #[test]
+    fn account_identifier_is_valid() {
+        let account_identifier = AccountIdentifier::new(&Principal::anonymous(), &ic_ledger_types::DEFAULT_SUBACCOUNT);
+        assert!(is_valid_account(&account_identifier.to_hex()));
+    }
+
+    #[test]
+    fn garbage_is_invalid() {
+        assert!(!is_valid_account("not an account"));
+        assert!(!is_valid_account("2vxsx-fae.zz"));
     }
 }


### PR DESCRIPTION
`save_crypto_account` only accepted a bare principal or a 64-hex ICP account identifier, so an ICRC-1 textual account with a subaccount (e.g. `owner-checksum.subaccount`) was rejected. Once a canister holds many users, each user's wallet is such an account. The frontend send flow already accepts these addresses, so a user could send to one but not save it as a named recipient.

## Changes
- Validation now parses the ICRC-1 textual form via `icrc_ledger_types::Account::from_str`, which also covers a bare principal, alongside the existing account identifier check.
- Extracted `is_valid_account` with unit tests for a principal, an indexed user's account, an account identifier, and garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
