### PR TITLE
Log out on session expiry, fix three crashes, filter clock-skew noise

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -170,6 +170,7 @@
             subscribe("hangup", hangup),
             subscribe("askToSpeak", askToSpeak),
             subscribe("userLoggedIn", onUserLoggedIn),
+            subscribe("sessionExpired", () => client.logout()),
         ];
         window.addEventListener("orientationchange", calculateHeight);
         window.addEventListener("unhandledrejection", unhandledError);

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -639,7 +639,12 @@
             return;
         }
         recordError("window", err);
-        logger?.error("Unhandled error: ", err);
+        // Deliberately not reported here. Rollbar's own captureUncaught /
+        // captureUnhandledRejections already reports every event this handler sees, and
+        // installs earlier than this listener, so logging again produced two Rollbar items
+        // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
+        // every defect in two and doubling the volume. This handler keeps the crash-log
+        // record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             client.logout();
             ev.preventDefault();

--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -643,8 +643,10 @@
         // captureUnhandledRejections already reports every event this handler sees, and
         // installs earlier than this listener, so logging again produced two Rollbar items
         // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
-        // every defect in two and doubling the volume. This handler keeps the crash-log
-        // record and the logout, which Rollbar's capture does not do.
+        // every defect in two and doubling the volume. Its `checkIgnore` reads the rejection
+        // reason out of the original arguments, so worker errors - which arrive as plain
+        // objects, not Errors - are still filtered on name and code. This handler keeps the
+        // crash-log record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             client.logout();
             ev.preventDefault();

--- a/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
@@ -66,19 +66,29 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0)!);
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1)!);
-    let symbol0 = $derived(tokenDetails0.symbol);
-    let symbol1 = $derived(tokenDetails1.symbol);
-    let transferFees = $derived(BigInt(2) * tokenDetails1.transferFee);
+    // Either side of the swap can name a ledger the registry does not carry. Asserting it did
+    // crashed this modal open; without decimals and a fee we also cannot state the amounts or
+    // let the swap be accepted, so treat it as an unacceptable swap.
+    let tokenDetails0 = $derived($cryptoLookup.get(ledger0));
+    let tokenDetails1 = $derived($cryptoLookup.get(ledger1));
+    let unknownToken = $derived(tokenDetails0 === undefined || tokenDetails1 === undefined);
+    let symbol0 = $derived(tokenDetails0?.symbol ?? "");
+    let symbol1 = $derived(tokenDetails1?.symbol ?? "");
+    let transferFees = $derived(BigInt(2) * (tokenDetails1?.transferFee ?? 0n));
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
-    let valid = $derived(error === undefined && !insufficient);
-    let amount0Text = $derived(client.formatTokens(amount0, tokenDetails0.decimals));
-    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, tokenDetails1.decimals));
+    let valid = $derived(error === undefined && !insufficient && !unknownToken);
+    let amount0Text = $derived(
+        tokenDetails0 === undefined ? "?????" : client.formatTokens(amount0, tokenDetails0.decimals),
+    );
+    let amount1Text = $derived(
+        tokenDetails1 === undefined
+            ? "?????"
+            : client.formatTokens(amount1 + transferFees, tokenDetails1.decimals),
+    );
 </script>
 
 <Overlay dismissible>

--- a/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
-    import type { OpenChat, SignerWallet } from "@client";
-    import {
-        cryptoBalanceStore,
-        enhancedCryptoLookup as cryptoLookup,
-        mobileWidth,
-    } from "@client";
+    import type { OpenChat, SignerWallet, TokenInfo } from "@client";
+    import { cryptoBalanceStore, mobileWidth } from "@client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
     import Button from "../Button.svelte";
@@ -20,8 +16,8 @@
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        ledger0: string;
-        ledger1: string;
+        token0: TokenInfo;
+        token1: TokenInfo;
         amount0: bigint;
         amount1: bigint;
         onClose: () => void;
@@ -30,7 +26,8 @@
         onAccept: (fromAccount?: string) => void;
     }
 
-    let { ledger0, ledger1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let { token0, token1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let ledger1 = $derived(token1.ledger);
 
     let refreshing = false;
     let error: string | undefined = undefined;
@@ -66,29 +63,21 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    // Either side of the swap can name a ledger the registry does not carry. Asserting it did
-    // crashed this modal open; without decimals and a fee we also cannot state the amounts or
-    // let the swap be accepted, so treat it as an unacceptable swap.
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0));
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1));
-    let unknownToken = $derived(tokenDetails0 === undefined || tokenDetails1 === undefined);
-    let symbol0 = $derived(tokenDetails0?.symbol ?? "");
-    let symbol1 = $derived(tokenDetails1?.symbol ?? "");
-    let transferFees = $derived(BigInt(2) * (tokenDetails1?.transferFee ?? 0n));
+    // Symbol, decimals and fee come from the swap message itself, not the registry: the
+    // message carries the TokenInfo the canister charges from (it debits token1.fee from the
+    // content), so this cannot drift from the real charge and cannot meet a ledger the registry
+    // has never heard of.
+    let symbol0 = $derived(token0.symbol);
+    let symbol1 = $derived(token1.symbol);
+    let transferFees = $derived(BigInt(2) * token1.fee);
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
-    let valid = $derived(error === undefined && !insufficient && !unknownToken);
-    let amount0Text = $derived(
-        tokenDetails0 === undefined ? "?????" : client.formatTokens(amount0, tokenDetails0.decimals),
-    );
-    let amount1Text = $derived(
-        tokenDetails1 === undefined
-            ? "?????"
-            : client.formatTokens(amount1 + transferFees, tokenDetails1.decimals),
-    );
+    let valid = $derived(error === undefined && !insufficient);
+    let amount0Text = $derived(client.formatTokens(amount0, token0.decimals));
+    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, token1.decimals));
 </script>
 
 <Overlay dismissible>

--- a/frontend/app/src/components/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components/home/BalanceWithRefresh.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { OpenChat, ResourceKey } from "@client";
+    import type { EnhancedTokenDetails, OpenChat, ResourceKey } from "@client";
     import { enhancedCryptoLookup as cryptoLookup } from "@client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
@@ -66,7 +66,7 @@
         toppingUp = !toppingUp;
     }
 
-    function convertValue(c: Exclude<typeof conversion, "none">, t: typeof tokenDetails): string {
+    function convertValue(c: Exclude<typeof conversion, "none">, t: EnhancedTokenDetails): string {
         switch (c) {
             case "usd":
                 return t.dollarBalance?.toFixed(2) ?? "???";
@@ -78,14 +78,18 @@
                 return t.ethBalance?.toFixed(6) ?? "???";
         }
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // An unrecognised ledger has no decimals we can trust, so a formatted figure would be
+    // wrong rather than missing. Show it as unknown instead.
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let formattedValue = $derived(
-        hideBalance
-            ? "*****"
-            : conversion === "none"
-              ? client.formatTokens(value, tokenDetails.decimals)
-              : convertValue(conversion, tokenDetails),
+        tokenDetails === undefined
+            ? "?????"
+            : hideBalance
+              ? "*****"
+              : conversion === "none"
+                ? client.formatTokens(value, tokenDetails.decimals)
+                : convertValue(conversion, tokenDetails),
     );
     $effect(() => {
         if (ledger) {

--- a/frontend/app/src/components/home/P2PSwapContent.svelte
+++ b/frontend/app/src/components/home/P2PSwapContent.svelte
@@ -251,8 +251,8 @@
             action={cancel} />
     {:else}
         <AcceptP2PSwapModal
-            ledger0={content.token0.ledger}
-            ledger1={content.token1.ledger}
+            token0={content.token0}
+            token1={content.token1}
             amount0={content.token0Amount}
             amount1={content.token1Amount}
             onAccept={accept}

--- a/frontend/app/src/components/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components/home/PrizeWinnerContent.svelte
@@ -36,10 +36,12 @@
         ev.stopPropagation();
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
-    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // The registry does not always carry the prize's ledger - it can predate the token being
+    // added, or outlive it being dropped - and asserting it does crashed the message list
+    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
+        client.formatTokens(content.transaction.amountE8s, tokenDetails?.decimals ?? 8),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components/home/PrizeWinnerContent.svelte
@@ -37,11 +37,16 @@
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
     // The registry does not always carry the prize's ledger - it can predate the token being
-    // added, or outlive it being dropped - and asserting it does crashed the message list
+    // added, or outlive it being dropped - and asserting it does crashed the message list.
+    // Without decimals the amount cannot be stated, so say so rather than invent a scale: the
+    // same transfer must never render as two different numbers depending on which component
+    // drew it.
     let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
     let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails?.decimals ?? 8),
+        tokenDetails === undefined
+            ? "?????"
+            : client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components/home/access/PaymentGateEvaluator.svelte
@@ -62,7 +62,7 @@
     function onClickPrimary() {
         if (insufficientFunds) {
             balanceWithRefresh?.refresh();
-        } else {
+        } else if (token !== undefined) {
             onApprovePayment({
                 ledger: token.ledger,
                 amount: gate.amount,
@@ -70,25 +70,35 @@
             });
         }
     }
-    let token = $derived(client.getTokenDetailsForAccessGate(gate)!);
-    let originalBalance = $derived($cryptoBalanceStore.get(token.ledger) ?? 0n);
+    // A gate can name a ledger the registry does not carry. Asserting it did threw on the first
+    // derived read of `token.ledger` - the s($).ledger boundary crash - and this is the copy every
+    // desktop-width viewport renders.
+    let token = $derived(client.getTokenDetailsForAccessGate(gate));
+    let originalBalance = $derived($cryptoBalanceStore.get(gate.ledgerCanister) ?? 0n);
     let cryptoBalance = $derived(
-        balanceAfterCurrentCommitments(token.ledger, paymentApprovals, originalBalance),
+        balanceAfterCurrentCommitments(gate.ledgerCanister, paymentApprovals, originalBalance),
     );
     let insufficientFunds = $derived(cryptoBalance < gate.amount);
     let approvalMessage = $derived(
-        interpolate(
-            $_,
-            i18nKey(
-                "access.paymentApprovalMessage",
-                {
-                    amount: client.formatTokens(gate.amount, token.decimals),
-                    token: token.symbol,
-                },
-                level,
-                true,
-            ),
-        ),
+        token === undefined
+            ? interpolate(
+                  $_,
+                  i18nKey(
+                      "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
+                  ),
+              )
+            : interpolate(
+                  $_,
+                  i18nKey(
+                      "access.paymentApprovalMessage",
+                      {
+                          amount: client.formatTokens(gate.amount, token.decimals),
+                          token: token.symbol,
+                      },
+                      level,
+                      true,
+                  ),
+              ),
     );
     let distributionMessage = $derived(
         interpolate($_, i18nKey("access.paymentDistributionMessage", undefined, level, true)),
@@ -115,7 +125,7 @@
 </div>
 <div>
     <p>
-        <Markdown text={approvalMessage + " " + distributionMessage} />
+        <Markdown text={token === undefined ? approvalMessage : approvalMessage + " " + distributionMessage} />
     </p>
     {#if gate.expiry !== undefined}
         <AlertBox>
@@ -127,7 +137,7 @@
             <ErrorMessage><Translatable resourceKey={errorMessage} /></ErrorMessage>
         </div>
     {/if}
-    {#if insufficientFunds}
+    {#if insufficientFunds && token !== undefined}
         <AccountInfo ledger={gate.ledgerCanister} />
         <p><Translatable resourceKey={i18nKey("tokenTransfer.makeDeposit")} /></p>
     {/if}
@@ -135,9 +145,11 @@
 <div>
     <ButtonGroup>
         <Button secondary onClick={onClose}>{$_("cancel")}</Button>
-        <Button loading={refreshingBalance} onClick={onClickPrimary}
-            ><Translatable
-                resourceKey={i18nKey(insufficientFunds ? "Refresh" : "Approve payment")} /></Button>
+        {#if token !== undefined}
+            <Button loading={refreshingBalance} onClick={onClickPrimary}
+                ><Translatable
+                    resourceKey={i18nKey(insufficientFunds ? "Refresh" : "Approve payment")} /></Button>
+        {/if}
     </ButtonGroup>
 </div>
 

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -144,6 +144,12 @@
             subscribe("userLoggedIn", onUserLoggedIn),
             subscribe("sessionExpired", () => client.logout()),
         ];
+        // Registered rather than called at each logout site: an expired session logs out from
+        // the worker agent now, not just from the handler below, and the previous user's
+        // shortcuts must not survive on the device either way.
+        client.onLogout(async () => {
+            if (client.isNativeApp()) clearChatShortcuts();
+        });
         window.addEventListener("orientationchange", calculateHeight);
         window.addEventListener("unhandledrejection", unhandledError);
         // visualViewport.resize fires when the iOS virtual keyboard appears/disappears
@@ -331,7 +337,6 @@
         // every defect in two and doubling the volume. This handler keeps the crash-log
         // record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
-            if (client.isNativeApp()) clearChatShortcuts();
             client.logout();
             ev.preventDefault();
         }

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -142,6 +142,7 @@
             subscribe("hangup", hangup),
             subscribe("askToSpeak", askToSpeak),
             subscribe("userLoggedIn", onUserLoggedIn),
+            subscribe("sessionExpired", () => client.logout()),
         ];
         window.addEventListener("orientationchange", calculateHeight);
         window.addEventListener("unhandledrejection", unhandledError);

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -324,7 +324,12 @@
             return;
         }
         recordError("window", err);
-        logger?.error("Unhandled error: ", err);
+        // Deliberately not reported here. Rollbar's own captureUncaught /
+        // captureUnhandledRejections already reports every event this handler sees, and
+        // installs earlier than this listener, so logging again produced two Rollbar items
+        // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
+        // every defect in two and doubling the volume. This handler keeps the crash-log
+        // record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             if (client.isNativeApp()) clearChatShortcuts();
             client.logout();

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -334,8 +334,10 @@
         // captureUnhandledRejections already reports every event this handler sees, and
         // installs earlier than this listener, so logging again produced two Rollbar items
         // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
-        // every defect in two and doubling the volume. This handler keeps the crash-log
-        // record and the logout, which Rollbar's capture does not do.
+        // every defect in two and doubling the volume. Its `checkIgnore` reads the rejection
+        // reason out of the original arguments, so worker errors - which arrive as plain
+        // objects, not Errors - are still filtered on name and code. This handler keeps the
+        // crash-log record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             client.logout();
             ev.preventDefault();

--- a/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Body, Column, CommonButton, Row, Sheet, Subtitle } from "component-lib";
-    import type { OpenChat, SignerWallet } from "@client";
-    import { cryptoBalanceStore, enhancedCryptoLookup as cryptoLookup } from "@client";
+    import type { OpenChat, SignerWallet, TokenInfo } from "@client";
+    import { cryptoBalanceStore } from "@client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
     import Translatable from "../Translatable.svelte";
@@ -13,8 +13,8 @@
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        ledger0: string;
-        ledger1: string;
+        token0: TokenInfo;
+        token1: TokenInfo;
         amount0: bigint;
         amount1: bigint;
         onClose: () => void;
@@ -23,7 +23,8 @@
         onAccept: (fromAccount?: string) => void;
     }
 
-    let { ledger0, ledger1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let { token0, token1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let ledger1 = $derived(token1.ledger);
 
     let refreshing = false;
     let error: string | undefined = undefined;
@@ -59,29 +60,21 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    // Either side of the swap can name a ledger the registry does not carry. Asserting it did
-    // crashed this sheet open; without decimals and a fee we also cannot state the amounts or
-    // let the swap be accepted, so treat it as an unacceptable swap.
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0));
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1));
-    let unknownToken = $derived(tokenDetails0 === undefined || tokenDetails1 === undefined);
-    let symbol0 = $derived(tokenDetails0?.symbol ?? "");
-    let symbol1 = $derived(tokenDetails1?.symbol ?? "");
-    let transferFees = $derived(BigInt(2) * (tokenDetails1?.transferFee ?? 0n));
+    // Symbol, decimals and fee come from the swap message itself, not the registry: the
+    // message carries the TokenInfo the canister charges from (it debits token1.fee from the
+    // content), so this cannot drift from the real charge and cannot meet a ledger the registry
+    // has never heard of.
+    let symbol0 = $derived(token0.symbol);
+    let symbol1 = $derived(token1.symbol);
+    let transferFees = $derived(BigInt(2) * token1.fee);
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
-    let valid = $derived(error === undefined && !insufficient && !unknownToken);
-    let amount0Text = $derived(
-        tokenDetails0 === undefined ? "?????" : client.formatTokens(amount0, tokenDetails0.decimals),
-    );
-    let amount1Text = $derived(
-        tokenDetails1 === undefined
-            ? "?????"
-            : client.formatTokens(amount1 + transferFees, tokenDetails1.decimals),
-    );
+    let valid = $derived(error === undefined && !insufficient);
+    let amount0Text = $derived(client.formatTokens(amount0, token0.decimals));
+    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, token1.decimals));
 </script>
 
 <Sheet onDismiss={onClose}>

--- a/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
@@ -59,19 +59,29 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0)!);
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1)!);
-    let symbol0 = $derived(tokenDetails0.symbol);
-    let symbol1 = $derived(tokenDetails1.symbol);
-    let transferFees = $derived(BigInt(2) * tokenDetails1.transferFee);
+    // Either side of the swap can name a ledger the registry does not carry. Asserting it did
+    // crashed this sheet open; without decimals and a fee we also cannot state the amounts or
+    // let the swap be accepted, so treat it as an unacceptable swap.
+    let tokenDetails0 = $derived($cryptoLookup.get(ledger0));
+    let tokenDetails1 = $derived($cryptoLookup.get(ledger1));
+    let unknownToken = $derived(tokenDetails0 === undefined || tokenDetails1 === undefined);
+    let symbol0 = $derived(tokenDetails0?.symbol ?? "");
+    let symbol1 = $derived(tokenDetails1?.symbol ?? "");
+    let transferFees = $derived(BigInt(2) * (tokenDetails1?.transferFee ?? 0n));
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
-    let valid = $derived(error === undefined && !insufficient);
-    let amount0Text = $derived(client.formatTokens(amount0, tokenDetails0.decimals));
-    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, tokenDetails1.decimals));
+    let valid = $derived(error === undefined && !insufficient && !unknownToken);
+    let amount0Text = $derived(
+        tokenDetails0 === undefined ? "?????" : client.formatTokens(amount0, tokenDetails0.decimals),
+    );
+    let amount1Text = $derived(
+        tokenDetails1 === undefined
+            ? "?????"
+            : client.formatTokens(amount1 + transferFees, tokenDetails1.decimals),
+    );
 </script>
 
 <Sheet onDismiss={onClose}>

--- a/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Body, Container } from "component-lib";
-    import type { OpenChat } from "@client";
+    import type { EnhancedTokenDetails, OpenChat } from "@client";
     import { enhancedCryptoLookup as cryptoLookup } from "@client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
@@ -62,7 +62,7 @@
         toppingUp = !toppingUp;
     }
 
-    function convertValue(c: Exclude<typeof conversion, "none">, t: typeof tokenDetails): string {
+    function convertValue(c: Exclude<typeof conversion, "none">, t: EnhancedTokenDetails): string {
         switch (c) {
             case "usd":
                 return t.dollarBalance?.toFixed(2) ?? "???";
@@ -74,12 +74,16 @@
                 return t.ethBalance?.toFixed(6) ?? "???";
         }
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // An unrecognised ledger has no decimals we can trust, so a formatted figure would be
+    // wrong rather than missing. Show it as unknown instead.
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let formattedValue = $derived(
-        conversion === "none"
-            ? client.formatTokens(value, tokenDetails.decimals)
-            : convertValue(conversion, tokenDetails),
+        tokenDetails === undefined
+            ? "?????"
+            : conversion === "none"
+              ? client.formatTokens(value, tokenDetails.decimals)
+              : convertValue(conversion, tokenDetails),
     );
     $effect(() => {
         if (ledger) {

--- a/frontend/app/src/components_mobile/home/CryptoContent.svelte
+++ b/frontend/app/src/components_mobile/home/CryptoContent.svelte
@@ -42,7 +42,7 @@
         $currentUserIdStore === senderId ? content.transfer.recipient : senderId,
     );
 
-    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)!));
+    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)));
     let transactionUrl = $derived(
         content.transfer.kind === "completed"
             ? client.buildTransactionUrl(content.transfer.blockIndex, content.transfer.ledger)

--- a/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
+++ b/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
@@ -77,8 +77,8 @@
         onRemove,
     }: Props = $props();
 
-    let fromState = $derived(new TokenState($cryptoLookup.get(content.token0.ledger)!));
-    let toState = $derived(new TokenState($cryptoLookup.get(content.token1.ledger)!));
+    let fromState = $derived(new TokenState($cryptoLookup.get(content.token0.ledger)));
+    let toState = $derived(new TokenState($cryptoLookup.get(content.token1.ledger)));
     let confirming = $state(false);
     let showDetails = $state(false);
     let finished = $derived(

--- a/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
+++ b/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
@@ -265,8 +265,8 @@
             action={cancel} />
     {:else}
         <AcceptP2PSwapModal
-            ledger0={content.token0.ledger}
-            ledger1={content.token1.ledger}
+            token0={content.token0}
+            token1={content.token1}
             amount0={content.token0Amount}
             amount1={content.token1Amount}
             onAccept={accept}

--- a/frontend/app/src/components_mobile/home/PrizeContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContent.svelte
@@ -242,12 +242,18 @@
                     height={{ size: "0.25rem" }}
                     background={ColourVars.surface1}
                     borderRadius="circle">.</Row>
-                <Row padding="sm">
-                    <TransferFeesMessage
-                        symbol={initialTokenState.symbol}
-                        tokenDecimals={initialTokenState.decimals}
-                        transferFees={content.fees} />
-                </Row>
+                <!-- tokenDecimals goes straight to the formatter, bypassing formatTokens and
+                     its unknown-token guard, so an unrecognised ledger would print the fee in
+                     raw base units next to an amount rendered as "?????" - two numbers for one
+                     token. Say nothing about fees instead. -->
+                {#if !initialTokenState.unknown}
+                    <Row padding="sm">
+                        <TransferFeesMessage
+                            symbol={initialTokenState.symbol}
+                            tokenDecimals={initialTokenState.decimals}
+                            transferFees={content.fees} />
+                    </Row>
+                {/if}
             </Column>
         </Column>
     {/if}

--- a/frontend/app/src/components_mobile/home/PrizeContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContent.svelte
@@ -180,7 +180,7 @@
 
     let initialTokenState = $derived(
         content.kind === "prize_content_initial"
-            ? new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)!)
+            ? new TokenState($enhancedCryptoLookup.get(content.transfer.ledger))
             : undefined,
     );
 

--- a/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
@@ -36,10 +36,12 @@
         ev.stopPropagation();
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
-    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // The registry does not always carry the prize's ledger - it can predate the token being
+    // added, or outlive it being dropped - and asserting it does crashed the message list
+    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
+        client.formatTokens(content.transaction.amountE8s, tokenDetails?.decimals ?? 8),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
@@ -37,11 +37,16 @@
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
     // The registry does not always carry the prize's ledger - it can predate the token being
-    // added, or outlive it being dropped - and asserting it does crashed the message list
+    // added, or outlive it being dropped - and asserting it does crashed the message list.
+    // Without decimals the amount cannot be stated, so say so rather than invent a scale: the
+    // same transfer must never render as two different numbers depending on which component
+    // drew it.
     let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
     let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails?.decimals ?? 8),
+        tokenDetails === undefined
+            ? "?????"
+            : client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
@@ -47,7 +47,7 @@
         switch (gate.kind) {
             case "token_balance_gate":
             case "payment_gate":
-                return new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)!, "usd");
+                return new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister), "usd");
             default:
                 return undefined;
         }

--- a/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
@@ -188,8 +188,8 @@
             "payment gate",
             tokenState.formatTokens(gate.amount),
             tokenState.formatTokens(balance),
-            () => onClick(gate),
-            () => tokenState.refreshBalance(client),
+            tokenState.unknown ? undefined : () => onClick(gate),
+            tokenState.unknown ? undefined : () => tokenState.refreshBalance(client),
         )}
     {:else if gate.kind === "token_balance_gate" && tokenState}
         {@const balance = accessApprovalState.balanceAfterCurrentCommitments(
@@ -204,8 +204,8 @@
             "minimum balance gate",
             tokenState.formatTokens(gate.minBalance),
             tokenState.formatTokens(balance),
-            () => onClick(gate),
-            () => tokenState.refreshBalance(client),
+            tokenState.unknown ? undefined : () => onClick(gate),
+            tokenState.unknown ? undefined : () => tokenState.refreshBalance(client),
         )}
     {:else if gate.kind === "neuron_gate" && token}
         {@render neuronGate(gate, token)}

--- a/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
@@ -138,9 +138,11 @@
     {:else}
         <MenuTrigger maskUI align={"end"} position={"bottom"} fill mobileMode={"longpress"}>
             {#snippet menuItems()}
-                <MenuItem onclick={refresh}>
-                    <Translatable resourceKey={i18nKey("Refresh balance")} />
-                </MenuItem>
+                {#if refresh}
+                    <MenuItem onclick={refresh}>
+                        <Translatable resourceKey={i18nKey("Refresh balance")} />
+                    </MenuItem>
+                {/if}
             {/snippet}
             <AccessGateBox {satisfied} satisfiable={!insufficient} {onClick}>
                 <Avatar url={logo} />

--- a/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
@@ -29,7 +29,7 @@
 
     let { gate, onClose }: Props = $props();
 
-    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)!));
+    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)));
     let cryptoBalance = $derived(
         accessApprovalState.balanceAfterCurrentCommitments(
             tokenState.ledger,

--- a/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
@@ -62,17 +62,21 @@
                 </Caption>
             </Column>
         </Row>
-        <Column
-            onClick={topup}
-            mainAxisAlignment={"center"}
-            crossAxisAlignment={"center"}
-            width={{ size: "4rem" }}
-            height={"fill"}
-            borderRadius={"lg"}
-            background={ColourVars.surface2}
-            padding={["sm", "md"]}>
-            <QrCode size={"2rem"} color={ColourVars.textSecondary} />
-        </Column>
+        <!-- No top-up for a ledger the registry does not carry: ReceiveCrypto would open on a
+             nameless token with no receiving address worth showing -->
+        {#if !tokenState.unknown}
+            <Column
+                onClick={topup}
+                mainAxisAlignment={"center"}
+                crossAxisAlignment={"center"}
+                width={{ size: "4rem" }}
+                height={"fill"}
+                borderRadius={"lg"}
+                background={ColourVars.surface2}
+                padding={["sm", "md"]}>
+                <QrCode size={"2rem"} color={ColourVars.textSecondary} />
+            </Column>
+        {/if}
     </Row>
 {/snippet}
 

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -86,17 +86,19 @@
             minHeight={"4rem"}
             gap={"md"}
             background={ColourVars.surface2}
-            padding={["md", "lg"]}>
+            padding={["md", "lg"]}
+        >
             <Avatar url={tokenState.logo} />
             <Column width={"fill"}>
                 <Body fontWeight={"bold"} colour={"textPrimary"} width={"hug"}
-                    >{tokenState.symbol}</Body>
+                    >{tokenState.symbol}</Body
+                >
                 <Caption colour={"textSecondary"} fontWeight={"bold"}>
                     {tokenState.formatTokens(cryptoBalance)}
                 </Caption>
             </Column>
         </Row>
-        {#if insufficientFunds}
+        {#if insufficientFunds && !tokenState.unknown}
             <Column
                 onClick={() => publish("receiveToken", tokenState)}
                 mainAxisAlignment={"center"}
@@ -105,96 +107,111 @@
                 height={"fill"}
                 borderRadius={"lg"}
                 background={ColourVars.surface2}
-                padding={["sm", "md"]}>
+                padding={["sm", "md"]}
+            >
                 <QrCode size={"2rem"} color={ColourVars.textSecondary} />
             </Column>
         {/if}
     </Row>
 {/snippet}
 
-<Column gap={"lg"}>
-    <Wallet size={"4.5rem"} color={ColourVars.primary} />
-    <H2 fontWeight={"bold"}>
-        <MulticolourText
-            parts={[
-                {
-                    text: i18nKey(tokenState.symbol),
-                    colour: "primary",
-                },
-                {
-                    text: i18nKey(" payment gate"),
-                    colour: "textPrimary",
-                },
-            ]} />
-    </H2>
-    <Body colour={"textSecondary"}>
-        <Markdown text={approvalMessage} />
-    </Body>
-
-    <Column gap={"sm"}>
-        {@render tokenBalance()}
-        {#if insufficientFunds}
-            <StatusCard
-                borderColour={ColourVars.surface2}
-                background={ColourVars.surface0}
-                mode={"warning"}
-                body={interpolate(
-                    $_,
-                    i18nKey(
-                        `Top up your ${tokenState.symbol} token account. Tap the QR code button to get your receiving address.`,
-                    ),
+{#if tokenState.unknown}
+    <Column gap={"lg"}>
+        <Wallet size={"4.5rem"} color={ColourVars.primary} />
+        <H2 fontWeight={"bold"}>
+            <Translatable resourceKey={i18nKey("Unrecognised token")} />
+        </H2>
+        <Body colour={"textSecondary"}>
+            <Translatable
+                resourceKey={i18nKey(
+                    "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
                 )}
-                title={interpolate($_, i18nKey("Insufficient funds"))}>
-            </StatusCard>
-        {/if}
-        {#if gate.expiry !== undefined}
-            <StatusCard
-                background={ColourVars.surface2}
-                mode={"information"}
-                title={interpolate($_, i18nKey("This is a recurring payment"))}>
-                {#snippet body()}
-                    <AccessGateExpiry expiry={gate.expiry} />
-                {/snippet}
-            </StatusCard>
-        {/if}
+            />
+        </Body>
+    </Column>
+{:else}
+    <Column gap={"lg"}>
+        <Wallet size={"4.5rem"} color={ColourVars.primary} />
+        <H2 fontWeight={"bold"}>
+            <MulticolourText
+                parts={[
+                    {
+                        text: i18nKey(tokenState.symbol),
+                        colour: "primary",
+                    },
+                    {
+                        text: i18nKey(" payment gate"),
+                        colour: "textPrimary",
+                    },
+                ]}
+            />
+        </H2>
+        <Body colour={"textSecondary"}>
+            <Markdown text={approvalMessage} />
+        </Body>
 
-        <Column borderRadius={"lg"} gap={"lg"} padding={"lg"} background={ColourVars.surface2}>
-            <Row mainAxisAlignment={"spaceBetween"}>
-                <BodySmall colour={"textSecondary"}>
-                    <Translatable resourceKey={i18nKey("Payment amount")} />
-                </BodySmall>
-                <Body width={"hug"} colour={"primary"} fontWeight={"bold"}>
-                    {totalAmount}
-                    {tokenState.symbol}
-                </Body>
-            </Row>
-            <Row mainAxisAlignment={"spaceBetween"}>
-                <BodySmall colour={"textSecondary"}>
-                    <Translatable resourceKey={i18nKey("Owner receives (98%)")} />
-                </BodySmall>
-                <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
-                    {toOwner}
-                    {tokenState.symbol}
-                </Body>
-            </Row>
-            <Row mainAxisAlignment={"spaceBetween"}>
-                <BodySmall colour={"textSecondary"}>
-                    <Translatable resourceKey={i18nKey("OpenChat treasury receives (2%)")} />
-                </BodySmall>
-                <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
-                    {toOC}
-                    {tokenState.symbol}
-                </Body>
-            </Row>
+        <Column gap={"sm"}>
+            {@render tokenBalance()}
+            {#if insufficientFunds}
+                <StatusCard
+                    borderColour={ColourVars.surface2}
+                    background={ColourVars.surface0}
+                    mode={"warning"}
+                    body={interpolate(
+                        $_,
+                        i18nKey(
+                            `Top up your ${tokenState.symbol} token account. Tap the QR code button to get your receiving address.`,
+                        ),
+                    )}
+                    title={interpolate($_, i18nKey("Insufficient funds"))}
+                ></StatusCard>
+            {/if}
+            {#if gate.expiry !== undefined}
+                <StatusCard
+                    background={ColourVars.surface2}
+                    mode={"information"}
+                    title={interpolate($_, i18nKey("This is a recurring payment"))}
+                >
+                    {#snippet body()}
+                        <AccessGateExpiry expiry={gate.expiry} />
+                    {/snippet}
+                </StatusCard>
+            {/if}
+
+            <Column borderRadius={"lg"} gap={"lg"} padding={"lg"} background={ColourVars.surface2}>
+                <Row mainAxisAlignment={"spaceBetween"}>
+                    <BodySmall colour={"textSecondary"}>
+                        <Translatable resourceKey={i18nKey("Payment amount")} />
+                    </BodySmall>
+                    <Body width={"hug"} colour={"primary"} fontWeight={"bold"}>
+                        {totalAmount}
+                        {tokenState.symbol}
+                    </Body>
+                </Row>
+                <Row mainAxisAlignment={"spaceBetween"}>
+                    <BodySmall colour={"textSecondary"}>
+                        <Translatable resourceKey={i18nKey("Owner receives (98%)")} />
+                    </BodySmall>
+                    <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
+                        {toOwner}
+                        {tokenState.symbol}
+                    </Body>
+                </Row>
+                <Row mainAxisAlignment={"spaceBetween"}>
+                    <BodySmall colour={"textSecondary"}>
+                        <Translatable resourceKey={i18nKey("OpenChat treasury receives (2%)")} />
+                    </BodySmall>
+                    <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
+                        {toOC}
+                        {tokenState.symbol}
+                    </Body>
+                </Row>
+            </Column>
         </Column>
     </Column>
-</Column>
+{/if}
 
 {#if tokenState.unknown}
-    <Translatable
-        resourceKey={i18nKey(
-            "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
-        )} />
     <CommonButton width={"fill"} size={"small_text"} onClick={onClose}>
         <Translatable resourceKey={i18nKey("cancel")} />
     </CommonButton>
@@ -208,7 +225,8 @@
                 ledger: token!.ledger,
                 amount: gate.amount,
                 approvalFee: token!.transferFee,
-            })}>
+            })}
+    >
         {#snippet icon(color)}
             <Wallet {color} />
         {/snippet}
@@ -225,7 +243,8 @@
         width={"fill"}
         mode={"active"}
         size={"small_text"}
-        onClick={() => tokenState.refreshBalance(client)}>
+        onClick={() => tokenState.refreshBalance(client)}
+    >
         {#snippet icon(color, size)}
             <Refresh {color} {size} />
         {/snippet}

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -86,13 +86,11 @@
             minHeight={"4rem"}
             gap={"md"}
             background={ColourVars.surface2}
-            padding={["md", "lg"]}
-        >
+            padding={["md", "lg"]}>
             <Avatar url={tokenState.logo} />
             <Column width={"fill"}>
                 <Body fontWeight={"bold"} colour={"textPrimary"} width={"hug"}
-                    >{tokenState.symbol}</Body
-                >
+                    >{tokenState.symbol}</Body>
                 <Caption colour={"textSecondary"} fontWeight={"bold"}>
                     {tokenState.formatTokens(cryptoBalance)}
                 </Caption>
@@ -107,32 +105,19 @@
                 height={"fill"}
                 borderRadius={"lg"}
                 background={ColourVars.surface2}
-                padding={["sm", "md"]}
-            >
+                padding={["sm", "md"]}>
                 <QrCode size={"2rem"} color={ColourVars.textSecondary} />
             </Column>
         {/if}
     </Row>
 {/snippet}
 
-{#if tokenState.unknown}
-    <Column gap={"lg"}>
-        <Wallet size={"4.5rem"} color={ColourVars.primary} />
-        <H2 fontWeight={"bold"}>
+<Column gap={"lg"}>
+    <Wallet size={"4.5rem"} color={ColourVars.primary} />
+    <H2 fontWeight={"bold"}>
+        {#if tokenState.unknown}
             <Translatable resourceKey={i18nKey("Unrecognised token")} />
-        </H2>
-        <Body colour={"textSecondary"}>
-            <Translatable
-                resourceKey={i18nKey(
-                    "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
-                )}
-            />
-        </Body>
-    </Column>
-{:else}
-    <Column gap={"lg"}>
-        <Wallet size={"4.5rem"} color={ColourVars.primary} />
-        <H2 fontWeight={"bold"}>
+        {:else}
             <MulticolourText
                 parts={[
                     {
@@ -143,73 +128,82 @@
                         text: i18nKey(" payment gate"),
                         colour: "textPrimary",
                     },
-                ]}
-            />
-        </H2>
-        <Body colour={"textSecondary"}>
+                ]} />
+        {/if}
+    </H2>
+    <Body colour={"textSecondary"}>
+        {#if tokenState.unknown}
+            <Translatable
+                resourceKey={i18nKey(
+                    "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
+                )} />
+        {:else}
             <Markdown text={approvalMessage} />
-        </Body>
+        {/if}
+    </Body>
 
-        <Column gap={"sm"}>
-            {@render tokenBalance()}
-            {#if insufficientFunds}
-                <StatusCard
-                    borderColour={ColourVars.surface2}
-                    background={ColourVars.surface0}
-                    mode={"warning"}
-                    body={interpolate(
-                        $_,
-                        i18nKey(
-                            `Top up your ${tokenState.symbol} token account. Tap the QR code button to get your receiving address.`,
-                        ),
-                    )}
-                    title={interpolate($_, i18nKey("Insufficient funds"))}
-                ></StatusCard>
-            {/if}
-            {#if gate.expiry !== undefined}
-                <StatusCard
-                    background={ColourVars.surface2}
-                    mode={"information"}
-                    title={interpolate($_, i18nKey("This is a recurring payment"))}
-                >
-                    {#snippet body()}
-                        <AccessGateExpiry expiry={gate.expiry} />
-                    {/snippet}
-                </StatusCard>
-            {/if}
+    <!-- Nothing below is meaningful for a token we cannot identify: the balance card would show
+         a blank symbol, and the breakdown amounts would all be "?????" -->
+    {#if !tokenState.unknown}
+    <Column gap={"sm"}>
+        {@render tokenBalance()}
+        {#if insufficientFunds}
+            <StatusCard
+                borderColour={ColourVars.surface2}
+                background={ColourVars.surface0}
+                mode={"warning"}
+                body={interpolate(
+                    $_,
+                    i18nKey(
+                        `Top up your ${tokenState.symbol} token account. Tap the QR code button to get your receiving address.`,
+                    ),
+                )}
+                title={interpolate($_, i18nKey("Insufficient funds"))}>
+            </StatusCard>
+        {/if}
+        {#if gate.expiry !== undefined}
+            <StatusCard
+                background={ColourVars.surface2}
+                mode={"information"}
+                title={interpolate($_, i18nKey("This is a recurring payment"))}>
+                {#snippet body()}
+                    <AccessGateExpiry expiry={gate.expiry} />
+                {/snippet}
+            </StatusCard>
+        {/if}
 
-            <Column borderRadius={"lg"} gap={"lg"} padding={"lg"} background={ColourVars.surface2}>
-                <Row mainAxisAlignment={"spaceBetween"}>
-                    <BodySmall colour={"textSecondary"}>
-                        <Translatable resourceKey={i18nKey("Payment amount")} />
-                    </BodySmall>
-                    <Body width={"hug"} colour={"primary"} fontWeight={"bold"}>
-                        {totalAmount}
-                        {tokenState.symbol}
-                    </Body>
-                </Row>
-                <Row mainAxisAlignment={"spaceBetween"}>
-                    <BodySmall colour={"textSecondary"}>
-                        <Translatable resourceKey={i18nKey("Owner receives (98%)")} />
-                    </BodySmall>
-                    <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
-                        {toOwner}
-                        {tokenState.symbol}
-                    </Body>
-                </Row>
-                <Row mainAxisAlignment={"spaceBetween"}>
-                    <BodySmall colour={"textSecondary"}>
-                        <Translatable resourceKey={i18nKey("OpenChat treasury receives (2%)")} />
-                    </BodySmall>
-                    <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
-                        {toOC}
-                        {tokenState.symbol}
-                    </Body>
-                </Row>
-            </Column>
+        <Column borderRadius={"lg"} gap={"lg"} padding={"lg"} background={ColourVars.surface2}>
+            <Row mainAxisAlignment={"spaceBetween"}>
+                <BodySmall colour={"textSecondary"}>
+                    <Translatable resourceKey={i18nKey("Payment amount")} />
+                </BodySmall>
+                <Body width={"hug"} colour={"primary"} fontWeight={"bold"}>
+                    {totalAmount}
+                    {tokenState.symbol}
+                </Body>
+            </Row>
+            <Row mainAxisAlignment={"spaceBetween"}>
+                <BodySmall colour={"textSecondary"}>
+                    <Translatable resourceKey={i18nKey("Owner receives (98%)")} />
+                </BodySmall>
+                <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
+                    {toOwner}
+                    {tokenState.symbol}
+                </Body>
+            </Row>
+            <Row mainAxisAlignment={"spaceBetween"}>
+                <BodySmall colour={"textSecondary"}>
+                    <Translatable resourceKey={i18nKey("OpenChat treasury receives (2%)")} />
+                </BodySmall>
+                <Body width={"hug"} colour={"textPrimary"} fontWeight={"bold"}>
+                    {toOC}
+                    {tokenState.symbol}
+                </Body>
+            </Row>
         </Column>
     </Column>
-{/if}
+    {/if}
+</Column>
 
 {#if tokenState.unknown}
     <CommonButton width={"fill"} size={"small_text"} onClick={onClose}>
@@ -225,8 +219,7 @@
                 ledger: token!.ledger,
                 amount: gate.amount,
                 approvalFee: token!.transferFee,
-            })}
-    >
+            })}>
         {#snippet icon(color)}
             <Wallet {color} />
         {/snippet}
@@ -243,8 +236,7 @@
         width={"fill"}
         mode={"active"}
         size={"small_text"}
-        onClick={() => tokenState.refreshBalance(client)}
-    >
+        onClick={() => tokenState.refreshBalance(client)}>
         {#snippet icon(color, size)}
             <Refresh {color} {size} />
         {/snippet}

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -50,8 +50,13 @@
     let tokenState = $derived(new TokenState(token));
     let refreshingBalance = $state(false);
     let totalAmount = $derived(tokenState.formatTokens(gate.amount));
-    let toOwner = $derived(tokenState.formatTokens(BigInt(Number(gate.amount) * 0.98)));
-    let toOC = $derived(tokenState.formatTokens(BigInt(Number(gate.amount) * 0.02)));
+    // Integer arithmetic: BigInt(Number(amount) * 0.98) throws a RangeError for any amount that
+    // is not a multiple of 50, because the product is not an integer (12345678n throws;
+    // 100000000n only happens to pass). The remainder goes to the treasury so the two sum to
+    // the amount, matching how the canister splits it.
+    let ownerShare = $derived((gate.amount * 98n) / 100n);
+    let toOwner = $derived(tokenState.formatTokens(ownerShare));
+    let toOC = $derived(tokenState.formatTokens(gate.amount - ownerShare));
 
     let cryptoBalance = $derived(
         accessApprovalState.balanceAfterCurrentCommitments(

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -43,7 +43,10 @@
 
     let { gate, level, onApprovePayment, onClose }: Props = $props();
 
-    let token = $derived($enhancedCryptoLookup.get(gate.ledgerCanister)!);
+    // A gate can name a ledger the registry does not carry. `token.ledger` below then threw and
+    // took the app down; and with no decimals or fee we can neither state the amount nor build a
+    // valid approval, so the payment must not be offered at all.
+    let token = $derived($enhancedCryptoLookup.get(gate.ledgerCanister));
     let tokenState = $derived(new TokenState(token));
     let refreshingBalance = $state(false);
     let totalAmount = $derived(tokenState.formatTokens(gate.amount));
@@ -65,7 +68,7 @@
                 "access.paymentApprovalMessage",
                 {
                     amount: tokenState.formatTokens(gate.amount),
-                    token: token.symbol,
+                    token: tokenState.symbol,
                 },
                 level,
                 true,
@@ -187,16 +190,24 @@
     </Column>
 </Column>
 
-{#if insufficientFunds}
+{#if tokenState.unknown}
+    <Translatable
+        resourceKey={i18nKey(
+            "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
+        )} />
+    <CommonButton width={"fill"} size={"small_text"} onClick={onClose}>
+        <Translatable resourceKey={i18nKey("cancel")} />
+    </CommonButton>
+{:else if insufficientFunds}
     {@render refreshBalance()}
 {:else}
     <Button
         width={"fill"}
         onClick={() =>
             onApprovePayment({
-                ledger: token.ledger,
+                ledger: token!.ledger,
                 amount: gate.amount,
-                approvalFee: token.transferFee,
+                approvalFee: token!.transferFee,
             })}>
         {#snippet icon(color)}
             <Wallet {color} />

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -211,14 +211,14 @@
     </CommonButton>
 {:else if insufficientFunds}
     {@render refreshBalance()}
-{:else}
+{:else if token}
     <Button
         width={"fill"}
         onClick={() =>
             onApprovePayment({
-                ledger: token!.ledger,
+                ledger: token.ledger,
                 amount: gate.amount,
-                approvalFee: token!.transferFee,
+                approvalFee: token.transferFee,
             })}>
         {#snippet icon(color)}
             <Wallet {color} />

--- a/frontend/app/src/components_mobile/home/insurance/StreakInsuranceBuy.svelte
+++ b/frontend/app/src/components_mobile/home/insurance/StreakInsuranceBuy.svelte
@@ -40,7 +40,7 @@
     const MAX_DAYS = 30;
     const ledger = LEDGER_CANISTER_CHAT;
     const token = $derived($enhancedCryptoLookup.get(ledger));
-    const tokenState = $derived(new TokenState(token!));
+    const tokenState = $derived(new TokenState(token));
     const currentDaysInsured = $streakInsuranceStore.daysInsured;
     const currentDaysMissed = $streakInsuranceStore.daysMissed;
     let { onClose }: Props = $props();

--- a/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
+++ b/frontend/app/src/components_mobile/home/user_profile/UserProfileSummary.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { i18nKey } from "@src/i18n/i18n";
-    import { clearChatShortcuts } from "@stores/chatShortcuts";
     import { Body, Container, IconButton, MenuItem, MenuTrigger } from "component-lib";
     import {
         allUsersStore,
@@ -75,10 +74,7 @@
                             </MenuItem>
                             <MenuItem
                                 danger
-                                onclick={() => {
-                                    if (client.isNativeApp()) clearChatShortcuts();
-                                    client.logout();
-                                }}>
+                                onclick={() => client.logout()}>
                                 <Translatable resourceKey={i18nKey("Logout")} />
                             </MenuItem>
                         {/snippet}

--- a/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
@@ -2,6 +2,7 @@
     import { i18nKey, interpolate } from "@src/i18n/i18n";
     import { Body, CommonButton2, Container, Form, Input } from "component-lib";
     import { namedAccountsStore, type NamedAccount, type OpenChat } from "@client";
+    import { isICRCAddressValid } from "@shared";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import Save from "svelte-material-icons/ContentSaveOutline.svelte";
@@ -25,8 +26,10 @@
     let nameDirty = $derived(trimmedName !== account?.name);
     let addressDirty = $derived(trimmedAddress !== account?.account);
     let dirty = $derived(nameDirty || addressDirty);
-    // TODO this probably isn't good enough
-    let validAddress = $derived(trimmedAddress.length > 0);
+    // Matches what save_crypto_account accepts: a principal, or an ICRC-1 textual account.
+    // Saving anything else used to succeed here and then throw out of the worker, unhandled,
+    // when the withdrawal mapper tried to decode it.
+    let validAddress = $derived(isICRCAddressValid(trimmedAddress));
     let validName = $derived(
         trimmedName.length > 0 &&
             $namedAccountsStore.find((a) => a.name.toLowerCase() === trimmedName.toLowerCase()) ===

--- a/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
@@ -26,10 +26,10 @@
     let nameDirty = $derived(trimmedName !== account?.name);
     let addressDirty = $derived(trimmedAddress !== account?.account);
     let dirty = $derived(nameDirty || addressDirty);
-    // Mirrors `is_valid_account` in save_crypto_account.rs: an ICRC-1 textual account, which
-    // covers a bare principal, or a hex ICP ledger account identifier. Saving anything else used
-    // to succeed here and then throw out of the worker, unhandled, when the withdrawal mapper
-    // tried to decode it.
+    // The same two forms `is_valid_account` in save_crypto_account.rs accepts: an ICRC-1 textual
+    // account, which covers a bare principal, or an ICP ledger account identifier (checksum
+    // included, as the canister checks it). Saving anything else used to succeed here and then
+    // throw out of the worker, unhandled, when the withdrawal mapper tried to decode it.
     let validAddress = $derived(
         isICRCAddressValid(trimmedAddress) || isAccountIdentifierValid(trimmedAddress),
     );
@@ -59,9 +59,7 @@
         } else {
             loading = false;
             toastStore.showFailureToast(
-                i18nKey(
-                    "Could not save recipient. Make sure that the address is a valid principal.",
-                ),
+                i18nKey("Could not save recipient. Make sure that the address is valid."),
             );
         }
     }

--- a/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
@@ -2,7 +2,7 @@
     import { i18nKey, interpolate } from "@src/i18n/i18n";
     import { Body, CommonButton2, Container, Form, Input } from "component-lib";
     import { namedAccountsStore, type NamedAccount, type OpenChat } from "@client";
-    import { isICRCAddressValid } from "@shared";
+    import { isAccountIdentifierValid, isICRCAddressValid } from "@shared";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import Save from "svelte-material-icons/ContentSaveOutline.svelte";
@@ -26,10 +26,13 @@
     let nameDirty = $derived(trimmedName !== account?.name);
     let addressDirty = $derived(trimmedAddress !== account?.account);
     let dirty = $derived(nameDirty || addressDirty);
-    // Matches what save_crypto_account accepts: a principal, or an ICRC-1 textual account.
-    // Saving anything else used to succeed here and then throw out of the worker, unhandled,
-    // when the withdrawal mapper tried to decode it.
-    let validAddress = $derived(isICRCAddressValid(trimmedAddress));
+    // Mirrors `is_valid_account` in save_crypto_account.rs: an ICRC-1 textual account, which
+    // covers a bare principal, or a hex ICP ledger account identifier. Saving anything else used
+    // to succeed here and then throw out of the worker, unhandled, when the withdrawal mapper
+    // tried to decode it.
+    let validAddress = $derived(
+        isICRCAddressValid(trimmedAddress) || isAccountIdentifierValid(trimmedAddress),
+    );
     let validName = $derived(
         trimmedName.length > 0 &&
             $namedAccountsStore.find((a) => a.name.toLowerCase() === trimmedName.toLowerCase()) ===

--- a/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
@@ -394,8 +394,10 @@
         <Container gap={"sm"} direction={"vertical"} padding={["sm", "xl", "zero", "xl"]}>
             <!-- Saved recipients are IC accounts only (principal, ICRC-1 account or ICP account
                  identifier - what save_crypto_account accepts). A BTC or EVM address would open
-                 the recipient form with a save button that never enables and no way to see why. -->
-            {#if namedAccount === undefined && !isBtc && !isOneSecNetwork}
+                 the recipient form with a save button that never enables and no way to see why.
+                 Keyed on the selected network, not the token: BTC sent over the ckBTC network
+                 goes to an IC principal, which can be saved. -->
+            {#if namedAccount === undefined && !isBtcNetwork && !isOneSecNetwork}
                 <Button secondary onClick={saveAddress}>
                     {#snippet icon(color)}
                         <Account {color} />

--- a/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
@@ -392,7 +392,10 @@
             </Container>
         </Container>
         <Container gap={"sm"} direction={"vertical"} padding={["sm", "xl", "zero", "xl"]}>
-            {#if namedAccount === undefined}
+            <!-- Saved recipients are IC accounts only (principal, ICRC-1 account or ICP account
+                 identifier - what save_crypto_account accepts). A BTC or EVM address would open
+                 the recipient form with a save button that never enables and no way to see why. -->
+            {#if namedAccount === undefined && !isBtc && !isOneSecNetwork}
                 <Button secondary onClick={saveAddress}>
                     {#snippet icon(color)}
                         <Account {color} />

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.test.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { TokenState } from "./walletState.svelte";
+
+// The first version of `unknown` compared `#token === nullToken`. `#token` is `$state`, Svelte
+// proxies whatever is assigned to it, and the comparison was always false - every guard built on
+// it was inert and the crash it was meant to stop was one tap away. This pins the contract.
+describe("TokenState with a ledger the registry does not carry", () => {
+    test("reports itself as unknown", () => {
+        expect(new TokenState(undefined).unknown).toBe(true);
+    });
+
+    test("refuses to format an amount rather than inventing a scale", () => {
+        expect(new TokenState(undefined).formatTokens(123456789n)).toBe("?????");
+    });
+
+    test("does not stay unknown once a real token is assigned", () => {
+        const state = new TokenState(undefined);
+        state.token = {
+            name: "Internet Computer",
+            symbol: "ICP",
+            ledger: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+            index: undefined,
+            decimals: 8,
+            transferFee: 10000n,
+            logo: "",
+            infoUrl: "",
+            transactionUrlFormat: "",
+            supportedStandards: [],
+            added: 0n,
+            enabled: true,
+            oneSecEnabled: false,
+            evmContractAddresses: [],
+            lastUpdated: 0n,
+            balance: 0n,
+            dollarBalance: undefined,
+            icpBalance: undefined,
+            btcBalance: undefined,
+            ethBalance: undefined,
+            zero: false,
+            urlFormat: "",
+        };
+        expect(state.unknown).toBe(false);
+        expect(state.formatTokens(123456789n)).not.toBe("?????");
+        expect(state.formatTokens(123456789n)).toMatch(/^1\.23456/);
+    });
+});

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
@@ -172,25 +172,23 @@ export class TokenState {
     // of `#token.ledger`. The null token stops the crash, but its zero decimals and empty symbol
     // would render an amount that is wrong rather than obviously missing, so callers must consult
     // `unknown` and refuse to show a figure or offer an action for a token we cannot identify.
-    #unknown = $state(false);
-
     constructor(t: EnhancedTokenDetails | undefined, c: ConversionToken = "usd") {
         this.#token = t ?? nullToken;
-        this.#unknown = t === undefined;
         this.#selectedConversion = c;
     }
 
     // True when the ledger is not in the registry: nothing about this token can be trusted,
-    // including any amount formatted with it.
+    // including any amount formatted with it. Derived from the token itself rather than latched
+    // in the constructor, so it stays correct through the `token` setter below.
     get unknown() {
-        return this.#unknown;
+        return this.#token === nullToken;
     }
 
     // The null token's zero decimals would turn e8s into a number that is wrong rather than
     // obviously missing, and every consumer of this class formats through here, so one guard
     // covers message content, gates and the wallet alike.
     formatTokens(amount: bigint) {
-        if (this.#unknown) return "?????";
+        if (this.unknown) return "?????";
         return formatTokens(amount, this.#decimals);
     }
 
@@ -306,6 +304,9 @@ export class TokenState {
     }
 
     refreshBalance(client: OpenChat) {
+        // The null token's ledger is "", and refreshing that reaches the worker as
+        // Principal.fromText("") - one unhandled rejection per tap. Nothing to refresh anyway.
+        if (this.unknown) return Promise.resolve();
         this.#refreshingBalance = true;
         return client
             .refreshAccountBalance(this.ledger, false)

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
@@ -169,13 +169,28 @@ export class TokenState {
     // Every caller looks the token up in the registry and asserts the result is there. It is not
     // always: a message or an access gate can name a ledger the registry has never carried or has
     // since dropped, and an undefined token here took the whole app down on the first derived read
-    // of `#token.ledger`. Falling back to the null token renders an empty, inert token instead.
+    // of `#token.ledger`. The null token stops the crash, but its zero decimals and empty symbol
+    // would render an amount that is wrong rather than obviously missing, so callers must consult
+    // `unknown` and refuse to show a figure or offer an action for a token we cannot identify.
+    #unknown = $state(false);
+
     constructor(t: EnhancedTokenDetails | undefined, c: ConversionToken = "usd") {
         this.#token = t ?? nullToken;
+        this.#unknown = t === undefined;
         this.#selectedConversion = c;
     }
 
+    // True when the ledger is not in the registry: nothing about this token can be trusted,
+    // including any amount formatted with it.
+    get unknown() {
+        return this.#unknown;
+    }
+
+    // The null token's zero decimals would turn e8s into a number that is wrong rather than
+    // obviously missing, and every consumer of this class formats through here, so one guard
+    // covers message content, gates and the wallet alike.
     formatTokens(amount: bigint) {
+        if (this.#unknown) return "?????";
         return formatTokens(amount, this.#decimals);
     }
 

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
@@ -166,8 +166,12 @@ export class TokenState {
         }
     });
 
-    constructor(t: EnhancedTokenDetails, c: ConversionToken = "usd") {
-        this.#token = t;
+    // Every caller looks the token up in the registry and asserts the result is there. It is not
+    // always: a message or an access gate can name a ledger the registry has never carried or has
+    // since dropped, and an undefined token here took the whole app down on the first derived read
+    // of `#token.ledger`. Falling back to the null token renders an empty, inert token instead.
+    constructor(t: EnhancedTokenDetails | undefined, c: ConversionToken = "usd") {
+        this.#token = t ?? nullToken;
         this.#selectedConversion = c;
     }
 

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
@@ -140,7 +140,7 @@ export class TokenState {
             this.#symbol,
         ),
     );
-    #formattedTokenBalance = $derived(formatTokens(this.#remainingBalance, this.#decimals));
+    #formattedTokenBalance = $derived(this.formatTokens(this.#remainingBalance));
     #convertedValue = $derived(
         getConvertedTokenValue(this.#selectedConversion, this.#convertedBalances),
     );
@@ -172,23 +172,28 @@ export class TokenState {
     // of `#token.ledger`. The null token stops the crash, but its zero decimals and empty symbol
     // would render an amount that is wrong rather than obviously missing, so callers must consult
     // `unknown` and refuse to show a figure or offer an action for a token we cannot identify.
+    // A plain boolean, deliberately. `#token` is `$state`, and Svelte proxies whatever is assigned
+    // to it, so `this.#token === nullToken` compares a proxy with the raw object and is always
+    // false - which made every guard keyed on it inert. Set wherever `#token` is.
+    #unknown = false;
+
     constructor(t: EnhancedTokenDetails | undefined, c: ConversionToken = "usd") {
         this.#token = t ?? nullToken;
+        this.#unknown = t === undefined;
         this.#selectedConversion = c;
     }
 
     // True when the ledger is not in the registry: nothing about this token can be trusted,
-    // including any amount formatted with it. Derived from the token itself rather than latched
-    // in the constructor, so it stays correct through the `token` setter below.
+    // including any amount formatted with it.
     get unknown() {
-        return this.#token === nullToken;
+        return this.#unknown;
     }
 
     // The null token's zero decimals would turn e8s into a number that is wrong rather than
     // obviously missing, and every consumer of this class formats through here, so one guard
     // covers message content, gates and the wallet alike.
     formatTokens(amount: bigint) {
-        if (this.unknown) return "?????";
+        if (this.#unknown) return "?????";
         return formatTokens(amount, this.#decimals);
     }
 
@@ -293,6 +298,7 @@ export class TokenState {
 
     set token(val: EnhancedTokenDetails) {
         this.#token = val;
+        this.#unknown = false;
     }
 
     get refreshingBalance() {
@@ -306,7 +312,7 @@ export class TokenState {
     refreshBalance(client: OpenChat) {
         // The null token's ledger is "", and refreshing that reaches the worker as
         // Principal.fromText("") - one unhandled rejection per tap. Nothing to refresh anyway.
-        if (this.unknown) return Promise.resolve();
+        if (this.#unknown) return Promise.resolve();
         this.#refreshingBalance = true;
         return client
             .refreshAccountBalance(this.ledger, false)

--- a/frontend/app/src/i18n/i18n.ts
+++ b/frontend/app/src/i18n/i18n.ts
@@ -114,14 +114,28 @@ register("pl", () => import("./pl.json"));
 register("fa", () => import("./fa.json"));
 register("ar", () => import("./ar.json"));
 
+// svelte-i18n's init() passes initialLocale through Intl.getCanonicalLocales, which throws a
+// RangeError on a tag it cannot parse - an empty string, or the underscore form ("zh_CN") some
+// Android WebViews report as navigator.language. The throw escapes init(), so no locale is ever
+// set and the first message the app formats kills it with "Cannot format a message without first
+// setting the initial locale".
+function usableLocale(code: string): boolean {
+    try {
+        return Intl.getCanonicalLocales(code).length > 0;
+    } catch {
+        return false;
+    }
+}
+
 export function getStoredLocale(): string {
     const fromStorage = localStorage.getItem(configKeys.locale);
 
-    if (fromStorage === null) {
-        return getLocaleFromNavigator() || "en";
-    }
+    const code =
+        fromStorage === null
+            ? getLocaleFromNavigator() || "en"
+            : setDialectIfMatchesBrowserLocale(fromStorage);
 
-    return setDialectIfMatchesBrowserLocale(fromStorage);
+    return usableLocale(code) ? code : "en";
 }
 
 export async function setLocale(code: string): Promise<void> {

--- a/frontend/app/src/i18n/i18n.ts
+++ b/frontend/app/src/i18n/i18n.ts
@@ -114,28 +114,14 @@ register("pl", () => import("./pl.json"));
 register("fa", () => import("./fa.json"));
 register("ar", () => import("./ar.json"));
 
-// svelte-i18n's init() passes initialLocale through Intl.getCanonicalLocales, which throws a
-// RangeError on a tag it cannot parse - an empty string, or the underscore form ("zh_CN") some
-// Android WebViews report as navigator.language. The throw escapes init(), so no locale is ever
-// set and the first message the app formats kills it with "Cannot format a message without first
-// setting the initial locale".
-function usableLocale(code: string): boolean {
-    try {
-        return Intl.getCanonicalLocales(code).length > 0;
-    } catch {
-        return false;
-    }
-}
-
 export function getStoredLocale(): string {
     const fromStorage = localStorage.getItem(configKeys.locale);
 
-    const code =
-        fromStorage === null
-            ? getLocaleFromNavigator() || "en"
-            : setDialectIfMatchesBrowserLocale(fromStorage);
+    if (fromStorage === null) {
+        return getLocaleFromNavigator() || "en";
+    }
 
-    return usableLocale(code) ? code : "en";
+    return setDialectIfMatchesBrowserLocale(fromStorage);
 }
 
 export async function setLocale(code: string): Promise<void> {

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/icpSwap.pool.client.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/icpSwap.pool.client.ts
@@ -18,7 +18,7 @@ export class IcpSwapPoolClient
         super(identity, agent, canisterId, idlFactory, "IcpSwapPool");
     }
 
-    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint> {
+    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint | undefined> {
         const zeroForOne = this.zeroForOne(inputToken, outputToken);
         const args = {
             amountIn: amountIn.toString(),

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.spec.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { quoteResponse } from "./mappers";
+
+// A decline (undefined) is dropped by quoteSwap and costs nothing; a throw is retried by
+// executeQuery seven times with backoff and, if every pool throws, reaches the error tracker.
+// Which ICPSwap variants land on which side is therefore load-bearing.
+describe("ICPSwap quoteResponse", () => {
+    test("a quote is returned as is", () => {
+        expect(quoteResponse({ ok: 123n })).toBe(123n);
+    });
+
+    test("InsufficientFunds and UnsupportedToken are declines", () => {
+        expect(quoteResponse({ err: { InsufficientFunds: null } })).toBeUndefined();
+        expect(quoteResponse({ err: { UnsupportedToken: "x" } })).toBeUndefined();
+    });
+
+    test("the dust-amount InternalError is a decline (the payload behind Rollbar #31881)", () => {
+        expect(
+            quoteResponse({
+                err: { InternalError: "The amount of input token is too small." },
+            }),
+        ).toBeUndefined();
+    });
+
+    test("any other InternalError, and CommonError, still throw so they are retried", () => {
+        expect(() => quoteResponse({ err: { InternalError: "pool is paused" } })).toThrow(
+            /Unable to get quote/,
+        );
+        expect(() => quoteResponse({ err: { CommonError: null } })).toThrow(/Unable to get quote/);
+    });
+});

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
@@ -1,8 +1,14 @@
 import type { ApiQuoteResponse } from "./candid/idl";
 
-export function quoteResponse(candid: ApiQuoteResponse): bigint {
+// A decoded `err` variant is ICPSwap declining to quote - "amount of input token is too small"
+// is the usual reason - and is returned as undefined rather than thrown. Throwing here made a
+// decline indistinguishable from a transport failure: executeQuery retried it seven times with
+// backoff (roughly twelve seconds for a dust amount), quoteSwap could not tell "every pool
+// declined" from "every pool is down", and the error tracker filled with non-events.
+export function quoteResponse(candid: ApiQuoteResponse): bigint | undefined {
     if ("ok" in candid) {
         return candid.ok;
     }
-    throw new Error("Unable to get quote from ICPSwap: " + JSON.stringify(candid));
+    console.debug("ICPSwap declined to quote: ", candid);
+    return undefined;
 }

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
@@ -1,4 +1,5 @@
 import type { ApiQuoteResponse } from "./candid/idl";
+import type { Error as ApiQuoteError } from "./candid/types";
 
 // A decoded `err` variant is ICPSwap declining to quote - "amount of input token is too small"
 // is the usual reason - and is returned as undefined rather than thrown. Throwing here made a
@@ -9,6 +10,20 @@ export function quoteResponse(candid: ApiQuoteResponse): bigint | undefined {
     if ("ok" in candid) {
         return candid.ok;
     }
-    console.debug("ICPSwap declined to quote: ", candid);
-    return undefined;
+    if (isDecline(candid.err)) {
+        console.debug("ICPSwap declined to quote: ", candid.err);
+        return undefined;
+    }
+    throw new Error("Unable to get quote from ICPSwap: " + JSON.stringify(candid));
+}
+
+// Which `err` variants mean "this pool will not quote this request" as opposed to "this pool
+// failed to answer". InsufficientFunds and UnsupportedToken are declines by definition.
+// InternalError is nominally a failure, but ICPSwap reports the commonest decline of all through
+// it - `{"InternalError":"The amount of input token is too small."}` is the exact payload behind
+// Rollbar #31881 - so that one message is a decline too. Anything else keeps throwing, which
+// keeps executeQuery's retries for a pool that is genuinely struggling.
+function isDecline(err: ApiQuoteError): boolean {
+    if ("InsufficientFunds" in err || "UnsupportedToken" in err) return true;
+    return "InternalError" in err && /too small/i.test(err.InternalError);
 }

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -66,15 +66,12 @@ export class DexesAgent {
                 ),
             ),
         );
-        const succeeded = quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
-
-        // Every pool failing is not the same thing as every pool declining. A candid change or a
-        // DEX outage takes them all out at once, and swallowing that would show the user "no
-        // quotes" while nothing reached the error tracker. Rethrow so it stays visible.
-        if (succeeded.length === 0 && quotes.length > 0) {
-            throw (quotes[0] as PromiseRejectedResult).reason;
-        }
-        return succeeded;
+        // No rethrow when they all fail. A DEX declines by throwing - ICPSwap's mapper throws on
+        // any non-ok variant, "amount of input token is too small" included - and a pair usually
+        // has a single pool, so "every pool failed" is the ordinary dust-amount case, not an
+        // outage. Rethrowing there just reinstated the noise this change exists to remove.
+        // `getAllSwapPools` above already swallows a DEX being unreachable for the same reason.
+        return quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
     }
 
     private getAllSwapPools(swapProviders: DexId[]): Promise<TokenSwapPool[]> {

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -67,13 +67,15 @@ export class DexesAgent {
             ),
         );
         // A pool that declines resolves to undefined and is dropped; a pool that fails rejects.
-        // The two now mean different things, so when every pool rejected it is an outage or a
-        // candid change, not a dust amount, and must surface rather than read as "no quotes".
+        // The two mean different things: with no quote in hand, a failure anywhere is what stopped
+        // the user getting one, and must surface rather than read as "no quotes". (Requiring every
+        // pool to have rejected let one decline plus one failure through as silence.)
         const succeeded = quotes.flatMap((q) =>
             q.status === "fulfilled" && q.value !== undefined ? [q.value] : [],
         );
-        if (succeeded.length === 0 && quotes.length > 0 && quotes.every((q) => q.status === "rejected")) {
-            throw (quotes[0] as PromiseRejectedResult).reason;
+        const failed = quotes.find((q): q is PromiseRejectedResult => q.status === "rejected");
+        if (succeeded.length === 0 && failed !== undefined) {
+            throw failed.reason;
         }
         return succeeded;
     }

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -55,13 +55,19 @@ export class DexesAgent {
     ): Promise<[DexId, bigint][]> {
         const pools = await this.getSwapPools(inputToken, new Set([outputToken]), swapProviders);
 
-        return await Promise.all(
+        // A pool that cannot quote is a normal answer, not a failure: the commonest case is an
+        // amount too small for that pool's fee, and pools also go dry or get retired. Dropping it
+        // lets the remaining pools still be quoted, and an empty result already means "no quotes"
+        // to the caller. Promise.all here failed the whole request on any one pool's rejection,
+        // and reported it.
+        const quotes = await Promise.allSettled(
             pools.map((p) =>
                 this.quoteSingle(p, inputToken, outputToken, amountIn).then(
                     (quote) => [p.dex, quote] as [DexId, bigint],
                 ),
             ),
         );
+        return quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
     }
 
     private getAllSwapPools(swapProviders: DexId[]): Promise<TokenSwapPool[]> {

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -61,17 +61,21 @@ export class DexesAgent {
         // to the caller. Promise.all here failed the whole request on any one pool's rejection.
         const quotes = await Promise.allSettled(
             pools.map((p) =>
-                this.quoteSingle(p, inputToken, outputToken, amountIn).then(
-                    (quote) => [p.dex, quote] as [DexId, bigint],
+                this.quoteSingle(p, inputToken, outputToken, amountIn).then((quote) =>
+                    quote === undefined ? undefined : ([p.dex, quote] as [DexId, bigint]),
                 ),
             ),
         );
-        // No rethrow when they all fail. A DEX declines by throwing - ICPSwap's mapper throws on
-        // any non-ok variant, "amount of input token is too small" included - and a pair usually
-        // has a single pool, so "every pool failed" is the ordinary dust-amount case, not an
-        // outage. Rethrowing there just reinstated the noise this change exists to remove.
-        // `getAllSwapPools` above already swallows a DEX being unreachable for the same reason.
-        return quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
+        // A pool that declines resolves to undefined and is dropped; a pool that fails rejects.
+        // The two now mean different things, so when every pool rejected it is an outage or a
+        // candid change, not a dust amount, and must surface rather than read as "no quotes".
+        const succeeded = quotes.flatMap((q) =>
+            q.status === "fulfilled" && q.value !== undefined ? [q.value] : [],
+        );
+        if (succeeded.length === 0 && quotes.length > 0 && quotes.every((q) => q.status === "rejected")) {
+            throw (quotes[0] as PromiseRejectedResult).reason;
+        }
+        return succeeded;
     }
 
     private getAllSwapPools(swapProviders: DexId[]): Promise<TokenSwapPool[]> {
@@ -103,7 +107,7 @@ export class DexesAgent {
         inputToken: string,
         outputToken: string,
         amountIn: bigint,
-    ): Promise<bigint> {
+    ): Promise<bigint | undefined> {
         const indexClient = this._swapIndexClients[pool.dex];
         if (indexClient === undefined) {
             return Promise.resolve(BigInt(0));
@@ -129,5 +133,7 @@ export interface SwapIndexClient {
 }
 
 export interface SwapPoolClient {
-    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint>;
+    // undefined when the pool declines to quote (amount too small, no liquidity); reject only
+    // for a failure to ask
+    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint | undefined>;
 }

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -58,8 +58,7 @@ export class DexesAgent {
         // A pool that cannot quote is a normal answer, not a failure: the commonest case is an
         // amount too small for that pool's fee, and pools also go dry or get retired. Dropping it
         // lets the remaining pools still be quoted, and an empty result already means "no quotes"
-        // to the caller. Promise.all here failed the whole request on any one pool's rejection,
-        // and reported it.
+        // to the caller. Promise.all here failed the whole request on any one pool's rejection.
         const quotes = await Promise.allSettled(
             pools.map((p) =>
                 this.quoteSingle(p, inputToken, outputToken, amountIn).then(
@@ -67,7 +66,15 @@ export class DexesAgent {
                 ),
             ),
         );
-        return quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
+        const succeeded = quotes.flatMap((q) => (q.status === "fulfilled" ? [q.value] : []));
+
+        // Every pool failing is not the same thing as every pool declining. A candid change or a
+        // DEX outage takes them all out at once, and swallowing that would show the user "no
+        // quotes" while nothing reached the error tracker. Rethrow so it stays visible.
+        if (succeeded.length === 0 && quotes.length > 0) {
+            throw (quotes[0] as PromiseRejectedResult).reason;
+        }
+        return succeeded;
     }
 
     private getAllSwapPools(swapProviders: DexId[]): Promise<TokenSwapPool[]> {

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -77,6 +77,14 @@ export class DexesAgent {
         if (succeeded.length === 0 && failed !== undefined) {
             throw failed.reason;
         }
+        // Some pool quoted, so the user gets a price - but a pool that failed after its retries
+        // while another answered is a DEX that is down, and the "best" quote shown may not be.
+        // Not worth failing the swap over; worth knowing about.
+        quotes.forEach((q, i) => {
+            if (q.status === "rejected") {
+                console.warn(`quoteSwap: ${pools[i].dex} pool failed, quoting without it`, q.reason);
+            }
+        });
         return succeeded;
     }
 

--- a/frontend/openchat-agent/src/services/error.spec.ts
+++ b/frontend/openchat-agent/src/services/error.spec.ts
@@ -12,7 +12,9 @@ import {
     DestinationInvalidError,
     HttpError,
     InvalidDelegationError,
+    SessionExpiryError,
 } from "@shared";
+import { Principal } from "@icp-sdk/core/principal";
 import { toCanisterResponseError } from "./error";
 
 // An expired session is the default - only the delegation tests need a live one
@@ -26,6 +28,19 @@ function reject(rejectCode: ReplicaRejectCode, message: string, errorCode?: stri
 }
 
 describe("toCanisterResponseError", () => {
+    // An anonymous identity has no delegation, so its "expiry" is 0 and every ProtocolError used
+    // to classify as an expired session. Now that a session-expiry error logs the user out, that
+    // would reload a logged-out visitor on every 503 or clock-skew 400 and loop.
+    test("a protocol error for an anonymous identity is not an expired session", () => {
+        const anonymous = { getPrincipal: () => Principal.anonymous() } as unknown as Identity;
+        const error = toCanisterResponseError(
+            ProtocolError.fromCode(new HttpErrorCode(503, "Service Unavailable", [], "")),
+            anonymous,
+        );
+        expect(error).not.toBeInstanceOf(SessionExpiryError);
+        expect(error).toBeInstanceOf(HttpError);
+    });
+
     // A query to a deleted group/community canister is rejected with `DestinationInvalid`. It must
     // be mapped to `DestinationInvalidError` so that the retry loop is short-circuited - retrying
     // can never succeed, and 7 retries with exponential backoff blocks the chat from loading.

--- a/frontend/openchat-agent/src/services/error.ts
+++ b/frontend/openchat-agent/src/services/error.ts
@@ -139,8 +139,13 @@ function classifyError(
         if (error.cause.code instanceof HttpErrorCode) {
             code = error.cause.code.status;
         }
-        const timeUntilSessionExpiryMs = getSessionExpiryMs(identity) - Date.now();
-        if (timeUntilSessionExpiryMs < 0) {
+        // An anonymous identity has no delegation, so getSessionExpiryMs returns 0 and every
+        // ProtocolError would look like an expired session. It is not one: nothing to log out
+        // of, and now that a session-expiry error triggers a logout, a 503 or a skewed clock on
+        // a logged-out visitor would reload the page, fail the same poll again, and loop.
+        const expiryMs = getSessionExpiryMs(identity);
+        const timeUntilSessionExpiryMs = expiryMs - Date.now();
+        if (expiryMs > 0 && timeUntilSessionExpiryMs < 0) {
             console.debug(
                 "SESSION: we received a 400 response and the session has timed out: ",
                 timeUntilSessionExpiryMs,

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -1239,7 +1239,17 @@ function makeCommunitySerializable(community: CommunitySummary): CommunitySummar
 // unusable instead and let `getUpdates` fall through to `getInitialState`, which is what the
 // staleness check above already does.
 function cachedChatsAreUsable(chats: ChatStateFull): boolean {
-    if (!Array.isArray(chats.directChats)) return false;
+    // `getUpdates` iterates all three of these inside the Stream initialiser, where a throw
+    // wedges the load rather than surfacing. No record missing groupChats or communities has
+    // been seen - the write is atomic - but the shape of the failure is the same, and checking
+    // is cheaper than the launch loop it would cause.
+    if (
+        !Array.isArray(chats.directChats) ||
+        !Array.isArray(chats.groupChats) ||
+        !Array.isArray(chats.communities)
+    ) {
+        return false;
+    }
     return chats.directChats.every((c) => c?.them !== undefined && c?.membership !== undefined);
 }
 

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -22,7 +22,6 @@ import type {
     CurrentUserSummary,
     DataContent,
     DiamondMembershipStatus,
-    DirectChatSummary,
     EventWrapper,
     EventsResponse,
     EventsSuccessResult,
@@ -55,7 +54,6 @@ import {
     chatIdentifiersEqual,
     emptyEventsResponse,
     isSuccessfulEventsResponse,
-    nullMembership,
     updateCreatedUser,
 } from "@shared";
 import { IndexedDbConnectionManager } from "./indexedDb";
@@ -338,9 +336,11 @@ export class ChatsDb {
             }
             return undefined;
         }
-        if (chats === undefined) return undefined;
-
-        return { ...chats, directChats: chats.directChats.map(repairCachedDirectChat) };
+        if (chats !== undefined && !cachedChatsAreUsable(chats)) {
+            await resolvedDb.clear("chats");
+            return undefined;
+        }
+        return chats;
     }
 
     async setCachedChats(
@@ -1218,17 +1218,16 @@ function makeCommunitySerializable(community: CommunitySummary): CommunitySummar
 // The cache is the one place a chat summary enters the agent without a mapper having built it:
 // every other route comes from candid. A record written by an older build (or a partial write)
 // can therefore be missing fields the type says are always there, and the app then dies reading
-// `them.userId` or `membership.readByMeUpTo` seconds after load. Both are recoverable without
-// the server - a direct chat's `them` is the same identifier as its `id` - so repair rather than
-// drop, which would hide the chat until the next server update mentioned it.
-function repairCachedDirectChat(chat: DirectChatSummary): DirectChatSummary {
-    if (chat.them !== undefined && chat.membership !== undefined) return chat;
-
-    return {
-        ...chat,
-        them: chat.them ?? chat.id,
-        membership: chat.membership ?? nullMembership(),
-    };
+// `them.userId` or `membership.readByMeUpTo` seconds after load.
+//
+// There is no safe local repair. `membership` cannot be invented - the role, read-up-to and mute
+// state are the server's to say. Dropping just the bad record is worse than it looks: the cached
+// list is the base `mergeDirectChatUpdates` applies deltas to, so a chat removed from it stays
+// gone until the server happens to send an update mentioning it. Treat the whole cache as
+// unusable instead and let `getUpdates` fall through to `getInitialState`, which is what the
+// staleness check above already does.
+function cachedChatsAreUsable(chats: ChatStateFull): boolean {
+    return chats.directChats.every((c) => c.them !== undefined && c.membership !== undefined);
 }
 
 function makeChatSummarySerializable<T extends ChatSummary>(chat: T): T {

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -325,22 +325,34 @@ export class ChatsDb {
         this.getDb().then((db) => db.put("bots", bots, this.principalString));
     }
 
+    // Never throws. `getUpdates` calls this from inside a `Stream` initialiser, which does not
+    // catch a rejected async initialiser: neither onResult nor onError would fire and the caller
+    // would await a load that never completes, on every launch. Returning undefined costs a full
+    // initial load; wedging the app costs everything.
     async getCachedChats(): Promise<ChatStateFull | undefined> {
-        const resolvedDb = await this.getDb();
-        const chats = await resolvedDb.get("chats", this.principalString);
+        try {
+            const resolvedDb = await this.getDb();
+            const chats = await resolvedDb.get("chats", this.principalString);
 
-        if (chats && chats.latestUserCanisterUpdates < BigInt(Date.now() - 30 * ONE_DAY)) {
-            const storeNames = resolvedDb.objectStoreNames;
-            for (let i = 0; i < storeNames.length; i++) {
-                await resolvedDb.clear(storeNames[i]);
+            // `== null`: a corrupt IndexedDB has been seen returning null rather than undefined
+            if (chats == null) return undefined;
+
+            if (chats.latestUserCanisterUpdates < BigInt(Date.now() - 30 * ONE_DAY)) {
+                const storeNames = resolvedDb.objectStoreNames;
+                for (let i = 0; i < storeNames.length; i++) {
+                    await resolvedDb.clear(storeNames[i]);
+                }
+                return undefined;
             }
+            if (!cachedChatsAreUsable(chats)) {
+                await resolvedDb.clear("chats");
+                return undefined;
+            }
+            return chats;
+        } catch (err) {
+            console.error("CACHE: unable to read cached chats, falling back to a full load", err);
             return undefined;
         }
-        if (chats !== undefined && !cachedChatsAreUsable(chats)) {
-            await resolvedDb.clear("chats");
-            return undefined;
-        }
-        return chats;
     }
 
     async setCachedChats(
@@ -1227,7 +1239,8 @@ function makeCommunitySerializable(community: CommunitySummary): CommunitySummar
 // unusable instead and let `getUpdates` fall through to `getInitialState`, which is what the
 // staleness check above already does.
 function cachedChatsAreUsable(chats: ChatStateFull): boolean {
-    return chats.directChats.every((c) => c.them !== undefined && c.membership !== undefined);
+    if (!Array.isArray(chats.directChats)) return false;
+    return chats.directChats.every((c) => c?.them !== undefined && c?.membership !== undefined);
 }
 
 function makeChatSummarySerializable<T extends ChatSummary>(chat: T): T {

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -1246,11 +1246,16 @@ function cachedChatsAreUsable(chats: ChatStateFull): boolean {
     if (
         !Array.isArray(chats.directChats) ||
         !Array.isArray(chats.groupChats) ||
-        !Array.isArray(chats.communities)
+        !Array.isArray(chats.communities) ||
+        // the staleness check above compares this with `<`; against undefined that is simply
+        // false, so a record with no timestamp would sail through as fresh
+        typeof chats.latestUserCanisterUpdates !== "bigint"
     ) {
         return false;
     }
-    return chats.directChats.every((c) => c?.them !== undefined && c?.membership !== undefined);
+    return chats.directChats.every(
+        (c) => c?.id?.userId !== undefined && c?.them !== undefined && c?.membership !== undefined,
+    );
 }
 
 function makeChatSummarySerializable<T extends ChatSummary>(chat: T): T {

--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -22,6 +22,7 @@ import type {
     CurrentUserSummary,
     DataContent,
     DiamondMembershipStatus,
+    DirectChatSummary,
     EventWrapper,
     EventsResponse,
     EventsSuccessResult,
@@ -54,6 +55,7 @@ import {
     chatIdentifiersEqual,
     emptyEventsResponse,
     isSuccessfulEventsResponse,
+    nullMembership,
     updateCreatedUser,
 } from "@shared";
 import { IndexedDbConnectionManager } from "./indexedDb";
@@ -336,7 +338,9 @@ export class ChatsDb {
             }
             return undefined;
         }
-        return chats;
+        if (chats === undefined) return undefined;
+
+        return { ...chats, directChats: chats.directChats.map(repairCachedDirectChat) };
     }
 
     async setCachedChats(
@@ -1208,6 +1212,22 @@ function makeCommunitySerializable(community: CommunitySummary): CommunitySummar
         channels,
         avatar,
         banner,
+    };
+}
+
+// The cache is the one place a chat summary enters the agent without a mapper having built it:
+// every other route comes from candid. A record written by an older build (or a partial write)
+// can therefore be missing fields the type says are always there, and the app then dies reading
+// `them.userId` or `membership.readByMeUpTo` seconds after load. Both are recoverable without
+// the server - a direct chat's `them` is the same identifier as its `id` - so repair rather than
+// drop, which would hide the chat until the next server update mentioned it.
+function repairCachedDirectChat(chat: DirectChatSummary): DirectChatSummary {
+    if (chat.them !== undefined && chat.membership !== undefined) return chat;
+
+    return {
+        ...chat,
+        them: chat.them ?? chat.id,
+        membership: chat.membership ?? nullMembership(),
     };
 }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1368,7 +1368,20 @@ export class OpenChat {
         );
     }
 
-    async logout(): Promise<void> {
+    #logoutPromise: Promise<void> | undefined;
+
+    // Idempotent. An expired session now reaches this twice, deterministically: the worker agent
+    // publishes sessionExpired and then rejects the request, and if nothing catches that the
+    // window's unhandledrejection handler calls logout again. A second run sent a second worker
+    // logout, cleared the agent and navigated within milliseconds - while the first was still in
+    // its pre-logout window removing the push token, which then failed with "Worker has no agent"
+    // and left the Android token registered to a signed-out user.
+    logout(): Promise<void> {
+        this.#logoutPromise ??= this.#doLogout();
+        return this.#logoutPromise;
+    }
+
+    async #doLogout(): Promise<void> {
         // Run any registered pre-logout tasks (e.g. push-token cleanup) while
         // the identity is still valid. Best-effort: Promise.resolve().then wraps
         // each task so a synchronous throw becomes a rejection that allSettled
@@ -1386,8 +1399,11 @@ export class OpenChat {
         // whatever the teardown does. `finally` alone is not enough: the worker's logout awaits
         // three sequential IndexedDB deletes with no timeout, so a wedged IndexedDB - the very
         // case this path exists for - leaves the Promise pending and `finally` never runs. Cap
-        // it the same way the pre-logout tasks are capped. Reloading re-evaluates auth anyway,
-        // and a stuck tab on a dead session has no way forward at all.
+        // it the same way the pre-logout tasks are capped.
+        // Known edge: if IndexedDB is blocked for longer than the cap, navigating can cut the
+        // auth client's delegation delete short, and startup may sign the user back in from the
+        // surviving delegation. Narrow, and no worse than the manual reload it replaces, but
+        // it is a consequence of choosing "always navigate" over "sometimes never".
         try {
             await this.#withTimeout(
                 Promise.allSettled([

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1382,10 +1382,19 @@ export class OpenChat {
             5000,
         );
 
-        await Promise.all([
-            this.#worker.send({ kind: "logout" }),
-            this.#authClient.then((c) => c.logout()),
-        ]).then(() => window.location.replace("/"));
+        // `finally`: the navigation is what actually ends the session for the user, so it must
+        // happen even if tearing down the worker or the auth client fails. Both are IndexedDB
+        // backed and do fail. Without this a rejected teardown left the tab sitting on a dead
+        // session with no way forward - and, since `sessionExpired` only fires once per page,
+        // no second attempt either. Reloading re-evaluates auth from scratch.
+        try {
+            await Promise.all([
+                this.#worker.send({ kind: "logout" }),
+                this.#authClient.then((c) => c.logout()),
+            ]);
+        } finally {
+            window.location.replace("/");
+        }
     }
 
     unreadThreadMessageCount(

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1382,16 +1382,20 @@ export class OpenChat {
             5000,
         );
 
-        // `finally`: the navigation is what actually ends the session for the user, so it must
-        // happen even if tearing down the worker or the auth client fails. Both are IndexedDB
-        // backed and do fail. Without this a rejected teardown left the tab sitting on a dead
-        // session with no way forward - and, since `sessionExpired` only fires once per page,
-        // no second attempt either. Reloading re-evaluates auth from scratch.
+        // The navigation is what actually ends the session for the user, so it must happen
+        // whatever the teardown does. `finally` alone is not enough: the worker's logout awaits
+        // three sequential IndexedDB deletes with no timeout, so a wedged IndexedDB - the very
+        // case this path exists for - leaves the Promise pending and `finally` never runs. Cap
+        // it the same way the pre-logout tasks are capped. Reloading re-evaluates auth anyway,
+        // and a stuck tab on a dead session has no way forward at all.
         try {
-            await Promise.all([
-                this.#worker.send({ kind: "logout" }),
-                this.#authClient.then((c) => c.logout()),
-            ]);
+            await this.#withTimeout(
+                Promise.allSettled([
+                    this.#worker.send({ kind: "logout" }),
+                    this.#authClient.then((c) => c.logout()),
+                ]),
+                5000,
+            );
         } finally {
             window.location.replace("/");
         }

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -6791,7 +6791,7 @@ export class OpenChat {
         const webhooks = new Set<string>();
         chats.forEach((chat) => {
             if (chat.kind === "direct_chat") {
-                userIds.add(chat.them.userId);
+                userIds.add(chat.them?.userId ?? chat.id.userId);
             } else if (chat.latestMessage?.event !== undefined) {
                 const sender = chat.latestMessage.event.sender;
                 if (chat.latestMessage.event.senderContext?.kind === "webhook") {
@@ -7284,7 +7284,7 @@ export class OpenChat {
                 } else {
                     messagesRead.syncWithServer(
                         chat.id,
-                        chat.membership.readByMeUpTo,
+                        chat.membership?.readByMeUpTo,
                         [],
                         undefined,
                     );

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1404,14 +1404,30 @@ export class OpenChat {
         // auth client's delegation delete short, and startup may sign the user back in from the
         // surviving delegation. Narrow, and no worse than the manual reload it replaces, but
         // it is a consequence of choosing "always navigate" over "sometimes never".
+        // allSettled so one step failing cannot stop the other, but never silently: a failed
+        // delegation delete means the user navigates away with the delegation still on disk, and
+        // that used to reach the error tracker as an unhandled rejection.
+        const teardown = Promise.allSettled([
+            this.#worker.send({ kind: "logout" }),
+            this.#authClient.then((c) => c.logout()),
+        ]).then((results) => {
+            const names = ["worker logout", "auth client logout"];
+            results.forEach((r, i) => {
+                if (r.status === "rejected") {
+                    this.#logger.error(`Logout: ${names[i]} failed`, r.reason);
+                }
+            });
+        });
         try {
-            await this.#withTimeout(
-                Promise.allSettled([
-                    this.#worker.send({ kind: "logout" }),
-                    this.#authClient.then((c) => c.logout()),
-                ]),
-                5000,
-            );
+            let settled = false;
+            teardown.finally(() => (settled = true));
+            await this.#withTimeout(teardown, 5000);
+            if (!settled) {
+                this.#logger.error(
+                    "Logout: teardown did not settle within 5s, navigating anyway",
+                    new Error("logout teardown timed out"),
+                );
+            }
         } finally {
             window.location.replace("/");
         }

--- a/frontend/openchat-client/src/workerAgent.ts
+++ b/frontend/openchat-client/src/workerAgent.ts
@@ -7,7 +7,7 @@ import type {
     WorkerResponse,
     WorkerResult,
 } from "@shared";
-import { ONE_MINUTE_MILLIS, Stream } from "@shared";
+import { ONE_MINUTE_MILLIS, Stream, publish, requiresLogout } from "@shared";
 import type { OpenChatConfig } from "./config";
 import { snapshot } from "./snapshot.svelte";
 import { messagesRead, storageStore } from "./state";
@@ -19,6 +19,7 @@ export class WorkerAgent {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly #inflightRequests: Map<number, PromiseResolver<any>> = new Map();
     readonly #logger: Logger;
+    #sessionExpired = false;
     nextCorrelationId: number = 0;
 
     constructor(config: OpenChatConfig) {
@@ -164,9 +165,22 @@ export class WorkerAgent {
     }
 
     #resolveError(data: WorkerError): void {
+        const error = JSON.parse(data.error);
+
+        // A request rejected because the session is gone only logged the user out if nobody
+        // caught it and it reached the window's unhandledrejection handler. Background pollers
+        // catch their own failures, so an expired delegation left the client polling on a timer
+        // for as long as the tab stayed open - thousands of identical failures from one client.
+        // Only once: a burst of pollers all fail together when a delegation expires, and logout
+        // ends in a page navigation.
+        if (!this.#sessionExpired && requiresLogout(error)) {
+            this.#sessionExpired = true;
+            publish("sessionExpired");
+        }
+
         const promise = this.#inflightRequests.get(data.correlationId);
         if (promise !== undefined) {
-            promise.reject(JSON.parse(data.error));
+            promise.reject(error);
             this.#inflightRequests.delete(data.correlationId);
         } else {
             this.#logUnexpected(data.requestKind, data.correlationId);

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -109,6 +109,28 @@ describe("shouldReportError", () => {
         expect(shouldReportError(lost)).toBe(false);
     });
 
+    test("silences a wrong client clock in both directions", () => {
+        // the client's clock is ahead, so the certificate the replica signed looks like the future
+        expect(
+            shouldReportError(
+                new Error("Certificate is signed more than 5 minutes in the future."),
+            ),
+        ).toBe(false);
+        // the client's clock is behind, so the expiry it computed is outside the replica's window
+        expect(
+            shouldReportError(
+                new HttpError(
+                    400,
+                    new Error(
+                        "Invalid request expiry: Minimum allowed expiry: 2026-09-08 01:43:31 UTC, " +
+                            "Maximum allowed expiry: 2026-09-08 01:49:01 UTC, " +
+                            "Provided expiry: 2026-08-26 04:23:00 UTC.",
+                    ),
+                ),
+            ),
+        ).toBe(false);
+    });
+
     test("silences the IC agent giving up after its fetch retries", () => {
         expect(
             shouldReportError(

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -58,11 +58,23 @@ const REQWEST_NOISE_PATTERN = /error decoding response body/i;
 
 const RETRY_EXHAUSTED_PATTERN = /retry strategy exhausted after \d+ attempts/i;
 
+// Every HttpError subclass overwrites `name` with its own, so a bare `name === "HttpError"` test
+// misses them. `code` only means an HTTP status on one of these.
+const HTTP_ERROR_NAMES = new Set<string>([
+    "HttpError",
+    "AuthError",
+    "DestinationInvalidError",
+    "CanisterUnavailableError",
+    "ResponseTooLargeError",
+]);
+
 function isTransientNetworkError(error: unknown): boolean {
     // Structural checks rather than instanceof: errors which crossed the worker boundary
     // arrive as plain objects where only name/message/code survive
     const name = errorName(error);
-    if (name === "HttpError") {
+    if (HTTP_ERROR_NAMES.has(name)) {
+        // 503 also covers CanisterUnavailableError: a frozen or uninstalled canister cannot
+        // recover inside one request, and server-side monitoring owns the incident.
         const code = Number((error as { code?: unknown }).code);
         if (code >= 502 && code <= 504) return true;
     }
@@ -102,6 +114,11 @@ const ENVIRONMENT_NOISE_PATTERNS: RegExp[] = [
     /connection to indexed database server lost/i,
     // The client's clock is wrong, so the replica certificate looks like it is from the future
     /certificate is signed more than 5 minutes in the future/i,
+    // The same wrong clock seen from the other side: the ingress expiry the agent computed from
+    // Date.now() falls outside the window the replica will accept. Devices weeks or months out of
+    // date produce these in storms, and because the replica echoes the timestamps back in the
+    // message, every skewed device mints a new error item rather than joining an existing one.
+    /invalid request expiry/i,
     // Safari's built-in media controls script, no frame of ours involved
     /can't find variable: EmptyRanges/i,
     // Benign browser warning surfaced as an error event

--- a/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
@@ -1,6 +1,12 @@
 import { Principal } from "@icp-sdk/core/principal";
 import { describe, expect, test } from "vitest";
-import { encodeIcrcAccount, icrcAccountToUserId, userIdToIcrcAccount } from "./icrcAccount";
+import {
+    bigEndianCrc32,
+    encodeIcrcAccount,
+    icrcAccountToUserId,
+    userIdToIcrcAccount,
+} from "./icrcAccount";
+import { isAccountIdentifierValid } from "./string";
 
 const canisterId = "dfdal-2uaaa-aaaaa-qaama-cai";
 
@@ -111,3 +117,28 @@ function subaccountOf(index: number): Uint8Array {
 function toHex(bytes: Uint8Array): string {
     return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
+
+// ICP ledger account identifiers carry a big-endian CRC32 of the hash in their first four bytes.
+// The canister checks it (AccountIdentifier::from_slice); a client that only checked length and
+// hex let a typo through to be rejected after the user had been told the address was fine.
+describe("isAccountIdentifierValid", () => {
+    const hash = new Uint8Array(28).map((_, i) => (i * 37 + 11) & 0xff);
+    const hex = (bytes: Uint8Array) =>
+        [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+    const valid = hex(bigEndianCrc32(hash)) + hex(hash);
+
+    test("accepts an identifier whose checksum matches", () => {
+        expect(valid.length).toBe(64);
+        expect(isAccountIdentifierValid(valid)).toBe(true);
+    });
+
+    test("rejects a single-character typo", () => {
+        const typo = valid.slice(0, 40) + (valid[40] === "0" ? "1" : "0") + valid.slice(41);
+        expect(isAccountIdentifierValid(typo)).toBe(false);
+    });
+
+    test("still rejects the wrong length or non-hex", () => {
+        expect(isAccountIdentifierValid(valid.slice(1))).toBe(false);
+        expect(isAccountIdentifierValid("zz" + valid.slice(2))).toBe(false);
+    });
+});

--- a/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.spec.ts
@@ -1,12 +1,6 @@
 import { Principal } from "@icp-sdk/core/principal";
 import { describe, expect, test } from "vitest";
-import {
-    bigEndianCrc32,
-    encodeIcrcAccount,
-    icrcAccountToUserId,
-    userIdToIcrcAccount,
-} from "./icrcAccount";
-import { isAccountIdentifierValid } from "./string";
+import { encodeIcrcAccount, icrcAccountToUserId, userIdToIcrcAccount } from "./icrcAccount";
 
 const canisterId = "dfdal-2uaaa-aaaaa-qaama-cai";
 
@@ -117,28 +111,3 @@ function subaccountOf(index: number): Uint8Array {
 function toHex(bytes: Uint8Array): string {
     return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
-
-// ICP ledger account identifiers carry a big-endian CRC32 of the hash in their first four bytes.
-// The canister checks it (AccountIdentifier::from_slice); a client that only checked length and
-// hex let a typo through to be rejected after the user had been told the address was fine.
-describe("isAccountIdentifierValid", () => {
-    const hash = new Uint8Array(28).map((_, i) => (i * 37 + 11) & 0xff);
-    const hex = (bytes: Uint8Array) =>
-        [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
-    const valid = hex(bigEndianCrc32(hash)) + hex(hash);
-
-    test("accepts an identifier whose checksum matches", () => {
-        expect(valid.length).toBe(64);
-        expect(isAccountIdentifierValid(valid)).toBe(true);
-    });
-
-    test("rejects a single-character typo", () => {
-        const typo = valid.slice(0, 40) + (valid[40] === "0" ? "1" : "0") + valid.slice(41);
-        expect(isAccountIdentifierValid(typo)).toBe(false);
-    });
-
-    test("still rejects the wrong length or non-hex", () => {
-        expect(isAccountIdentifierValid(valid.slice(1))).toBe(false);
-        expect(isAccountIdentifierValid("zz" + valid.slice(2))).toBe(false);
-    });
-});

--- a/frontend/openchat-shared/src/utils/icrcAccount.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.ts
@@ -61,7 +61,7 @@ function encodeCrc({ owner, subaccount }: Required<IcrcAccount>): string {
     return encodeBase32(checksum);
 }
 
-export function bigEndianCrc32(bytes: Uint8Array): Uint8Array {
+function bigEndianCrc32(bytes: Uint8Array): Uint8Array {
     let crc = 0xffffffff;
 
     for (const byte of bytes) {
@@ -109,7 +109,7 @@ function uint8ArrayToHexString(bytes: Uint8Array): string {
     return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-export function hexStringToUint8Array(hex: string): Uint8Array {
+function hexStringToUint8Array(hex: string): Uint8Array {
     if (hex.length % 2 !== 0 || /[^0-9a-f]/i.test(hex)) {
         throw new Error("Invalid account. Invalid subaccount.");
     }

--- a/frontend/openchat-shared/src/utils/icrcAccount.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.ts
@@ -61,7 +61,7 @@ function encodeCrc({ owner, subaccount }: Required<IcrcAccount>): string {
     return encodeBase32(checksum);
 }
 
-function bigEndianCrc32(bytes: Uint8Array): Uint8Array {
+export function bigEndianCrc32(bytes: Uint8Array): Uint8Array {
     let crc = 0xffffffff;
 
     for (const byte of bytes) {

--- a/frontend/openchat-shared/src/utils/icrcAccount.ts
+++ b/frontend/openchat-shared/src/utils/icrcAccount.ts
@@ -109,7 +109,7 @@ function uint8ArrayToHexString(bytes: Uint8Array): string {
     return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-function hexStringToUint8Array(hex: string): Uint8Array {
+export function hexStringToUint8Array(hex: string): Uint8Array {
     if (hex.length % 2 !== 0 || /[^0-9a-f]/i.test(hex)) {
         throw new Error("Invalid account. Invalid subaccount.");
     }

--- a/frontend/openchat-shared/src/utils/logging.spec.ts
+++ b/frontend/openchat-shared/src/utils/logging.spec.ts
@@ -19,8 +19,10 @@ describe("normaliseSourceMapUrls", () => {
                 "https://webtest.oc.app/main-D_Idsc5v.js",
                 "https://6hsbt-vqaaa-aaaaf-aaafq-cai.icp0.io/main-D_Idsc5v.js",
                 "http://tauri.localhost/main-D_Idsc5v.js",
+                // iOS: a custom scheme, not http
+                "tauri://localhost/main-D_Idsc5v.js",
             ),
-        ).toEqual(Array(4).fill("http://dynamichost/main-D_Idsc5v.js"));
+        ).toEqual(Array(5).fill("http://dynamichost/main-D_Idsc5v.js"));
     });
 
     test("drops the worker's cache-busting query", () => {

--- a/frontend/openchat-shared/src/utils/logging.spec.ts
+++ b/frontend/openchat-shared/src/utils/logging.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { normaliseSourceMapUrls } from "./logging";
+import { normaliseSourceMapUrls, uncaughtReason } from "./logging";
 
 // These expectations are the other half of a contract: `scripts/upload-source-maps.mjs` registers
 // each map as `http://dynamichost/<path relative to frontend/app/build>`. If a frame's filename
@@ -77,5 +77,30 @@ describe("normaliseSourceMapUrls", () => {
     test("ignores payloads with no trace at all", () => {
         expect(() => normaliseSourceMapUrls({ body: { message: { body: "hello" } } })).not.toThrow();
         expect(() => normaliseSourceMapUrls({})).not.toThrow();
+    });
+});
+
+// Rollbar passes `[message, reason, context, promise]` as the args for an unhandled rejection.
+// Anything thrown in the worker arrives as a plain object rather than an Error, so Rollbar files
+// it with no exception class and the payload alone cannot be filtered on name or code.
+describe("uncaughtReason", () => {
+    test("finds a worker error that lost its prototype", () => {
+        const reason = { name: "SessionExpiryError", message: "HTTP request failed", code: 400 };
+        expect(uncaughtReason(["HTTP request failed", reason, undefined, {}])).toBe(reason);
+    });
+
+    test("finds a real Error", () => {
+        const err = new TypeError("boom");
+        expect(uncaughtReason(["boom", err, undefined, {}])).toBe(err);
+    });
+
+    test("skips the message string and the promise", () => {
+        expect(uncaughtReason(["just a message", undefined, undefined, {}])).toBeUndefined();
+    });
+
+    test("tolerates a missing or malformed args list", () => {
+        expect(uncaughtReason(undefined)).toBeUndefined();
+        expect(uncaughtReason([])).toBeUndefined();
+        expect(uncaughtReason("not an array")).toBeUndefined();
     });
 });

--- a/frontend/openchat-shared/src/utils/logging.spec.ts
+++ b/frontend/openchat-shared/src/utils/logging.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { normaliseSourceMapUrls } from "./logging";
+
+// These expectations are the other half of a contract: `scripts/upload-source-maps.mjs` registers
+// each map as `http://dynamichost/<path relative to frontend/app/build>`. If a frame's filename
+// does not normalise to exactly that, Rollbar finds no map and the trace stays minified with no
+// error anywhere.
+function frames(...filenames: unknown[]) {
+    const payload = { body: { trace: { frames: filenames.map((filename) => ({ filename })) } } };
+    normaliseSourceMapUrls(payload);
+    return payload.body.trace.frames.map((f) => f.filename);
+}
+
+describe("normaliseSourceMapUrls", () => {
+    test("collapses every origin the bundle is served from", () => {
+        expect(
+            frames(
+                "https://oc.app/main-D_Idsc5v.js",
+                "https://webtest.oc.app/main-D_Idsc5v.js",
+                "https://6hsbt-vqaaa-aaaaf-aaafq-cai.icp0.io/main-D_Idsc5v.js",
+                "http://tauri.localhost/main-D_Idsc5v.js",
+            ),
+        ).toEqual(Array(4).fill("http://dynamichost/main-D_Idsc5v.js"));
+    });
+
+    test("drops the worker's cache-busting query", () => {
+        expect(frames("https://oc.app/worker.js?v=2.0.2052")).toEqual([
+            "http://dynamichost/worker.js",
+        ]);
+    });
+
+    test("keeps a nested chunk's directory", () => {
+        expect(frames("https://oc.app/assets/lazy-abc123.js")).toEqual([
+            "http://dynamichost/assets/lazy-abc123.js",
+        ]);
+    });
+
+    test("leaves extension frames alone so the extension filter still matches", () => {
+        expect(
+            frames(
+                "chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js",
+                "moz-extension://abc/inject.js",
+                "safari-web-extension://abc/inject.js",
+            ),
+        ).toEqual([
+            "chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js",
+            "moz-extension://abc/inject.js",
+            "safari-web-extension://abc/inject.js",
+        ]);
+    });
+
+    test("tolerates frames with no usable filename", () => {
+        expect(frames(undefined, "", "<anonymous>", 42)).toEqual([
+            undefined,
+            "",
+            "<anonymous>",
+            42,
+        ]);
+    });
+
+    test("walks every trace in a chain", () => {
+        const payload = {
+            body: {
+                trace_chain: [
+                    { frames: [{ filename: "https://oc.app/a.js" }] },
+                    { frames: [{ filename: "https://oc.app/b.js?v=1" }] },
+                ],
+            },
+        };
+        normaliseSourceMapUrls(payload);
+        expect(payload.body.trace_chain.map((t) => t.frames[0].filename)).toEqual([
+            "http://dynamichost/a.js",
+            "http://dynamichost/b.js",
+        ]);
+    });
+
+    test("ignores payloads with no trace at all", () => {
+        expect(() => normaliseSourceMapUrls({ body: { message: { body: "hello" } } })).not.toThrow();
+        expect(() => normaliseSourceMapUrls({})).not.toThrow();
+    });
+});

--- a/frontend/openchat-shared/src/utils/logging.ts
+++ b/frontend/openchat-shared/src/utils/logging.ts
@@ -32,6 +32,25 @@ function rollbarPayloadError(payload: any): { name: string; message: string } {
     };
 }
 
+// Rollbar hands `checkIgnore` the original arguments alongside the payload, and for an unhandled
+// rejection those include the rejection reason itself. That matters for anything thrown in the
+// worker: it crosses the boundary as JSON, so the reason arrives as a plain object rather than an
+// Error, Rollbar cannot read an exception class off it and files the item as "(unknown): message"
+// with no class at all. `name` and `code` are exactly what most of `shouldReportError`'s rules
+// are keyed on - session expiry, the 502-504 range, retry-exhausted - so reading them off the
+// payload alone silently loses every one of those. Recover the reason and filter on that.
+// Exported for testing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function uncaughtReason(args: any): unknown {
+    if (!Array.isArray(args)) return undefined;
+    return args.find(
+        (arg) =>
+            arg != null &&
+            typeof arg === "object" &&
+            (typeof arg.name === "string" || typeof arg.message === "string"),
+    );
+}
+
 // True when the innermost frame of the primary error is browser-extension code: the error was
 // thrown by an extension (CSP violations from injected wasm, wallet inpage scripts, ...), not us.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,9 +122,13 @@ export function inititaliseLogger(apikey: string, version: string, env: string):
             // captureUncaught / captureUnhandledRejections bypass our logger, so uncaught
             // items get the same noise filtering at the transport layer. Logger-reported items
             // (isUncaught false) already passed shouldReportError and are not re-filtered here.
-            checkIgnore: (isUncaught, _args, payload) => {
+            checkIgnore: (isUncaught, args, payload) => {
                 if (!isUncaught) return false;
                 if (thrownByExtension(payload)) return true;
+                // Prefer the reason itself: it still carries name and code, which the payload
+                // does not for anything that crossed the worker boundary
+                const reason = uncaughtReason(args);
+                if (reason !== undefined) return !shouldReportError(reason);
                 const { name, message } = rollbarPayloadError(payload);
                 return !shouldReportMessage(name, message);
             },

--- a/frontend/openchat-shared/src/utils/logging.ts
+++ b/frontend/openchat-shared/src/utils/logging.ts
@@ -44,6 +44,46 @@ function thrownByExtension(payload: any): boolean {
     return typeof filename === "string" && /^(chrome|moz|safari-web)-extension:\/\//.test(filename);
 }
 
+// Rollbar matches an uploaded source map to a stack frame by exact minified URL. The same bundle
+// is served from four origins - oc.app, webtest.oc.app, the canister's own .icp0.io domain, and
+// http://tauri.localhost in the native app - and the workers are loaded with a `?v=` cache
+// buster, so a frame's filename is one of many strings for the same file. `dynamichost` is
+// Rollbar's placeholder host for exactly this: rewrite every frame to it and one uploaded map
+// covers all four. `scripts/upload-source-maps.mjs` registers the same URLs.
+// Frames that are not http(s) are left alone - `thrownByExtension` identifies extension code by
+// the `chrome-extension://` prefix, and rewriting those would break that check.
+const DYNAMIC_HOST = "http://dynamichost";
+
+function normaliseFrameFilename(filename: unknown): string | undefined {
+    if (typeof filename !== "string" || !/^https?:\/\//i.test(filename)) return undefined;
+    try {
+        // pathname only: drops the origin and the `?v=` query, keeping any directory prefix so
+        // the URL still matches the map's path relative to the build directory
+        return `${DYNAMIC_HOST}${new URL(filename).pathname}`;
+    } catch {
+        return undefined;
+    }
+}
+
+// Exported for testing: a mismatch between this and the URLs `upload-source-maps.mjs` registers
+// fails silently, with traces simply staying minified.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normaliseSourceMapUrls(payload: any): void {
+    const body = payload?.body;
+    const traces = body?.trace_chain ?? (body?.trace != null ? [body.trace] : []);
+    if (!Array.isArray(traces)) return;
+    for (const trace of traces) {
+        const frames = trace?.frames;
+        if (!Array.isArray(frames)) continue;
+        for (const frame of frames) {
+            const normalised = normaliseFrameFilename(frame?.filename);
+            if (normalised !== undefined) {
+                frame.filename = normalised;
+            }
+        }
+    }
+}
+
 export function inititaliseLogger(apikey: string, version: string, env: string): Logger {
     if (env === "production") {
         rollbar = Rollbar.init({
@@ -69,6 +109,7 @@ export function inititaliseLogger(apikey: string, version: string, env: string):
                 const { name, message } = rollbarPayloadError(payload);
                 return !shouldReportMessage(name, message);
             },
+            transform: (payload) => normaliseSourceMapUrls(payload),
             payload: {
                 environment: env,
                 client: {

--- a/frontend/openchat-shared/src/utils/logging.ts
+++ b/frontend/openchat-shared/src/utils/logging.ts
@@ -74,7 +74,9 @@ function thrownByExtension(payload: any): boolean {
 const DYNAMIC_HOST = "http://dynamichost";
 
 function normaliseFrameFilename(filename: unknown): string | undefined {
-    if (typeof filename !== "string" || !/^https?:\/\//i.test(filename)) return undefined;
+    // tauri: is iOS, which serves the bundle from tauri://localhost (see navigation.rs); Android
+    // uses http://tauri.localhost and is covered by https?
+    if (typeof filename !== "string" || !/^(https?|tauri):\/\//i.test(filename)) return undefined;
     try {
         // pathname only: drops the origin and the `?v=` query, keeping any directory prefix so
         // the URL still matches the map's path relative to the build directory

--- a/frontend/openchat-shared/src/utils/pubsub_events.ts
+++ b/frontend/openchat-shared/src/utils/pubsub_events.ts
@@ -117,6 +117,7 @@ export type PubSubEvents = {
     userLoggedIn: string;
     reactionSelected: { messageId: bigint; kind: "add" | "remove" };
     userSuspensionChanged: undefined;
+    sessionExpired: undefined;
     selectedChatInvalid: undefined;
     chitEarned: ChitEvent[];
     sendMessageFailed: boolean;

--- a/frontend/openchat-shared/src/utils/string.spec.ts
+++ b/frontend/openchat-shared/src/utils/string.spec.ts
@@ -1,0 +1,26 @@
+import { AccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
+import { Principal } from "@icp-sdk/core/principal";
+import { describe, expect, test } from "vitest";
+import { isAccountIdentifierValid } from "./string";
+
+// ICP ledger account identifiers carry a big-endian CRC32 of the hash in their first four bytes.
+// The canister checks it (AccountIdentifier::from_slice); a client that only checked length and
+// hex let a typo through to be rejected after the user had been told the address was fine.
+describe("isAccountIdentifierValid", () => {
+    const valid = AccountIdentifier.fromPrincipal({ principal: Principal.anonymous() }).toHex();
+
+    test("accepts an identifier whose checksum matches", () => {
+        expect(valid.length).toBe(64);
+        expect(isAccountIdentifierValid(valid)).toBe(true);
+    });
+
+    test("rejects a single-character typo", () => {
+        const typo = valid.slice(0, 40) + (valid[40] === "0" ? "1" : "0") + valid.slice(41);
+        expect(isAccountIdentifierValid(typo)).toBe(false);
+    });
+
+    test("still rejects the wrong length or non-hex", () => {
+        expect(isAccountIdentifierValid(valid.slice(1))).toBe(false);
+        expect(isAccountIdentifierValid("zz" + valid.slice(2))).toBe(false);
+    });
+});

--- a/frontend/openchat-shared/src/utils/string.ts
+++ b/frontend/openchat-shared/src/utils/string.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@icp-sdk/core/principal";
-import { decodeIcrcAccount } from "./icrcAccount";
+import { bigEndianCrc32, decodeIcrcAccount } from "./icrcAccount";
 
 export const HEX_REGEX = new RegExp("^[A-Fa-f0-9]+$");
 
@@ -23,8 +23,18 @@ export function isSubAccountValid(text: string): boolean {
     return text.length <= 64 && isHexString(text);
 }
 
+// An ICP ledger account identifier is 32 bytes: a big-endian CRC32 of the 28-byte hash, then
+// the hash. Length and hex alone let a typo through to the canister, whose
+// AccountIdentifier::from_slice checks the checksum and rejects it - by which point the user has
+// already been told the address was fine.
 export function isAccountIdentifierValid(text: string): boolean {
-    return text.length === 64 && isHexString(text);
+    if (text.length !== 64 || !isHexString(text)) return false;
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+        bytes[i] = parseInt(text.slice(i * 2, i * 2 + 2), 16);
+    }
+    const checksum = bigEndianCrc32(bytes.subarray(4));
+    return checksum.every((b, i) => b === bytes[i]);
 }
 
 export function isICRCAddressValid(text: string): boolean {

--- a/frontend/openchat-shared/src/utils/string.ts
+++ b/frontend/openchat-shared/src/utils/string.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@icp-sdk/core/principal";
-import { bigEndianCrc32, decodeIcrcAccount } from "./icrcAccount";
+import { bigEndianCrc32, decodeIcrcAccount, hexStringToUint8Array } from "./icrcAccount";
 
 export const HEX_REGEX = new RegExp("^[A-Fa-f0-9]+$");
 
@@ -29,10 +29,7 @@ export function isSubAccountValid(text: string): boolean {
 // already been told the address was fine.
 export function isAccountIdentifierValid(text: string): boolean {
     if (text.length !== 64 || !isHexString(text)) return false;
-    const bytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) {
-        bytes[i] = parseInt(text.slice(i * 2, i * 2 + 2), 16);
-    }
+    const bytes = hexStringToUint8Array(text);
     const checksum = bigEndianCrc32(bytes.subarray(4));
     return checksum.every((b, i) => b === bytes[i]);
 }

--- a/frontend/openchat-shared/src/utils/string.ts
+++ b/frontend/openchat-shared/src/utils/string.ts
@@ -1,5 +1,6 @@
 import { Principal } from "@icp-sdk/core/principal";
-import { bigEndianCrc32, decodeIcrcAccount, hexStringToUint8Array } from "./icrcAccount";
+import { isIcpAccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
+import { decodeIcrcAccount } from "./icrcAccount";
 
 export const HEX_REGEX = new RegExp("^[A-Fa-f0-9]+$");
 
@@ -23,15 +24,11 @@ export function isSubAccountValid(text: string): boolean {
     return text.length <= 64 && isHexString(text);
 }
 
-// An ICP ledger account identifier is 32 bytes: a big-endian CRC32 of the 28-byte hash, then
-// the hash. Length and hex alone let a typo through to the canister, whose
-// AccountIdentifier::from_slice checks the checksum and rejects it - by which point the user has
-// already been told the address was fine.
+// Length, hex and the CRC32 in the first four bytes. Length and hex alone let a typo through to
+// the canister, whose AccountIdentifier::from_slice checks the checksum and rejects it - by which
+// point the user had already been told the address was fine.
 export function isAccountIdentifierValid(text: string): boolean {
-    if (text.length !== 64 || !isHexString(text)) return false;
-    const bytes = hexStringToUint8Array(text);
-    const checksum = bigEndianCrc32(bytes.subarray(4));
-    return checksum.every((b, i) => b === bytes[i]);
+    return isIcpAccountIdentifier(text);
 }
 
 export function isICRCAddressValid(text: string): boolean {

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -225,15 +225,11 @@ function sendEvent(msg: Omit<WorkerEvent, "kind">): void {
     });
 }
 
-self.addEventListener("error", (err: ErrorEvent) => {
-    // The underlying error, not the event: the event serialises to nothing useful and dodges
-    // the logger's filtering
-    logger.error("WORKER: unhandled error: ", err.error ?? err.message);
-});
-
-self.addEventListener("unhandledrejection", (err: PromiseRejectionEvent) => {
-    logger.error("WORKER: unhandled promise rejection: ", err.reason ?? err);
-});
+// No error / unhandledrejection listeners here, deliberately. inititaliseLogger's Rollbar.init
+// runs in this worker too, and its captureUncaught / captureUnhandledRejections attach to `self`
+// (rollbar falls back to `self` where there is no `window`), so listeners that also called
+// logger.error reported every worker failure twice under two different titles - the same
+// duplication App.svelte had. Rollbar's checkIgnore filters on the rejection reason itself.
 
 self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) => {
     logger.debug("WORKER: received ", msg.data.kind, msg.data.correlationId);

--- a/scripts/deploy-website-prod-test.sh
+++ b/scripts/deploy-website-prod-test.sh
@@ -14,6 +14,10 @@ npm run --prefix frontend deploy:prod_test
 
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
+
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
     dfx --identity $IDENTITY deploy --network ic_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod_test - failed"

--- a/scripts/deploy-website-testnet.sh
+++ b/scripts/deploy-website-testnet.sh
@@ -16,6 +16,10 @@ npm run --prefix frontend deploy:testnet
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+
     dfx --identity $IDENTITY deploy --network $OC_DFX_NETWORK --no-wallet --with-cycles 100000000000000 website
 else
   echo "npm run --prefix frontend deploy:testnet - failed"

--- a/scripts/deploy-website-web-test.sh
+++ b/scripts/deploy-website-web-test.sh
@@ -15,6 +15,10 @@ npm run --prefix frontend deploy:prod
 
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
+
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
     dfx --identity $IDENTITY deploy --network web_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod - failed"

--- a/scripts/prepare-frontend-assets.sh
+++ b/scripts/prepare-frontend-assets.sh
@@ -15,6 +15,10 @@ npm run --prefix frontend deploy:prod
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+
     dfx --identity $IDENTITY deploy --network ic --by-proposal website
 else
   echo "npm run --prefix frontend deploy:prod - failed"

--- a/scripts/upload-source-maps.mjs
+++ b/scripts/upload-source-maps.mjs
@@ -1,0 +1,129 @@
+// Uploads the built source maps to Rollbar so production stack traces demangle.
+//
+// Rollbar does not fetch source maps from your site, even when they are public (ours are). It
+// only reads maps uploaded to its API, stored per project + version + minified URL. That keying
+// is the point: errors are processed asynchronously, and worker.js has a fixed name, so a map
+// fetched after a later deploy would demangle old traces against new source and produce line
+// numbers that look right and are wrong.
+//
+// The URLs registered here must match what `normaliseSourceMapUrls` in openchat-shared's
+// logging.ts rewrites each stack frame to. Change one and you must change the other.
+//
+// Usage: node scripts/upload-source-maps.mjs <version>
+// Requires OC_ROLLBAR_SERVER_TOKEN - a post_server_item token from Rollbar's
+// Settings -> Project Access Tokens. The client token in OC_ROLLBAR_ACCESS_TOKEN is a
+// post_client_item token and the endpoint rejects it.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ENDPOINT = "https://api.rollbar.com/api/1/sourcemap";
+const DYNAMIC_HOST = "http://dynamichost";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const buildDir = path.join(repoRoot, "frontend/app/build");
+
+const version = process.argv[2] ?? process.env.OC_WEBSITE_VERSION;
+const token = process.env.OC_ROLLBAR_SERVER_TOKEN;
+
+if (!version) {
+    console.error("upload-source-maps: no version given (argv[2] or OC_WEBSITE_VERSION)");
+    process.exit(1);
+}
+
+// Not fatal. A missing token should not sink a deploy that is otherwise fine, but it must be
+// loud, because the failure mode is silent: traces simply stay minified.
+if (!token) {
+    console.warn("");
+    console.warn("  ****************************************************************");
+    console.warn("  OC_ROLLBAR_SERVER_TOKEN is not set - SKIPPING source map upload.");
+    console.warn(`  Stack traces for ${version} will stay minified in Rollbar.`);
+    console.warn("  ****************************************************************");
+    console.warn("");
+    process.exit(0);
+}
+
+function findMaps(dir) {
+    const found = [];
+    for (const entry of readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            found.push(...findMaps(full));
+        } else if (entry.endsWith(".js.map")) {
+            found.push(full);
+        }
+    }
+    return found;
+}
+
+const maps = findMaps(buildDir);
+if (maps.length === 0) {
+    console.error(`upload-source-maps: no .js.map files under ${buildDir} - did the build run?`);
+    process.exit(1);
+}
+
+console.log(`upload-source-maps: uploading ${maps.length} maps for ${version}`);
+
+// A lazy chunk per route means well over a hundred uploads, so run a few at a time. Small enough
+// not to look like abuse, large enough that the whole set finishes in seconds rather than minutes.
+const CONCURRENCY = 8;
+
+// A bad token fails all of them identically. Stop on the first one rather than printing the same
+// 403 a hundred and seventy times.
+class FatalUploadError extends Error {}
+
+async function upload(mapPath) {
+    // "build/main-D_Idsc5v.js.map" -> "http://dynamichost/main-D_Idsc5v.js"
+    const relative = path.relative(buildDir, mapPath).split(path.sep).join("/");
+    const minifiedUrl = `${DYNAMIC_HOST}/${relative.replace(/\.map$/, "")}`;
+
+    const form = new FormData();
+    form.append("access_token", token);
+    form.append("version", version);
+    form.append("minified_url", minifiedUrl);
+    form.append("source_map", new Blob([readFileSync(mapPath)]), path.basename(mapPath));
+
+    let response;
+    try {
+        response = await fetch(ENDPOINT, { method: "POST", body: form });
+    } catch (err) {
+        console.error(`  FAIL  ${minifiedUrl} - ${err}`);
+        return false;
+    }
+
+    if (response.ok) return true;
+
+    const body = (await response.text()).replace(/\s+/g, " ").trim();
+    if (response.status === 401 || response.status === 403) {
+        throw new FatalUploadError(
+            `Rollbar rejected the token (${response.status}): ${body}\n` +
+                "  OC_ROLLBAR_SERVER_TOKEN must be a post_server_item token from Rollbar's\n" +
+                "  Settings -> Project Access Tokens, not the post_client_item one the app uses.",
+        );
+    }
+    console.error(`  FAIL  ${minifiedUrl} - ${response.status} ${body}`);
+    return false;
+}
+
+let failed = 0;
+const queue = [...maps];
+try {
+    await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+            for (let next = queue.pop(); next !== undefined; next = queue.pop()) {
+                if (!(await upload(next))) failed++;
+            }
+        }),
+    );
+} catch (err) {
+    if (!(err instanceof FatalUploadError)) throw err;
+    console.error(`upload-source-maps: ${err.message}`);
+    process.exit(1);
+}
+
+if (failed > 0) {
+    console.error(`upload-source-maps: ${failed} of ${maps.length} uploads failed`);
+    process.exit(1);
+}
+console.log(`upload-source-maps: all ${maps.length} maps uploaded for ${version}`);

--- a/scripts/upload-source-maps.mjs
+++ b/scripts/upload-source-maps.mjs
@@ -73,6 +73,12 @@ const CONCURRENCY = 8;
 // 403 a hundred and seventy times.
 class FatalUploadError extends Error {}
 
+// Rollbar echoes the rejected token back in its 403 body, which would otherwise put the secret
+// into terminal scrollback and CI logs.
+function redact(text) {
+    return text.split(token).join("<OC_ROLLBAR_SERVER_TOKEN>");
+}
+
 async function upload(mapPath) {
     // "build/main-D_Idsc5v.js.map" -> "http://dynamichost/main-D_Idsc5v.js"
     const relative = path.relative(buildDir, mapPath).split(path.sep).join("/");
@@ -88,13 +94,13 @@ async function upload(mapPath) {
     try {
         response = await fetch(ENDPOINT, { method: "POST", body: form });
     } catch (err) {
-        console.error(`  FAIL  ${minifiedUrl} - ${err}`);
+        console.error(`  FAIL  ${minifiedUrl} - ${redact(String(err))}`);
         return false;
     }
 
     if (response.ok) return true;
 
-    const body = (await response.text()).replace(/\s+/g, " ").trim();
+    const body = redact((await response.text()).replace(/\s+/g, " ").trim());
     if (response.status === 401 || response.status === 403) {
         throw new FatalUploadError(
             `Rollbar rejected the token (${response.status}): ${body}\n` +


### PR DESCRIPTION
Rollbar sweep for 2026-09-08, covering the last 24 hours of production items, plus the source-map pipeline that makes the next sweep possible. Six commits; the last one addresses a review round.

## Session expiry never logged anyone out

The biggest find, and not what I set out looking for. `#30673 lastOnline` is 17,630 occurrences over seven months, 293 in the last day, all from **one IP** on **2.0.2003**, retrying every 60 seconds with a `SessionExpiryError` and never signing out. `#30666 getUsers`, `#30669 updateRegistry`, `#30675 getBots`, `#25992` and `#31665`/`#31667` are the same client. Between them that is most of the daily volume.

`requiresLogout` was only consulted in `App.svelte`'s `unhandledrejection` handler. Background pollers catch their own failures, so the rejection never reached the window and the client polled on a timer for as long as the tab stayed open. `workerAgent.ts:#resolveError` now checks every worker rejection and publishes `sessionExpired` once, which both `App.svelte`s turn into a logout.

Three supporting changes came out of review. `clearChatShortcuts` is registered through `client.onLogout` rather than called at each logout site, so the previous user's shortcuts cannot survive a logout that starts from the worker agent. `logout()` is idempotent (`#logoutPromise ??= #doLogout()`): an expired session reaches it twice, deterministically — the worker agent publishes `sessionExpired` and then rejects, and an uncaught rejection brings the window handler round again — and the second run used to navigate while the first was still removing the push token, leaving the Android token registered to a signed-out user. And `logout()` navigates in a `finally` with the teardown capped at 5s, because the worker's logout awaits three sequential IndexedDB deletes and a wedged IndexedDB is the very case this path exists for.

**Known edge of that cap, stated plainly:** if IndexedDB is blocked for longer than 5s, navigating can cut the auth client's delegation delete short, and startup may sign the user back in from the surviving delegation. Narrow, and no worse than the manual reload it replaces, but it is a consequence of choosing "always navigate" over "sometimes never".

## Crashes

**`s($).ledger`, `#31876`** — a top-level boundary error, so the whole app dies. `TokenState`'s constructor took a non-optional token and ~25 call sites passed `$cryptoLookup.get(x)!`. A gate or message naming a ledger the registry has never carried or has since dropped made the first derived read of `#token.ledger` throw.

The first attempt just fell back to a null token, which review correctly called a half-fix: zero decimals and an empty symbol render an amount that is *wrong* rather than obviously missing, and `PrizeWinnerContent`'s `decimals ?? 8` meant one transfer could show two different numbers depending on which component drew it. `TokenState` now exposes `unknown`, `formatTokens` returns `"?????"` rather than a figure built from zero decimals (one guard covering every consumer), and components that can act on a token refuse to — the payment gate explains itself instead of offering Approve, in both the mobile and the desktop copy (the desktop one was missed until the fifth review round; it is the copy every desktop-width viewport renders).

The p2p swap accept modal went a different way: the swap message already carries a `TokenInfo` per side — symbol, decimals, and the fee the canister actually debits — so both copies now take those instead of ledger ids and never consult the registry at all. No registry lookup means no unknown-ledger case, and no way to drift from the real charge.

Review also found five more `$cryptoLookup.get(ledger)!` sites one tap beyond the ones first fixed, so an unknown ledger rendered and then died on Join or Accept: `PaymentGateEvaluator` (which reads `token.ledger` directly, bypassing `TokenState`), and `AcceptP2PSwapModal` and `BalanceWithRefresh` in both layouts. A sixth, `BigInt(Number(gate.amount) * 0.98)` in the mobile payment breakdown, was pre-existing but in the same sheet: it throws a `RangeError` for any amount that is not a multiple of 50. Integer arithmetic now.

**`t.membership.readByMeUpTo` (`#31716`), `e.them.userId` (`#31582`), `n.chat.id` (`#31618`)** — direct chat summaries arriving without fields the type says are always present. `openchat.ts:7287` was the only branch reading `membership` without `?.`; the group and channel branches beside it already guarded.

For the cause: the IndexedDB cache is the one place a chat summary enters the agent without a mapper having built it from candid. `getCachedChats` now treats such a cache as unusable, clears it, and lets `getUpdates` fall through to `getInitialState` — what the existing >30-day staleness check already does. It never throws, either: `Stream` calls its initialiser synchronously and never catches a rejected async one, so a throw here would fire neither `onResult` nor `onError` and wedge every launch.

Two earlier attempts were wrong and are worth recording. Repairing the fields cannot work — `membership` is the server's to say (`nullMembership()` gives `ROLE_NONE` where a direct chat is always `ROLE_OWNER`, and an undefined `readByMeUpTo` marks the chat entirely unread). Dropping just the bad record is worse, because the cached list is the base `mergeDirectChatUpdates` applies deltas to, so a chat removed from it never returns until the server happens to mention it.

## Noise

- **`/invalid request expiry/i`** added to `ENVIRONMENT_NOISE_PATTERNS`. The client's clock being wrong, seen from the replica's side — `#31879`'s payload has a device 13 days behind, `#30918`'s claims an expiry in April. The replica echoes the timestamps back in the message, so every skewed device was minting a fresh item rather than joining one. Clears `#30918` (1,122/day), `#31165`, `#31873`, `#31879`.
- **`CanisterUnavailableError` was never filtered.** `isTransientNetworkError` gated its 502-504 check on `name === "HttpError"`, but every `HttpError` subclass overwrites `name`, so a 503 from a frozen canister sailed past a filter written to catch exactly that.
- **Duplicate reporting.** `captureUnhandledRejections` is on *and* `App.svelte` added its own listener calling `logger.error`, so every rejection produced two items with different titles. `#31582` logged both at 06:16:57 on 2026-09-08. Rollbar's capture installs at init, before the listener is added on mount, so dropping the log loses no coverage — and its items are the ones source maps demangle. At triage time: `#31837`, `#31822` and `#25983` are logger-path items and will go quiet; their capture-path twins carry on.
- **`quoteSwap`** used `Promise.all`, so one pool rejecting failed and reported every pool. This took four rounds to get right and the root cause was in the ICPSwap mapper, which threw on a decoded `err` variant — making a decline indistinguishable from a transport failure, and (since that Error was not in `executeQuery`'s no-retry list) retrying a dust-amount quote seven times with backoff, roughly twelve seconds. The mapper now returns `undefined` for a decline and throws for a failure; `quoteSwap` drops declines and throws if nothing succeeded and anything failed.

  Which variants are declines is load-bearing and pinned by a spec. `InsufficientFunds` and `UnsupportedToken` by definition. `InternalError` is nominally a failure, but ICPSwap reports the commonest decline of all through it — `{"InternalError":"The amount of input token is too small."}` is the exact payload behind `#31881` — so that one message is a decline; any other `InternalError`, and `CommonError`, still throw and retry.

## Validation

`EditRecipient.svelte` checked `trimmedAddress.length > 0` under a `// TODO this probably isn't good enough`, and a bad address threw unhandled out of the worker's withdrawal mapper (`#31864`). It now accepts the same two forms as `is_valid_account` in `save_crypto_account.rs`: an ICRC-1 textual account, or an ICP ledger account identifier — checksum included, via the SDK's own `isIcpAccountIdentifier`, since the canister verifies the CRC and a length-and-hex check let typos through to a confusing rejection. (The first attempt used the ICRC check alone, which was *stricter* than the backend and silently disabled the save button for valid 64-hex addresses.) `SendToAddress` no longer offers "Save address" after a send over the BTC or an EVM network, where the target can never be an IC account; it still does over ckBTC, where it is one.

## Source maps

Rollbar never fetches maps from your site, even public ones — it only reads maps uploaded to its API, keyed by project + version + minified URL. That keying matters: errors are processed asynchronously and `worker.js` has a fixed, unhashed name, so a map fetched after a later deploy would demangle old traces against new source and produce line numbers that look right and are wrong.

Two halves that must agree, because a mismatch fails silently:

- `scripts/upload-source-maps.mjs` walks `frontend/app/build` for `*.js.map` and registers each as `http://dynamichost/<path relative to build>`. No new dependencies — node 22 has `fetch`, `FormData` and `Blob`. Eight concurrent; a 401/403 aborts with one message about the token, and the token is redacted from Rollbar's error body, which echoes it back.
- `normaliseSourceMapUrls` in `logging.ts`, wired in as Rollbar's `transform`, rewrites every http(s) frame to that same URL. The bundle is served from four origins (`oc.app`, `webtest.oc.app`, the canister's `.icp0.io` domain, `http://tauri.localhost`) and the workers carry a `?v=` cache buster, so without this a frame's filename is one of many strings for the same file. Non-http frames are untouched so `thrownByExtension` still matches on `chrome-extension://`.

Side benefit: errors from `oc.app` and from the native app currently fingerprint as separate items because the filenames differ. After this they group.

Wired into all four website deploy scripts between the build and the `dfx deploy`. Needs `OC_ROLLBAR_SERVER_TOKEN` (a `post_server_item` token; the app's `OC_ROLLBAR_ACCESS_TOKEN` is `post_client_item` and gets rejected). Without it the script warns loudly and exits 0.

**Verified for real:** 173 maps uploaded successfully for 2.0.2052 in 10.7s, including the 5.2MB vendor map, so there is no size limit problem. Separately, the local build was found byte-identical to what is live, so the same maps were backfilled under the URLs the *deployed* 2.0.2052 bundle's frames actually carry — meaning `#31837` should demangle on its next occurrence without waiting for a deploy. That backfill covered `oc.app` only, not `webtest.oc.app` or `tauri.localhost`.

## Left alone

**`#31837`** (`Cannot read properties of undefined (reading 'id')`, 28 hits since 2.0.2051) is a real regression I could not pin down without a usable stack, which is what prompted the source-map work. Very likely the same defect as `#31618` in Chrome's wording.

**The svelte-i18n boundary crash** (`#31868`/`#31880`, "Cannot format a message without first setting the initial locale"). An earlier commit added a locale guard here; review showed it fixed nothing and it has been reverted. svelte-i18n 3.7.1 already wraps its `getCanonicalLocales` call in `try/catch` and falls back to `fallbackLocale`, so a malformed tag never caused this. The real cause is that `locale.set` defers the store write until the locale's loader resolves, so any `$_` between `init()` and `en.json` arriving throws. Fixing it means gating the first render on `waitLocale` or bundling `en` synchronously — its own change, not this one.

**Muting the stuck-client items** — the logout fix stops this for anyone on a current build, but the 2.0.2003 client is unreachable and will keep firing. Its titles are generic enough (`lastOnline`, `getUsers`, `WORKER: unhandled promise rejection:`) that a mute would hide future genuine failures, so snoozing is the safer option.

**`#31872`** (`aytea-…` out of cycles) — the message can't distinguish a third-party SNS ledger running dry from one of ours, and two occurrences isn't worth the risk.

## Testing

`npm run typecheck` 0 errors, `typecheck:agent` clean, 912 tests pass, lint clean on the touched files. New tests cover a wrong client clock in both directions (`error.spec.ts`) and the source-map frame rewriting against the literal URLs the upload script registers (`logging.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA


