### PR TITLE
Include Group and Community canisters in the LocalUserIndex low balance check

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Include MultiUser canisters in the cycles top up paths, so they can report a low balance and are picked up by the weekly balance sweep ([#9311](https://github.com/open-chat-labs/open-chat/pull/9311))
+- Include Group and Community canisters in the weekly cycles balance sweep - they were queued up but never selected, so the sweep silently skipped them ([#9313](https://github.com/open-chat-labs/open-chat/pull/9313))
 
 ## [[2.0.2033](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2033-local_user_index)] - 2026-08-20
 

--- a/backend/canisters/local_user_index/impl/src/jobs/topup_canisters.rs
+++ b/backend/canisters/local_user_index/impl/src/jobs/topup_canisters.rs
@@ -66,14 +66,19 @@ fn next(state: &mut RuntimeState) -> GetNextResult {
     let mut count = 0;
     let now = state.env.now();
     while let Some(canister_id) = state.data.cycles_balance_check_queue.pop_front() {
-        // Note: local groups and communities are queued up above but are not matched here, so they
-        // are never balance checked by this job. That is pre-existing behaviour, they rely on
-        // their own `check_cycles_balance` regular job calling `c2c_notify_low_balance` instead
         let cycle_top_ups = state
             .data
             .local_users
             .get(&canister_id.into())
             .map(|u| &u.cycle_top_ups)
+            .or_else(|| state.data.local_groups.get(&canister_id.into()).map(|g| &g.cycle_top_ups))
+            .or_else(|| {
+                state
+                    .data
+                    .local_communities
+                    .get(&canister_id.into())
+                    .map(|c| &c.cycle_top_ups)
+            })
             .or_else(|| state.data.local_multi_users.get(&canister_id).map(|c| &c.cycle_top_ups));
 
         if let Some(cycle_top_ups) = cycle_top_ups {


### PR DESCRIPTION
## Summary

The LocalUserIndex runs a weekly cycles balance sweep (`jobs::topup_canisters`). `populate_canisters` queues up every local User, Group, Community and MultiUser canister, but `next` only matched Users and MultiUsers - Groups and Communities were popped off the queue and silently dropped, so the sweep never checked them. They relied solely on their own `check_cycles_balance` regular job calling `c2c_notify_low_balance`.

This extends the lookup in `next` to `local_groups` and `local_communities`, so all four child canister types are covered by the same path, with the same "only check if the last top up was more than 10 days ago" guard. `c2c_notify_low_balance::commit` already records top ups against groups and communities, so that guard works for them without any further change.

## Impact

`run_async` tops up `CHILD_CANISTER_TOP_UP_AMOUNT` (0.2T cycles) whenever `status.cycles < MIN_CYCLES_BALANCE || status.cycles < 60 * idle_cycles_burned_per_day`. Any group or community currently sitting below that threshold - because its own `check_cycles_balance` job never fired, or its notification failed - will now be topped up by the sweep. That is the point of the change, but it does mean real mainnet cycle spending on the first run after deploy.

The sweep is a backstop, not a replacement: groups and communities keep their own `check_cycles_balance` job, and the 10 day guard stops the two paths from stacking top ups.

## Test plan

- [x] `cargo clippy --package local_user_index_canister_impl --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
