### PR TITLE
Add a multi_user_canisters_enabled flag set by proposal on the UserIndex

### DIFF
--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `c2c_create_multi_user_canister` and `c2c_upgrade_multi_user_canister_wasm` plus a rolling upgrade job for MultiUser canisters ([#9311](https://github.com/open-chat-labs/open-chat/pull/9311))
+- Add the `multi_user_canisters_enabled` flag, set by the UserIndex and surfaced in metrics ([#9314](https://github.com/open-chat-labs/open-chat/pull/9314))
 - Expose the user-event sync queue's in-flight batch count in metrics, alongside the existing queued length ([#9177](https://github.com/open-chat-labs/open-chat/pull/9177))
 
 ### Changed

--- a/backend/canisters/local_user_index/api/src/lib.rs
+++ b/backend/canisters/local_user_index/api/src/lib.rs
@@ -60,6 +60,7 @@ pub enum UserIndexEvent {
     SetOpenAIApiKey(SetOpenAIApiKey),
     SetModerationReferralConfig(SetModerationReferralConfig),
     SetMediaScanConfig(types::MediaScanConfig),
+    SetMultiUserCanistersEnabled(bool),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/backend/canisters/local_user_index/api/src/lifecycle/init.rs
+++ b/backend/canisters/local_user_index/api/src/lifecycle/init.rs
@@ -26,5 +26,7 @@ pub struct Args {
     pub moderation_referral_config: Option<ModerationReferralConfig>,
     #[serde(default)]
     pub media_scan_config: MediaScanConfig,
+    #[serde(default)]
+    pub multi_user_canisters_enabled: bool,
     pub test_mode: bool,
 }

--- a/backend/canisters/local_user_index/impl/src/lib.rs
+++ b/backend/canisters/local_user_index/impl/src/lib.rs
@@ -494,6 +494,7 @@ impl RuntimeState {
             multi_user_upgrades_pending: multi_user_upgrades_metrics.pending,
             multi_user_upgrades_in_progress: multi_user_upgrades_metrics.in_progress,
             multi_user_wasm_version: self.data.child_canister_wasms.get(ChildCanisterType::MultiUser).wasm.version,
+            multi_user_canisters_enabled: self.data.multi_user_canisters_enabled,
             user_versions: self
                 .data
                 .local_users
@@ -641,6 +642,9 @@ struct Data {
     pub media_scan_config: MediaScanConfig,
     #[serde(default)]
     pub media_scan_job_log: MediaScanJobLog,
+    // Mirrors the flag on the UserIndex. Not acted on yet
+    #[serde(default)]
+    pub multi_user_canisters_enabled: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -678,6 +682,7 @@ impl Data {
         openai_api_key: Option<String>,
         moderation_referral_config: Option<ModerationReferralConfig>,
         media_scan_config: MediaScanConfig,
+        multi_user_canisters_enabled: bool,
         test_mode: bool,
     ) -> Self {
         Data {
@@ -741,6 +746,7 @@ impl Data {
             message_moderation_queue: ModerationQueue::default(),
             media_scan_config,
             media_scan_job_log: MediaScanJobLog::default(),
+            multi_user_canisters_enabled,
         }
     }
 }
@@ -787,6 +793,7 @@ pub struct Metrics {
     pub multi_user_upgrades_pending: u64,
     pub multi_user_upgrades_in_progress: u64,
     pub multi_user_wasm_version: BuildVersion,
+    pub multi_user_canisters_enabled: bool,
     pub user_events_queue_length: usize,
     // Batches currently mid-flight: len() alone cannot distinguish an idle queue from one
     // whose last batch is still awaiting its reply

--- a/backend/canisters/local_user_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/local_user_index/impl/src/lifecycle/init.rs
@@ -37,6 +37,7 @@ fn init(args: Args) {
         args.openai_api_key,
         args.moderation_referral_config,
         args.media_scan_config,
+        args.multi_user_canisters_enabled,
         args.test_mode,
     );
 

--- a/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
+++ b/backend/canisters/local_user_index/impl/src/updates/c2c_notify_user_index_events.rs
@@ -340,6 +340,9 @@ fn handle_event<F: FnOnce() -> TimestampMillis>(
         UserIndexEvent::SetMediaScanConfig(config) => {
             state.data.media_scan_config = config;
         }
+        UserIndexEvent::SetMultiUserCanistersEnabled(enabled) => {
+            state.data.multi_user_canisters_enabled = enabled;
+        }
     }
 }
 

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `upgrade_multi_user_canister_wasm` and `create_multi_user_canister` so MultiUser canisters can be installed and upgraded via the LocalUserIndexes ([#9311](https://github.com/open-chat-labs/open-chat/pull/9311))
+- Add `set_multi_user_canisters_enabled` proposal, recorded on the UserIndex, fanned out to the LocalUserIndexes and surfaced in metrics ([#9314](https://github.com/open-chat-labs/open-chat/pull/9314))
 - Support paying for Diamond membership from external wallets using ICRC2 ([#9265](https://github.com/open-chat-labs/open-chat/pull/9265))
 
 ### Changed

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `upgrade_multi_user_canister_wasm` and `create_multi_user_canister` so MultiUser canisters can be installed and upgraded via the LocalUserIndexes ([#9311](https://github.com/open-chat-labs/open-chat/pull/9311))
-- Add `set_multi_user_canisters_enabled` proposal, recorded on the UserIndex, fanned out to the LocalUserIndexes and surfaced in metrics ([#9314](https://github.com/open-chat-labs/open-chat/pull/9314))
+- Add `set_multi_user_canisters_enabled` endpoint which fans out to the LocalUserIndexes ([#9314](https://github.com/open-chat-labs/open-chat/pull/9314))
 - Support paying for Diamond membership from external wallets using ICRC2 ([#9265](https://github.com/open-chat-labs/open-chat/pull/9265))
 
 ### Changed

--- a/backend/canisters/user_index/api/src/updates/mod.rs
+++ b/backend/canisters/user_index/api/src/updates/mod.rs
@@ -44,6 +44,7 @@ pub mod set_max_concurrent_user_canister_upgrades;
 pub mod set_media_scan_config;
 pub mod set_moderation_flags;
 pub mod set_moderation_referral_config;
+pub mod set_multi_user_canisters_enabled;
 pub mod set_openai_api_key;
 pub mod set_premium_item_cost;
 pub mod set_user_upgrade_concurrency;

--- a/backend/canisters/user_index/api/src/updates/set_multi_user_canisters_enabled.rs
+++ b/backend/canisters/user_index/api/src/updates/set_multi_user_canisters_enabled.rs
@@ -1,0 +1,11 @@
+use candid::CandidType;
+use human_readable::HumanReadable;
+use serde::{Deserialize, Serialize};
+use types::SuccessOnly;
+
+#[derive(CandidType, Serialize, Deserialize, HumanReadable, Clone, Debug)]
+pub struct Args {
+    pub enabled: bool,
+}
+
+pub type Response = SuccessOnly;

--- a/backend/canisters/user_index/impl/src/lib.rs
+++ b/backend/canisters/user_index/impl/src/lib.rs
@@ -272,6 +272,7 @@ impl RuntimeState {
             user_index_events_queue_length: self.data.user_index_event_sync_queue.len(),
             local_user_indexes: self.data.local_index_map.iter().map(|(c, i)| (*c, i.clone())).collect(),
             multi_user_canisters: self.data.multi_user_canisters.iter().map(|(c, i)| (*c, *i)).collect(),
+            multi_user_canisters_enabled: self.data.multi_user_canisters_enabled,
             platform_moderators_group: self.data.platform_moderators_group,
             nns_8_year_neuron: self.data.nns_8_year_neuron.clone(),
             event_store_client_info,
@@ -447,6 +448,9 @@ struct Data {
     // MultiUser canister id -> the LocalUserIndex which controls it
     #[serde(default)]
     pub multi_user_canisters: HashMap<CanisterId, CanisterId>,
+    // Set by proposal and fanned out to the LocalUserIndexes. Not acted on yet
+    #[serde(default)]
+    pub multi_user_canisters_enabled: bool,
 }
 
 impl Data {
@@ -551,6 +555,7 @@ impl Data {
             internal_moderation_channel: None,
             blocked_attempt_notice_throttle: HashMap::new(),
             multi_user_canisters: HashMap::new(),
+            multi_user_canisters_enabled: false,
         };
 
         // Register the ProposalsBot
@@ -674,6 +679,7 @@ impl Default for Data {
             internal_moderation_channel: None,
             blocked_attempt_notice_throttle: HashMap::new(),
             multi_user_canisters: HashMap::new(),
+            multi_user_canisters_enabled: false,
         }
     }
 }
@@ -704,6 +710,7 @@ pub struct Metrics {
     pub user_index_events_queue_length: usize,
     pub local_user_indexes: Vec<(CanisterId, LocalUserIndex)>,
     pub multi_user_canisters: Vec<(CanisterId, CanisterId)>,
+    pub multi_user_canisters_enabled: bool,
     pub platform_moderators_group: Option<ChatId>,
     pub nns_8_year_neuron: Option<NnsNeuron>,
     pub event_store_client_info: EventStoreClientInfo,

--- a/backend/canisters/user_index/impl/src/lifecycle/inspect_message.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/inspect_message.rs
@@ -58,6 +58,7 @@ fn accept_if_valid(state: &RuntimeState) {
         | "set_max_concurrent_user_canister_upgrades"
         | "add_local_user_index_canister"
         | "create_multi_user_canister"
+        | "set_multi_user_canisters_enabled"
         | "upgrade_user_canister_wasm"
         | "upgrade_multi_user_canister_wasm"
         | "upgrade_local_user_index_canister_wasm"

--- a/backend/canisters/user_index/impl/src/updates/add_local_user_index_canister.rs
+++ b/backend/canisters/user_index/impl/src/updates/add_local_user_index_canister.rs
@@ -147,6 +147,7 @@ fn prepare(args: &Args, state: &mut RuntimeState) -> Result<PrepareResult, Respo
                 openai_api_key: state.data.openai_api_key.clone(),
                 moderation_referral_config: state.data.moderation_referral_config.clone(),
                 media_scan_config: state.data.media_scan_config.clone(),
+                multi_user_canisters_enabled: state.data.multi_user_canisters_enabled,
                 test_mode: state.data.test_mode,
             },
         })

--- a/backend/canisters/user_index/impl/src/updates/mod.rs
+++ b/backend/canisters/user_index/impl/src/updates/mod.rs
@@ -43,6 +43,7 @@ pub mod set_max_concurrent_user_canister_upgrades;
 pub(crate) mod set_media_scan_config;
 pub mod set_moderation_flags;
 pub mod set_moderation_referral_config;
+pub mod set_multi_user_canisters_enabled;
 pub(crate) mod set_openai_api_key;
 pub mod set_premium_item_cost;
 pub mod set_user_upgrade_concurrency;

--- a/backend/canisters/user_index/impl/src/updates/set_multi_user_canisters_enabled.rs
+++ b/backend/canisters/user_index/impl/src/updates/set_multi_user_canisters_enabled.rs
@@ -1,0 +1,26 @@
+use crate::guards::caller_is_governance_principal;
+use crate::{RuntimeState, mutate_state};
+use canister_api_macros::proposal;
+use canister_tracing_macros::trace;
+use local_user_index_canister::UserIndexEvent;
+use tracing::info;
+use user_index_canister::set_multi_user_canisters_enabled::*;
+
+// Kill switch for the MultiUser canister rollout. Recorded here and fanned out to every
+// LocalUserIndex over the event queue, so a new LocalUserIndex is seeded with it and an existing
+// one picks it up even if it is mid-upgrade when the proposal executes. Nothing acts on it yet,
+// it is only surfaced in metrics
+#[proposal(guard = "caller_is_governance_principal")]
+#[trace]
+async fn set_multi_user_canisters_enabled(args: Args) -> Response {
+    mutate_state(|state| set_multi_user_canisters_enabled_impl(args, state))
+}
+
+fn set_multi_user_canisters_enabled_impl(args: Args, state: &mut RuntimeState) -> Response {
+    state.data.multi_user_canisters_enabled = args.enabled;
+
+    state.push_event_to_all_local_user_indexes(UserIndexEvent::SetMultiUserCanistersEnabled(args.enabled), None);
+
+    info!("MultiUser canisters enabled set to {}", args.enabled);
+    Response::Success
+}

--- a/backend/integration_tests/src/client/user_index.rs
+++ b/backend/integration_tests/src/client/user_index.rs
@@ -23,6 +23,7 @@ generate_update_call!(add_local_user_index_canister);
 generate_update_call!(add_platform_moderator);
 generate_update_call!(add_platform_operator);
 generate_update_call!(create_multi_user_canister);
+generate_update_call!(set_multi_user_canisters_enabled);
 generate_update_call!(assign_platform_moderators_group);
 generate_msgpack_update_call!(pay_for_diamond_membership);
 generate_msgpack_update_call!(remove_bot);
@@ -281,6 +282,25 @@ pub mod happy_path {
             user_index_canister::create_multi_user_canister::Response::Success(canister_id) => canister_id,
             response => panic!("'create_multi_user_canister' error: {response:?}"),
         }
+    }
+
+    pub fn set_multi_user_canisters_enabled(
+        env: &mut PocketIc,
+        sender: Principal,
+        user_index_canister_id: CanisterId,
+        enabled: bool,
+    ) {
+        let response = super::set_multi_user_canisters_enabled(
+            env,
+            sender,
+            user_index_canister_id,
+            &user_index_canister::set_multi_user_canisters_enabled::Args { enabled },
+        );
+
+        assert!(matches!(
+            response,
+            user_index_canister::set_multi_user_canisters_enabled::Response::Success
+        ));
     }
 
     pub fn upgrade_multi_user_canister_wasm(

--- a/backend/integration_tests/src/multi_user_canister_tests.rs
+++ b/backend/integration_tests/src/multi_user_canister_tests.rs
@@ -83,6 +83,38 @@ fn upgrade_filter_naming_unknown_canister_is_rejected() {
     );
 }
 
+#[test]
+fn multi_user_canisters_enabled_flag_fans_out_to_local_user_indexes() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+    } = wrapper.env();
+
+    let local_user_index = client::user_index::happy_path::user_registration_canister(env, canister_ids.user_index);
+
+    assert!(!multi_user_canisters_enabled(env, canister_ids.user_index));
+    assert!(!multi_user_canisters_enabled(env, local_user_index));
+
+    client::user_index::happy_path::set_multi_user_canisters_enabled(env, *controller, canister_ids.user_index, true);
+
+    // The UserIndex records it immediately, the LocalUserIndex receives it over the event queue
+    assert!(multi_user_canisters_enabled(env, canister_ids.user_index));
+    tick_many(env, 5);
+    assert!(multi_user_canisters_enabled(env, local_user_index));
+
+    client::user_index::happy_path::set_multi_user_canisters_enabled(env, *controller, canister_ids.user_index, false);
+    tick_many(env, 5);
+
+    assert!(!multi_user_canisters_enabled(env, canister_ids.user_index));
+    assert!(!multi_user_canisters_enabled(env, local_user_index));
+}
+
+fn multi_user_canisters_enabled(env: &PocketIc, canister_id: CanisterId) -> bool {
+    serde_json::from_value(metrics(env, canister_id)["multi_user_canisters_enabled"].clone()).unwrap()
+}
+
 fn wasm_version(env: &PocketIc, canister_id: CanisterId) -> BuildVersion {
     serde_json::from_value(metrics(env, canister_id)["wasm_version"].clone()).unwrap()
 }

--- a/sns/scripts/proposals/create_custom_sns_functions/1017.user_index.set_multi_user_canisters_enabled.ini
+++ b/sns/scripts/proposals/create_custom_sns_functions/1017.user_index.set_multi_user_canisters_enabled.ini
@@ -1,4 +1,4 @@
 FUNCTION_NAME="Set multi_user canisters enabled"
-FUNCTION_DESC="Enables or disables the use of multi_user canisters. The flag is recorded on the user_index and pushed to the local_user_index on each subnet. Currently the flag is only surfaced in metrics."
+FUNCTION_DESC="Enables or disables the use of multi_user canisters. The flag is recorded on the user_index then pushed to the local_user_index on each subnet."
 URL="https://github.com/open-chat-labs/open-chat/blob/master/backend/canisters/user_index/impl/src/updates/set_multi_user_canisters_enabled.rs"
 TOPIC="DappCanisterManagement"

--- a/sns/scripts/proposals/create_custom_sns_functions/1017.user_index.set_multi_user_canisters_enabled.ini
+++ b/sns/scripts/proposals/create_custom_sns_functions/1017.user_index.set_multi_user_canisters_enabled.ini
@@ -1,0 +1,4 @@
+FUNCTION_NAME="Set multi_user canisters enabled"
+FUNCTION_DESC="Enables or disables the use of multi_user canisters. The flag is recorded on the user_index and pushed to the local_user_index on each subnet. Currently the flag is only surfaced in metrics."
+URL="https://github.com/open-chat-labs/open-chat/blob/master/backend/canisters/user_index/impl/src/updates/set_multi_user_canisters_enabled.rs"
+TOPIC="DappCanisterManagement"


### PR DESCRIPTION
Follows on from #9311.

## Summary

Adds a `multi_user_canisters_enabled` flag as a kill switch for the MultiUser canister rollout. For now it is only surfaced in metrics - nothing acts on it yet.

**UserIndex**
- `set_multi_user_canisters_enabled` governance proposal (`Args { enabled: bool }`), whitelisted in `inspect_message`. Records the flag on `Data` and fans it out to every LocalUserIndex over the existing idempotent event queue as `UserIndexEvent::SetMultiUserCanistersEnabled(bool)`.
- New LocalUserIndexes are seeded with the current value via their init args, so a subnet added after the flag is set starts in the right state.
- Exposed as `multi_user_canisters_enabled` in metrics.

**LocalUserIndex**
- New `#[serde(default)]` init arg and `Data` field, event handler arm, and the same metric.

**Governance**
- SNS custom function definition `1017.user_index.set_multi_user_canisters_enabled.ini`.

## Test plan
- [x] `cargo clippy --workspace --exclude open-chat --exclude tauri-plugin-oc --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Integration test `multi_user_canister_tests::multi_user_canisters_enabled_flag_fans_out_to_local_user_indexes`: sets the flag on then off via the governance principal and checks it lands in both the UserIndex and LocalUserIndex metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
