### PR TITLE
Skip the required frontend checks on backend-only PRs

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -10,7 +10,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Backend-only PRs have nothing here to check. `install-and-test` is a required status check,
+  # so it must still run on every PR (a workflow-level `paths:` filter would leave the check
+  # pending and the PR unmergeable); instead it skips itself when nothing it depends on changed.
+  # A skipped job satisfies branch protection. This mirrors the `changes` job in backend.yaml.
+  changes:
+    name: detect frontend changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - "frontend/**"
+              - ".prettierignore"
+              - ".github/workflows/**"
+
   install-and-test:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Applies the same approach as #9294 to the "Frontend linting, type check & unit tests" workflow.

A new `changes` job uses `dorny/paths-filter` to detect whether anything the frontend build depends on changed (`frontend/**`, `.prettierignore`, `.github/workflows/**`). The `install-and-test` job now depends on it and skips itself otherwise. The job id is unchanged, so the required status check keeps its name, and a skipped job still satisfies branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)