### PR TITLE
Rollbar sweep: noise filters, duplicate reporting, quote declines, source maps

### DIFF
--- a/frontend/app/src/components/App.svelte
+++ b/frontend/app/src/components/App.svelte
@@ -638,7 +638,14 @@
             return;
         }
         recordError("window", err);
-        logger?.error("Unhandled error: ", err);
+        // Deliberately not reported here. Rollbar's own captureUncaught /
+        // captureUnhandledRejections already reports every event this handler sees, and
+        // installs earlier than this listener, so logging again produced two Rollbar items
+        // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
+        // every defect in two and doubling the volume. Its `checkIgnore` reads the rejection
+        // reason out of the original arguments, so worker errors - which arrive as plain
+        // objects, not Errors - are still filtered on name and code. This handler keeps the
+        // crash-log record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             client.logout();
             ev.preventDefault();

--- a/frontend/app/src/components_mobile/App.svelte
+++ b/frontend/app/src/components_mobile/App.svelte
@@ -323,7 +323,14 @@
             return;
         }
         recordError("window", err);
-        logger?.error("Unhandled error: ", err);
+        // Deliberately not reported here. Rollbar's own captureUncaught /
+        // captureUnhandledRejections already reports every event this handler sees, and
+        // installs earlier than this listener, so logging again produced two Rollbar items
+        // per rejection - one titled "Unhandled error: X" and one titled "X" - splitting
+        // every defect in two and doubling the volume. Its `checkIgnore` reads the rejection
+        // reason out of the original arguments, so worker errors - which arrive as plain
+        // objects, not Errors - are still filtered on name and code. This handler keeps the
+        // crash-log record and the logout, which Rollbar's capture does not do.
         if (ev instanceof PromiseRejectionEvent && requiresLogout(ev.reason)) {
             if (client.isNativeApp()) clearChatShortcuts();
             client.logout();

--- a/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/EditRecipient.svelte
@@ -2,6 +2,7 @@
     import { i18nKey, interpolate } from "@src/i18n/i18n";
     import { Body, CommonButton2, Container, Form, Input } from "component-lib";
     import { namedAccountsStore, type NamedAccount, type OpenChat } from "@client";
+    import { isAccountIdentifierValid, isICRCAddressValid } from "@shared";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
     import Save from "svelte-material-icons/ContentSaveOutline.svelte";
@@ -25,8 +26,13 @@
     let nameDirty = $derived(trimmedName !== account?.name);
     let addressDirty = $derived(trimmedAddress !== account?.account);
     let dirty = $derived(nameDirty || addressDirty);
-    // TODO this probably isn't good enough
-    let validAddress = $derived(trimmedAddress.length > 0);
+    // The same two forms `is_valid_account` in save_crypto_account.rs accepts: an ICRC-1 textual
+    // account, which covers a bare principal, or an ICP ledger account identifier (checksum
+    // included, as the canister checks it). Saving anything else used to succeed here and then
+    // throw out of the worker, unhandled, when the withdrawal mapper tried to decode it.
+    let validAddress = $derived(
+        isICRCAddressValid(trimmedAddress) || isAccountIdentifierValid(trimmedAddress),
+    );
     let validName = $derived(
         trimmedName.length > 0 &&
             $namedAccountsStore.find((a) => a.name.toLowerCase() === trimmedName.toLowerCase()) ===
@@ -53,9 +59,7 @@
         } else {
             loading = false;
             toastStore.showFailureToast(
-                i18nKey(
-                    "Could not save recipient. Make sure that the address is a valid principal.",
-                ),
+                i18nKey("Could not save recipient. Make sure that the address is valid."),
             );
         }
     }

--- a/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
+++ b/frontend/app/src/components_mobile/home/wallet/SendToAddress.svelte
@@ -392,7 +392,12 @@
             </Container>
         </Container>
         <Container gap={"sm"} direction={"vertical"} padding={["sm", "xl", "zero", "xl"]}>
-            {#if namedAccount === undefined}
+            <!-- Saved recipients are IC accounts only (principal, ICRC-1 account or ICP account
+                 identifier - what save_crypto_account accepts). A BTC or EVM address would open
+                 the recipient form with a save button that never enables and no way to see why.
+                 Keyed on the selected network, not the token: BTC sent over the ckBTC network
+                 goes to an IC principal, which can be saved. -->
+            {#if namedAccount === undefined && !isBtcNetwork && !isOneSecNetwork}
                 <Button secondary onClick={saveAddress}>
                     {#snippet icon(color)}
                         <Account {color} />

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/icpSwap.pool.client.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/icpSwap.pool.client.ts
@@ -18,7 +18,7 @@ export class IcpSwapPoolClient
         super(identity, agent, canisterId, idlFactory, "IcpSwapPool");
     }
 
-    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint> {
+    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint | undefined> {
         const zeroForOne = this.zeroForOne(inputToken, outputToken);
         const args = {
             amountIn: amountIn.toString(),

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.spec.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { quoteResponse } from "./mappers";
+
+// A decline (undefined) is dropped by quoteSwap and costs nothing; a throw is retried by
+// executeQuery seven times with backoff and, if every pool throws, reaches the error tracker.
+// Which ICPSwap variants land on which side is therefore load-bearing.
+describe("ICPSwap quoteResponse", () => {
+    test("a quote is returned as is", () => {
+        expect(quoteResponse({ ok: 123n })).toBe(123n);
+    });
+
+    test("InsufficientFunds and UnsupportedToken are declines", () => {
+        expect(quoteResponse({ err: { InsufficientFunds: null } })).toBeUndefined();
+        expect(quoteResponse({ err: { UnsupportedToken: "x" } })).toBeUndefined();
+    });
+
+    test("the dust-amount InternalError is a decline (the payload behind Rollbar #31881)", () => {
+        expect(
+            quoteResponse({
+                err: { InternalError: "The amount of input token is too small." },
+            }),
+        ).toBeUndefined();
+    });
+
+    test("any other InternalError, and CommonError, still throw so they are retried", () => {
+        expect(() => quoteResponse({ err: { InternalError: "pool is paused" } })).toThrow(
+            /Unable to get quote/,
+        );
+        expect(() => quoteResponse({ err: { CommonError: null } })).toThrow(/Unable to get quote/);
+    });
+});

--- a/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
+++ b/frontend/openchat-agent/src/services/dexes/icpSwap/pool/mappers.ts
@@ -1,8 +1,29 @@
 import type { ApiQuoteResponse } from "./candid/idl";
+import type { Error as ApiQuoteError } from "./candid/types";
 
-export function quoteResponse(candid: ApiQuoteResponse): bigint {
+// A decoded `err` variant is ICPSwap declining to quote - "amount of input token is too small"
+// is the usual reason - and is returned as undefined rather than thrown. Throwing here made a
+// decline indistinguishable from a transport failure: executeQuery retried it seven times with
+// backoff (roughly twelve seconds for a dust amount), quoteSwap could not tell "every pool
+// declined" from "every pool is down", and the error tracker filled with non-events.
+export function quoteResponse(candid: ApiQuoteResponse): bigint | undefined {
     if ("ok" in candid) {
         return candid.ok;
     }
+    if (isDecline(candid.err)) {
+        console.debug("ICPSwap declined to quote: ", candid.err);
+        return undefined;
+    }
     throw new Error("Unable to get quote from ICPSwap: " + JSON.stringify(candid));
+}
+
+// Which `err` variants mean "this pool will not quote this request" as opposed to "this pool
+// failed to answer". InsufficientFunds and UnsupportedToken are declines by definition.
+// InternalError is nominally a failure, but ICPSwap reports the commonest decline of all through
+// it - `{"InternalError":"The amount of input token is too small."}` is the exact payload behind
+// Rollbar #31881 - so that one message is a decline too. Anything else keeps throwing, which
+// keeps executeQuery's retries for a pool that is genuinely struggling.
+function isDecline(err: ApiQuoteError): boolean {
+    if ("InsufficientFunds" in err || "UnsupportedToken" in err) return true;
+    return "InternalError" in err && /too small/i.test(err.InternalError);
 }

--- a/frontend/openchat-agent/src/services/dexes/index.ts
+++ b/frontend/openchat-agent/src/services/dexes/index.ts
@@ -55,13 +55,37 @@ export class DexesAgent {
     ): Promise<[DexId, bigint][]> {
         const pools = await this.getSwapPools(inputToken, new Set([outputToken]), swapProviders);
 
-        return await Promise.all(
+        // A pool that cannot quote is a normal answer, not a failure: the commonest case is an
+        // amount too small for that pool's fee, and pools also go dry or get retired. Dropping it
+        // lets the remaining pools still be quoted, and an empty result already means "no quotes"
+        // to the caller. Promise.all here failed the whole request on any one pool's rejection.
+        const quotes = await Promise.allSettled(
             pools.map((p) =>
-                this.quoteSingle(p, inputToken, outputToken, amountIn).then(
-                    (quote) => [p.dex, quote] as [DexId, bigint],
+                this.quoteSingle(p, inputToken, outputToken, amountIn).then((quote) =>
+                    quote === undefined ? undefined : ([p.dex, quote] as [DexId, bigint]),
                 ),
             ),
         );
+        // A pool that declines resolves to undefined and is dropped; a pool that fails rejects.
+        // The two mean different things: with no quote in hand, a failure anywhere is what stopped
+        // the user getting one, and must surface rather than read as "no quotes". (Requiring every
+        // pool to have rejected let one decline plus one failure through as silence.)
+        const succeeded = quotes.flatMap((q) =>
+            q.status === "fulfilled" && q.value !== undefined ? [q.value] : [],
+        );
+        const failed = quotes.find((q): q is PromiseRejectedResult => q.status === "rejected");
+        if (succeeded.length === 0 && failed !== undefined) {
+            throw failed.reason;
+        }
+        // Some pool quoted, so the user gets a price - but a pool that failed after its retries
+        // while another answered is a DEX that is down, and the "best" quote shown may not be.
+        // Not worth failing the swap over; worth knowing about.
+        quotes.forEach((q, i) => {
+            if (q.status === "rejected") {
+                console.warn(`quoteSwap: ${pools[i].dex} pool failed, quoting without it`, q.reason);
+            }
+        });
+        return succeeded;
     }
 
     private getAllSwapPools(swapProviders: DexId[]): Promise<TokenSwapPool[]> {
@@ -93,7 +117,7 @@ export class DexesAgent {
         inputToken: string,
         outputToken: string,
         amountIn: bigint,
-    ): Promise<bigint> {
+    ): Promise<bigint | undefined> {
         const indexClient = this._swapIndexClients[pool.dex];
         if (indexClient === undefined) {
             return Promise.resolve(BigInt(0));
@@ -119,5 +143,7 @@ export interface SwapIndexClient {
 }
 
 export interface SwapPoolClient {
-    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint>;
+    // undefined when the pool declines to quote (amount too small, no liquidity); reject only
+    // for a failure to ask
+    quote(inputToken: string, outputToken: string, amountIn: bigint): Promise<bigint | undefined>;
 }

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -109,6 +109,28 @@ describe("shouldReportError", () => {
         expect(shouldReportError(lost)).toBe(false);
     });
 
+    test("silences a wrong client clock in both directions", () => {
+        // the client's clock is ahead, so the certificate the replica signed looks like the future
+        expect(
+            shouldReportError(
+                new Error("Certificate is signed more than 5 minutes in the future."),
+            ),
+        ).toBe(false);
+        // the client's clock is behind, so the expiry it computed is outside the replica's window
+        expect(
+            shouldReportError(
+                new HttpError(
+                    400,
+                    new Error(
+                        "Invalid request expiry: Minimum allowed expiry: 2026-09-08 01:43:31 UTC, " +
+                            "Maximum allowed expiry: 2026-09-08 01:49:01 UTC, " +
+                            "Provided expiry: 2026-08-26 04:23:00 UTC.",
+                    ),
+                ),
+            ),
+        ).toBe(false);
+    });
+
     test("silences the IC agent giving up after its fetch retries", () => {
         expect(
             shouldReportError(

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -58,11 +58,23 @@ const REQWEST_NOISE_PATTERN = /error decoding response body/i;
 
 const RETRY_EXHAUSTED_PATTERN = /retry strategy exhausted after \d+ attempts/i;
 
+// Every HttpError subclass overwrites `name` with its own, so a bare `name === "HttpError"` test
+// misses them. `code` only means an HTTP status on one of these.
+const HTTP_ERROR_NAMES = new Set<string>([
+    "HttpError",
+    "AuthError",
+    "DestinationInvalidError",
+    "CanisterUnavailableError",
+    "ResponseTooLargeError",
+]);
+
 function isTransientNetworkError(error: unknown): boolean {
     // Structural checks rather than instanceof: errors which crossed the worker boundary
     // arrive as plain objects where only name/message/code survive
     const name = errorName(error);
-    if (name === "HttpError") {
+    if (HTTP_ERROR_NAMES.has(name)) {
+        // 503 also covers CanisterUnavailableError: a frozen or uninstalled canister cannot
+        // recover inside one request, and server-side monitoring owns the incident.
         const code = Number((error as { code?: unknown }).code);
         if (code >= 502 && code <= 504) return true;
     }
@@ -102,6 +114,11 @@ const ENVIRONMENT_NOISE_PATTERNS: RegExp[] = [
     /connection to indexed database server lost/i,
     // The client's clock is wrong, so the replica certificate looks like it is from the future
     /certificate is signed more than 5 minutes in the future/i,
+    // The same wrong clock seen from the other side: the ingress expiry the agent computed from
+    // Date.now() falls outside the window the replica will accept. Devices weeks or months out of
+    // date produce these in storms, and because the replica echoes the timestamps back in the
+    // message, every skewed device mints a new error item rather than joining an existing one.
+    /invalid request expiry/i,
     // Safari's built-in media controls script, no frame of ours involved
     /can't find variable: EmptyRanges/i,
     // Benign browser warning surfaced as an error event

--- a/frontend/openchat-shared/src/utils/logging.spec.ts
+++ b/frontend/openchat-shared/src/utils/logging.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest";
+import { normaliseSourceMapUrls, uncaughtReason } from "./logging";
+
+// These expectations are the other half of a contract: `scripts/upload-source-maps.mjs` registers
+// each map as `http://dynamichost/<path relative to frontend/app/build>`. If a frame's filename
+// does not normalise to exactly that, Rollbar finds no map and the trace stays minified with no
+// error anywhere.
+function frames(...filenames: unknown[]) {
+    const payload = { body: { trace: { frames: filenames.map((filename) => ({ filename })) } } };
+    normaliseSourceMapUrls(payload);
+    return payload.body.trace.frames.map((f) => f.filename);
+}
+
+describe("normaliseSourceMapUrls", () => {
+    test("collapses every origin the bundle is served from", () => {
+        expect(
+            frames(
+                "https://oc.app/main-D_Idsc5v.js",
+                "https://webtest.oc.app/main-D_Idsc5v.js",
+                "https://6hsbt-vqaaa-aaaaf-aaafq-cai.icp0.io/main-D_Idsc5v.js",
+                "http://tauri.localhost/main-D_Idsc5v.js",
+                // iOS: a custom scheme, not http
+                "tauri://localhost/main-D_Idsc5v.js",
+            ),
+        ).toEqual(Array(5).fill("http://dynamichost/main-D_Idsc5v.js"));
+    });
+
+    test("drops the worker's cache-busting query", () => {
+        expect(frames("https://oc.app/worker.js?v=2.0.2052")).toEqual([
+            "http://dynamichost/worker.js",
+        ]);
+    });
+
+    test("keeps a nested chunk's directory", () => {
+        expect(frames("https://oc.app/assets/lazy-abc123.js")).toEqual([
+            "http://dynamichost/assets/lazy-abc123.js",
+        ]);
+    });
+
+    test("leaves extension frames alone so the extension filter still matches", () => {
+        expect(
+            frames(
+                "chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js",
+                "moz-extension://abc/inject.js",
+                "safari-web-extension://abc/inject.js",
+            ),
+        ).toEqual([
+            "chrome-extension://cadiboklkpojfamcoggejbbdjcoiljjk/inpage.js",
+            "moz-extension://abc/inject.js",
+            "safari-web-extension://abc/inject.js",
+        ]);
+    });
+
+    test("tolerates frames with no usable filename", () => {
+        expect(frames(undefined, "", "<anonymous>", 42)).toEqual([
+            undefined,
+            "",
+            "<anonymous>",
+            42,
+        ]);
+    });
+
+    test("walks every trace in a chain", () => {
+        const payload = {
+            body: {
+                trace_chain: [
+                    { frames: [{ filename: "https://oc.app/a.js" }] },
+                    { frames: [{ filename: "https://oc.app/b.js?v=1" }] },
+                ],
+            },
+        };
+        normaliseSourceMapUrls(payload);
+        expect(payload.body.trace_chain.map((t) => t.frames[0].filename)).toEqual([
+            "http://dynamichost/a.js",
+            "http://dynamichost/b.js",
+        ]);
+    });
+
+    test("ignores payloads with no trace at all", () => {
+        expect(() => normaliseSourceMapUrls({ body: { message: { body: "hello" } } })).not.toThrow();
+        expect(() => normaliseSourceMapUrls({})).not.toThrow();
+    });
+});
+
+// Rollbar passes `[message, reason, context, promise]` as the args for an unhandled rejection.
+// Anything thrown in the worker arrives as a plain object rather than an Error, so Rollbar files
+// it with no exception class and the payload alone cannot be filtered on name or code.
+describe("uncaughtReason", () => {
+    test("finds a worker error that lost its prototype", () => {
+        const reason = { name: "SessionExpiryError", message: "HTTP request failed", code: 400 };
+        expect(uncaughtReason(["HTTP request failed", reason, undefined, {}])).toBe(reason);
+    });
+
+    test("finds a real Error", () => {
+        const err = new TypeError("boom");
+        expect(uncaughtReason(["boom", err, undefined, {}])).toBe(err);
+    });
+
+    test("skips the message string and the promise", () => {
+        expect(uncaughtReason(["just a message", undefined, undefined, {}])).toBeUndefined();
+    });
+
+    test("tolerates a missing or malformed args list", () => {
+        expect(uncaughtReason(undefined)).toBeUndefined();
+        expect(uncaughtReason([])).toBeUndefined();
+        expect(uncaughtReason("not an array")).toBeUndefined();
+    });
+});

--- a/frontend/openchat-shared/src/utils/logging.ts
+++ b/frontend/openchat-shared/src/utils/logging.ts
@@ -32,6 +32,25 @@ function rollbarPayloadError(payload: any): { name: string; message: string } {
     };
 }
 
+// Rollbar hands `checkIgnore` the original arguments alongside the payload, and for an unhandled
+// rejection those include the rejection reason itself. That matters for anything thrown in the
+// worker: it crosses the boundary as JSON, so the reason arrives as a plain object rather than an
+// Error, Rollbar cannot read an exception class off it and files the item as "(unknown): message"
+// with no class at all. `name` and `code` are exactly what most of `shouldReportError`'s rules
+// are keyed on - session expiry, the 502-504 range, retry-exhausted - so reading them off the
+// payload alone silently loses every one of those. Recover the reason and filter on that.
+// Exported for testing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function uncaughtReason(args: any): unknown {
+    if (!Array.isArray(args)) return undefined;
+    return args.find(
+        (arg) =>
+            arg != null &&
+            typeof arg === "object" &&
+            (typeof arg.name === "string" || typeof arg.message === "string"),
+    );
+}
+
 // True when the innermost frame of the primary error is browser-extension code: the error was
 // thrown by an extension (CSP violations from injected wasm, wallet inpage scripts, ...), not us.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,6 +61,48 @@ function thrownByExtension(payload: any): boolean {
     // Rollbar frames are ordered outermost first, so the throw site is last
     const filename = frames[frames.length - 1]?.filename;
     return typeof filename === "string" && /^(chrome|moz|safari-web)-extension:\/\//.test(filename);
+}
+
+// Rollbar matches an uploaded source map to a stack frame by exact minified URL. The same bundle
+// is served from four origins - oc.app, webtest.oc.app, the canister's own .icp0.io domain, and
+// http://tauri.localhost in the native app - and the workers are loaded with a `?v=` cache
+// buster, so a frame's filename is one of many strings for the same file. `dynamichost` is
+// Rollbar's placeholder host for exactly this: rewrite every frame to it and one uploaded map
+// covers all four. `scripts/upload-source-maps.mjs` registers the same URLs.
+// Frames that are not http(s) are left alone - `thrownByExtension` identifies extension code by
+// the `chrome-extension://` prefix, and rewriting those would break that check.
+const DYNAMIC_HOST = "http://dynamichost";
+
+function normaliseFrameFilename(filename: unknown): string | undefined {
+    // tauri: is iOS, which serves the bundle from tauri://localhost (see navigation.rs); Android
+    // uses http://tauri.localhost and is covered by https?
+    if (typeof filename !== "string" || !/^(https?|tauri):\/\//i.test(filename)) return undefined;
+    try {
+        // pathname only: drops the origin and the `?v=` query, keeping any directory prefix so
+        // the URL still matches the map's path relative to the build directory
+        return `${DYNAMIC_HOST}${new URL(filename).pathname}`;
+    } catch {
+        return undefined;
+    }
+}
+
+// Exported for testing: a mismatch between this and the URLs `upload-source-maps.mjs` registers
+// fails silently, with traces simply staying minified.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normaliseSourceMapUrls(payload: any): void {
+    const body = payload?.body;
+    const traces = body?.trace_chain ?? (body?.trace != null ? [body.trace] : []);
+    if (!Array.isArray(traces)) return;
+    for (const trace of traces) {
+        const frames = trace?.frames;
+        if (!Array.isArray(frames)) continue;
+        for (const frame of frames) {
+            const normalised = normaliseFrameFilename(frame?.filename);
+            if (normalised !== undefined) {
+                frame.filename = normalised;
+            }
+        }
+    }
 }
 
 export function inititaliseLogger(apikey: string, version: string, env: string): Logger {
@@ -63,12 +124,17 @@ export function inititaliseLogger(apikey: string, version: string, env: string):
             // captureUncaught / captureUnhandledRejections bypass our logger, so uncaught
             // items get the same noise filtering at the transport layer. Logger-reported items
             // (isUncaught false) already passed shouldReportError and are not re-filtered here.
-            checkIgnore: (isUncaught, _args, payload) => {
+            checkIgnore: (isUncaught, args, payload) => {
                 if (!isUncaught) return false;
                 if (thrownByExtension(payload)) return true;
+                // Prefer the reason itself: it still carries name and code, which the payload
+                // does not for anything that crossed the worker boundary
+                const reason = uncaughtReason(args);
+                if (reason !== undefined) return !shouldReportError(reason);
                 const { name, message } = rollbarPayloadError(payload);
                 return !shouldReportMessage(name, message);
             },
+            transform: (payload) => normaliseSourceMapUrls(payload),
             payload: {
                 environment: env,
                 client: {

--- a/frontend/openchat-shared/src/utils/string.spec.ts
+++ b/frontend/openchat-shared/src/utils/string.spec.ts
@@ -1,0 +1,26 @@
+import { AccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
+import { Principal } from "@icp-sdk/core/principal";
+import { describe, expect, test } from "vitest";
+import { isAccountIdentifierValid } from "./string";
+
+// ICP ledger account identifiers carry a big-endian CRC32 of the hash in their first four bytes.
+// The canister checks it (AccountIdentifier::from_slice); a client that only checked length and
+// hex let a typo through to be rejected after the user had been told the address was fine.
+describe("isAccountIdentifierValid", () => {
+    const valid = AccountIdentifier.fromPrincipal({ principal: Principal.anonymous() }).toHex();
+
+    test("accepts an identifier whose checksum matches", () => {
+        expect(valid.length).toBe(64);
+        expect(isAccountIdentifierValid(valid)).toBe(true);
+    });
+
+    test("rejects a single-character typo", () => {
+        const typo = valid.slice(0, 40) + (valid[40] === "0" ? "1" : "0") + valid.slice(41);
+        expect(isAccountIdentifierValid(typo)).toBe(false);
+    });
+
+    test("still rejects the wrong length or non-hex", () => {
+        expect(isAccountIdentifierValid(valid.slice(1))).toBe(false);
+        expect(isAccountIdentifierValid("zz" + valid.slice(2))).toBe(false);
+    });
+});

--- a/frontend/openchat-shared/src/utils/string.ts
+++ b/frontend/openchat-shared/src/utils/string.ts
@@ -1,4 +1,5 @@
 import { Principal } from "@icp-sdk/core/principal";
+import { isIcpAccountIdentifier } from "@icp-sdk/canisters/ledger/icp";
 import { decodeIcrcAccount } from "./icrcAccount";
 
 export const HEX_REGEX = new RegExp("^[A-Fa-f0-9]+$");
@@ -23,8 +24,11 @@ export function isSubAccountValid(text: string): boolean {
     return text.length <= 64 && isHexString(text);
 }
 
+// Length, hex and the CRC32 in the first four bytes. Length and hex alone let a typo through to
+// the canister, whose AccountIdentifier::from_slice checks the checksum and rejects it - by which
+// point the user had already been told the address was fine.
 export function isAccountIdentifierValid(text: string): boolean {
-    return text.length === 64 && isHexString(text);
+    return isIcpAccountIdentifier(text);
 }
 
 export function isICRCAddressValid(text: string): boolean {

--- a/frontend/openchat-worker/src/worker.ts
+++ b/frontend/openchat-worker/src/worker.ts
@@ -225,15 +225,11 @@ function sendEvent(msg: Omit<WorkerEvent, "kind">): void {
     });
 }
 
-self.addEventListener("error", (err: ErrorEvent) => {
-    // The underlying error, not the event: the event serialises to nothing useful and dodges
-    // the logger's filtering
-    logger.error("WORKER: unhandled error: ", err.error ?? err.message);
-});
-
-self.addEventListener("unhandledrejection", (err: PromiseRejectionEvent) => {
-    logger.error("WORKER: unhandled promise rejection: ", err.reason ?? err);
-});
+// No error / unhandledrejection listeners here, deliberately. inititaliseLogger's Rollbar.init
+// runs in this worker too, and its captureUncaught / captureUnhandledRejections attach to `self`
+// (rollbar falls back to `self` where there is no `window`), so listeners that also called
+// logger.error reported every worker failure twice under two different titles - the same
+// duplication App.svelte had. Rollbar's checkIgnore filters on the rejection reason itself.
 
 self.addEventListener("message", (msg: MessageEvent<CorrelatedWorkerRequest>) => {
     logger.debug("WORKER: received ", msg.data.kind, msg.data.correlationId);

--- a/scripts/deploy-website-prod-test.sh
+++ b/scripts/deploy-website-prod-test.sh
@@ -14,6 +14,10 @@ npm run --prefix frontend deploy:prod_test
 
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
+
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
     dfx --identity $IDENTITY deploy --network ic_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod_test - failed"

--- a/scripts/deploy-website-testnet.sh
+++ b/scripts/deploy-website-testnet.sh
@@ -16,6 +16,10 @@ npm run --prefix frontend deploy:testnet
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+
     dfx --identity $IDENTITY deploy --network $OC_DFX_NETWORK --no-wallet --with-cycles 100000000000000 website
 else
   echo "npm run --prefix frontend deploy:testnet - failed"

--- a/scripts/deploy-website-web-test.sh
+++ b/scripts/deploy-website-web-test.sh
@@ -15,6 +15,10 @@ npm run --prefix frontend deploy:prod
 
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
+
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
     dfx --identity $IDENTITY deploy --network web_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod - failed"

--- a/scripts/prepare-frontend-assets.sh
+++ b/scripts/prepare-frontend-assets.sh
@@ -15,6 +15,10 @@ npm run --prefix frontend deploy:prod
 if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
+    # Register the built maps with Rollbar before the assets go live, so traces from this
+    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+
     dfx --identity $IDENTITY deploy --network ic --by-proposal website
 else
   echo "npm run --prefix frontend deploy:prod - failed"

--- a/scripts/upload-source-maps.mjs
+++ b/scripts/upload-source-maps.mjs
@@ -1,0 +1,135 @@
+// Uploads the built source maps to Rollbar so production stack traces demangle.
+//
+// Rollbar does not fetch source maps from your site, even when they are public (ours are). It
+// only reads maps uploaded to its API, stored per project + version + minified URL. That keying
+// is the point: errors are processed asynchronously, and worker.js has a fixed name, so a map
+// fetched after a later deploy would demangle old traces against new source and produce line
+// numbers that look right and are wrong.
+//
+// The URLs registered here must match what `normaliseSourceMapUrls` in openchat-shared's
+// logging.ts rewrites each stack frame to. Change one and you must change the other.
+//
+// Usage: node scripts/upload-source-maps.mjs <version>
+// Requires OC_ROLLBAR_SERVER_TOKEN - a post_server_item token from Rollbar's
+// Settings -> Project Access Tokens. The client token in OC_ROLLBAR_ACCESS_TOKEN is a
+// post_client_item token and the endpoint rejects it.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ENDPOINT = "https://api.rollbar.com/api/1/sourcemap";
+const DYNAMIC_HOST = "http://dynamichost";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const buildDir = path.join(repoRoot, "frontend/app/build");
+
+const version = process.argv[2] ?? process.env.OC_WEBSITE_VERSION;
+const token = process.env.OC_ROLLBAR_SERVER_TOKEN;
+
+if (!version) {
+    console.error("upload-source-maps: no version given (argv[2] or OC_WEBSITE_VERSION)");
+    process.exit(1);
+}
+
+// Not fatal. A missing token should not sink a deploy that is otherwise fine, but it must be
+// loud, because the failure mode is silent: traces simply stay minified.
+if (!token) {
+    console.warn("");
+    console.warn("  ****************************************************************");
+    console.warn("  OC_ROLLBAR_SERVER_TOKEN is not set - SKIPPING source map upload.");
+    console.warn(`  Stack traces for ${version} will stay minified in Rollbar.`);
+    console.warn("  ****************************************************************");
+    console.warn("");
+    process.exit(0);
+}
+
+function findMaps(dir) {
+    const found = [];
+    for (const entry of readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            found.push(...findMaps(full));
+        } else if (entry.endsWith(".js.map")) {
+            found.push(full);
+        }
+    }
+    return found;
+}
+
+const maps = findMaps(buildDir);
+if (maps.length === 0) {
+    console.error(`upload-source-maps: no .js.map files under ${buildDir} - did the build run?`);
+    process.exit(1);
+}
+
+console.log(`upload-source-maps: uploading ${maps.length} maps for ${version}`);
+
+// A lazy chunk per route means well over a hundred uploads, so run a few at a time. Small enough
+// not to look like abuse, large enough that the whole set finishes in seconds rather than minutes.
+const CONCURRENCY = 8;
+
+// A bad token fails all of them identically. Stop on the first one rather than printing the same
+// 403 a hundred and seventy times.
+class FatalUploadError extends Error {}
+
+// Rollbar echoes the rejected token back in its 403 body, which would otherwise put the secret
+// into terminal scrollback and CI logs.
+function redact(text) {
+    return text.split(token).join("<OC_ROLLBAR_SERVER_TOKEN>");
+}
+
+async function upload(mapPath) {
+    // "build/main-D_Idsc5v.js.map" -> "http://dynamichost/main-D_Idsc5v.js"
+    const relative = path.relative(buildDir, mapPath).split(path.sep).join("/");
+    const minifiedUrl = `${DYNAMIC_HOST}/${relative.replace(/\.map$/, "")}`;
+
+    const form = new FormData();
+    form.append("access_token", token);
+    form.append("version", version);
+    form.append("minified_url", minifiedUrl);
+    form.append("source_map", new Blob([readFileSync(mapPath)]), path.basename(mapPath));
+
+    let response;
+    try {
+        response = await fetch(ENDPOINT, { method: "POST", body: form });
+    } catch (err) {
+        console.error(`  FAIL  ${minifiedUrl} - ${redact(String(err))}`);
+        return false;
+    }
+
+    if (response.ok) return true;
+
+    const body = redact((await response.text()).replace(/\s+/g, " ").trim());
+    if (response.status === 401 || response.status === 403) {
+        throw new FatalUploadError(
+            `Rollbar rejected the token (${response.status}): ${body}\n` +
+                "  OC_ROLLBAR_SERVER_TOKEN must be a post_server_item token from Rollbar's\n" +
+                "  Settings -> Project Access Tokens, not the post_client_item one the app uses.",
+        );
+    }
+    console.error(`  FAIL  ${minifiedUrl} - ${response.status} ${body}`);
+    return false;
+}
+
+let failed = 0;
+const queue = [...maps];
+try {
+    await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+            for (let next = queue.pop(); next !== undefined; next = queue.pop()) {
+                if (!(await upload(next))) failed++;
+            }
+        }),
+    );
+} catch (err) {
+    if (!(err instanceof FatalUploadError)) throw err;
+    console.error(`upload-source-maps: ${err.message}`);
+    process.exit(1);
+}
+
+if (failed > 0) {
+    console.error(`upload-source-maps: ${failed} of ${maps.length} uploads failed`);
+    process.exit(1);
+}
+console.log(`upload-source-maps: all ${maps.length} maps uploaded for ${version}`);


### PR DESCRIPTION
The low-risk half of #9312, split out so it can merge on its own. Everything here is a filter, a deduplication, or build tooling. Nothing changes what the app does for a signed-in user. The behavioural changes from the sweep (session-expiry logout, unknown-ledger crashes, malformed cached chats) are in their own PRs.

## Noise filters

- **`/invalid request expiry/i`** in `ENVIRONMENT_NOISE_PATTERNS`. The client's clock being wrong, seen from the replica's side; `#31879`'s payload has a device 13 days behind. The replica echoes the timestamps back in the message, so every skewed device minted a new item. `#30918` alone was 1,122/day. Test covers a wrong clock in both directions.
- **`CanisterUnavailableError` was never filtered.** `isTransientNetworkError` gated its 502-504 check on `name === "HttpError"`, but every subclass overwrites `name`.

## Duplicate reporting

`captureUnhandledRejections` is on *and* `App.svelte` added its own listener calling `logger.error`, so every rejection produced two items under two titles (`#31582` logged both at 06:16:57). The worker had the identical pattern — Rollbar's `_gWindow()` falls back to `self` there. The logger calls are gone in all three places. At triage: `#31837`, `#31822` and `#25983` are logger-path items and will go quiet; their capture-path twins carry on.

That made `checkIgnore` the only filter for uncaught errors, and it read the payload alone. Anything thrown in the worker crosses as JSON, so the reason arrives as a plain object, Rollbar files it as `(unknown): message` with no class (`#2195` has that shape), and every name- or code-keyed rule silently missed. Rollbar passes the reason in `checkIgnore`'s `args`; it's filtered on that now, with tests.

## Quote declines

The ICPSwap mapper threw on a decoded `err` variant, so a decline looked like a transport failure: not in `executeQuery`'s no-retry list, so retried seven times with backoff (~12s for a dust amount), then reported. Now `InsufficientFunds` and `UnsupportedToken` decline; `InternalError` declines only for the "amount of input token is too small" message, which is the literal payload behind `#31881`; anything else throws and retries. `quoteSwap` drops declines, throws if nothing succeeded and anything failed, and warns about a pool that failed while another quoted. A spec pins all five cases.

## Recipient validation

`EditRecipient` accepted any non-empty string under a `// TODO this probably isn't good enough`; a bad address then threw out of the worker's withdrawal mapper, unhandled (`#31864`). It now accepts what `save_crypto_account` does: an ICRC-1 textual account or an ICP account identifier, checksum included via the SDK's `isIcpAccountIdentifier`. `SendToAddress` stops offering "Save address" after a send over the BTC or an EVM network, where the target can never be an IC account; it still does over ckBTC, where it is one.

## Source maps

Rollbar never fetches maps from your site, even public ones. It only reads uploaded ones, keyed by version + minified URL, and that keying matters because `worker.js` has a fixed name, so a map fetched after a later deploy would demangle old traces against new source.

- `scripts/upload-source-maps.mjs` registers every `build/*.js.map` as `http://dynamichost/<path>`. No new dependencies. Eight concurrent; a 401/403 aborts with one redacted message.
- A `transform` in `logging.ts` rewrites each frame to that same URL, collapsing the origins the bundle is served from (`oc.app`, webtest, the canister domain, `http://tauri.localhost` on Android and `tauri://localhost` on iOS) and the workers' `?v=` cache buster. Tests pin the rewrite against the literal URLs the script registers.
- Wired into all four website deploy scripts. Needs `OC_ROLLBAR_SERVER_TOKEN` (`post_server_item`); warns loudly and exits 0 without it.

Verified for real: 173 maps for 2.0.2052 uploaded in ~11s including the 5.2MB vendor map, and the same maps backfilled under the live `oc.app` URLs so `#31837` should demangle on its next occurrence.

## Testing

`npm run typecheck` 0 errors, `typecheck:agent` clean, 908 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA
