### PR TITLE
Stop crashing on a ledger the token registry does not carry

### DIFF
--- a/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
-    import type { OpenChat, SignerWallet } from "@client";
-    import {
-        cryptoBalanceStore,
-        enhancedCryptoLookup as cryptoLookup,
-        mobileWidth,
-    } from "@client";
+    import type { OpenChat, SignerWallet, TokenInfo } from "@client";
+    import { cryptoBalanceStore, mobileWidth } from "@client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
     import Button from "../Button.svelte";
@@ -20,8 +16,8 @@
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        ledger0: string;
-        ledger1: string;
+        token0: TokenInfo;
+        token1: TokenInfo;
         amount0: bigint;
         amount1: bigint;
         onClose: () => void;
@@ -30,7 +26,8 @@
         onAccept: (fromAccount?: string) => void;
     }
 
-    let { ledger0, ledger1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let { token0, token1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let ledger1 = $derived(token1.ledger);
 
     let refreshing = false;
     let error: string | undefined = undefined;
@@ -66,19 +63,21 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0)!);
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1)!);
-    let symbol0 = $derived(tokenDetails0.symbol);
-    let symbol1 = $derived(tokenDetails1.symbol);
-    let transferFees = $derived(BigInt(2) * tokenDetails1.transferFee);
+    // Symbol, decimals and fee come from the swap message itself, not the registry: the
+    // message carries the TokenInfo the canister charges from (it debits token1.fee from the
+    // content), so this cannot drift from the real charge and cannot meet a ledger the registry
+    // has never heard of.
+    let symbol0 = $derived(token0.symbol);
+    let symbol1 = $derived(token1.symbol);
+    let transferFees = $derived(BigInt(2) * token1.fee);
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
     let valid = $derived(error === undefined && !insufficient);
-    let amount0Text = $derived(client.formatTokens(amount0, tokenDetails0.decimals));
-    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, tokenDetails1.decimals));
+    let amount0Text = $derived(client.formatTokens(amount0, token0.decimals));
+    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, token1.decimals));
 </script>
 
 <Overlay dismissible>

--- a/frontend/app/src/components/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components/home/BalanceWithRefresh.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { OpenChat, ResourceKey } from "@client";
+    import type { EnhancedTokenDetails, OpenChat, ResourceKey } from "@client";
     import { enhancedCryptoLookup as cryptoLookup } from "@client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
@@ -66,7 +66,7 @@
         toppingUp = !toppingUp;
     }
 
-    function convertValue(c: Exclude<typeof conversion, "none">, t: typeof tokenDetails): string {
+    function convertValue(c: Exclude<typeof conversion, "none">, t: EnhancedTokenDetails): string {
         switch (c) {
             case "usd":
                 return t.dollarBalance?.toFixed(2) ?? "???";
@@ -78,14 +78,18 @@
                 return t.ethBalance?.toFixed(6) ?? "???";
         }
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // An unrecognised ledger has no decimals we can trust, so a formatted figure would be
+    // wrong rather than missing. Show it as unknown instead.
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let formattedValue = $derived(
-        hideBalance
-            ? "*****"
-            : conversion === "none"
-              ? client.formatTokens(value, tokenDetails.decimals)
-              : convertValue(conversion, tokenDetails),
+        tokenDetails === undefined
+            ? "?????"
+            : hideBalance
+              ? "*****"
+              : conversion === "none"
+                ? client.formatTokens(value, tokenDetails.decimals)
+                : convertValue(conversion, tokenDetails),
     );
     $effect(() => {
         if (ledger) {

--- a/frontend/app/src/components/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components/home/BalanceWithRefresh.svelte
@@ -44,6 +44,9 @@
     }: Props = $props();
 
     export function refresh(allowCached: boolean = false) {
+        // Nothing to refresh for a ledger the registry does not carry, and a failure would be
+        // reported under a blank symbol. Mirrors TokenState.refreshBalance.
+        if (tokenDetails === undefined) return Promise.resolve();
         onClick?.();
         refreshing = true;
 
@@ -105,12 +108,12 @@
     <div class="amount" class:bold>
         {formattedValue}
     </div>
-    {#if showRefresh && !hideBalance}
+    {#if showRefresh && !hideBalance && tokenDetails !== undefined}
         <div class="refresh" class:refreshing onclick={() => refresh()}>
             <Refresh size={"1em"} color={"var(--icon-txt)"} />
         </div>
     {/if}
-    {#if showTopUp}
+    {#if showTopUp && tokenDetails !== undefined}
         <div class="top-up" onclick={topUp} title={$_("cryptoAccount.topUp")}>
             <Plus size={"1em"} color={toppingUp ? "var(--icon-selected)" : "var(--icon-txt)"} />
         </div>

--- a/frontend/app/src/components/home/P2PSwapContent.svelte
+++ b/frontend/app/src/components/home/P2PSwapContent.svelte
@@ -251,8 +251,8 @@
             action={cancel} />
     {:else}
         <AcceptP2PSwapModal
-            ledger0={content.token0.ledger}
-            ledger1={content.token1.ledger}
+            token0={content.token0}
+            token1={content.token1}
             amount0={content.token0Amount}
             amount1={content.token1Amount}
             onAccept={accept}

--- a/frontend/app/src/components/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components/home/PrizeWinnerContent.svelte
@@ -36,10 +36,17 @@
         ev.stopPropagation();
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
-    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // The registry does not always carry the prize's ledger - it can predate the token being
+    // added, or outlive it being dropped - and asserting it does crashed the message list.
+    // Without decimals the amount cannot be stated, so say so rather than invent a scale: the
+    // same transfer must never render as two different numbers depending on which component
+    // drew it.
+    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
+        tokenDetails === undefined
+            ? "?????"
+            : client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components/home/access/PaymentGateEvaluator.svelte
@@ -62,7 +62,7 @@
     function onClickPrimary() {
         if (insufficientFunds) {
             balanceWithRefresh?.refresh();
-        } else {
+        } else if (token !== undefined) {
             onApprovePayment({
                 ledger: token.ledger,
                 amount: gate.amount,
@@ -70,25 +70,35 @@
             });
         }
     }
-    let token = $derived(client.getTokenDetailsForAccessGate(gate)!);
-    let originalBalance = $derived($cryptoBalanceStore.get(token.ledger) ?? 0n);
+    // A gate can name a ledger the registry does not carry. Asserting it did threw on the first
+    // derived read of `token.ledger` - the s($).ledger boundary crash - and this is the copy every
+    // desktop-width viewport renders.
+    let token = $derived(client.getTokenDetailsForAccessGate(gate));
+    let originalBalance = $derived($cryptoBalanceStore.get(gate.ledgerCanister) ?? 0n);
     let cryptoBalance = $derived(
-        balanceAfterCurrentCommitments(token.ledger, paymentApprovals, originalBalance),
+        balanceAfterCurrentCommitments(gate.ledgerCanister, paymentApprovals, originalBalance),
     );
     let insufficientFunds = $derived(cryptoBalance < gate.amount);
     let approvalMessage = $derived(
-        interpolate(
-            $_,
-            i18nKey(
-                "access.paymentApprovalMessage",
-                {
-                    amount: client.formatTokens(gate.amount, token.decimals),
-                    token: token.symbol,
-                },
-                level,
-                true,
-            ),
-        ),
+        token === undefined
+            ? interpolate(
+                  $_,
+                  i18nKey(
+                      "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
+                  ),
+              )
+            : interpolate(
+                  $_,
+                  i18nKey(
+                      "access.paymentApprovalMessage",
+                      {
+                          amount: client.formatTokens(gate.amount, token.decimals),
+                          token: token.symbol,
+                      },
+                      level,
+                      true,
+                  ),
+              ),
     );
     let distributionMessage = $derived(
         interpolate($_, i18nKey("access.paymentDistributionMessage", undefined, level, true)),
@@ -115,7 +125,7 @@
 </div>
 <div>
     <p>
-        <Markdown text={approvalMessage + " " + distributionMessage} />
+        <Markdown text={token === undefined ? approvalMessage : approvalMessage + " " + distributionMessage} />
     </p>
     {#if gate.expiry !== undefined}
         <AlertBox>
@@ -127,7 +137,7 @@
             <ErrorMessage><Translatable resourceKey={errorMessage} /></ErrorMessage>
         </div>
     {/if}
-    {#if insufficientFunds}
+    {#if insufficientFunds && token !== undefined}
         <AccountInfo ledger={gate.ledgerCanister} />
         <p><Translatable resourceKey={i18nKey("tokenTransfer.makeDeposit")} /></p>
     {/if}
@@ -135,9 +145,11 @@
 <div>
     <ButtonGroup>
         <Button secondary onClick={onClose}>{$_("cancel")}</Button>
-        <Button loading={refreshingBalance} onClick={onClickPrimary}
-            ><Translatable
-                resourceKey={i18nKey(insufficientFunds ? "Refresh" : "Approve payment")} /></Button>
+        {#if token !== undefined}
+            <Button loading={refreshingBalance} onClick={onClickPrimary}
+                ><Translatable
+                    resourceKey={i18nKey(insufficientFunds ? "Refresh" : "Approve payment")} /></Button>
+        {/if}
     </ButtonGroup>
 </div>
 

--- a/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Body, Column, CommonButton, Row, Sheet, Subtitle } from "component-lib";
-    import type { OpenChat, SignerWallet } from "@client";
-    import { cryptoBalanceStore, enhancedCryptoLookup as cryptoLookup } from "@client";
+    import type { OpenChat, SignerWallet, TokenInfo } from "@client";
+    import { cryptoBalanceStore } from "@client";
     import { getContext } from "svelte";
     import { i18nKey } from "../../i18n/i18n";
     import Translatable from "../Translatable.svelte";
@@ -13,8 +13,8 @@
     const client = getContext<OpenChat>("client");
 
     interface Props {
-        ledger0: string;
-        ledger1: string;
+        token0: TokenInfo;
+        token1: TokenInfo;
         amount0: bigint;
         amount1: bigint;
         onClose: () => void;
@@ -23,7 +23,8 @@
         onAccept: (fromAccount?: string) => void;
     }
 
-    let { ledger0, ledger1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let { token0, token1, amount0, amount1, onClose, onAccept }: Props = $props();
+    let ledger1 = $derived(token1.ledger);
 
     let refreshing = false;
     let error: string | undefined = undefined;
@@ -59,19 +60,21 @@
     }
 
     let cryptoBalance = $derived($cryptoBalanceStore.get(ledger1) ?? 0n);
-    let tokenDetails0 = $derived($cryptoLookup.get(ledger0)!);
-    let tokenDetails1 = $derived($cryptoLookup.get(ledger1)!);
-    let symbol0 = $derived(tokenDetails0.symbol);
-    let symbol1 = $derived(tokenDetails1.symbol);
-    let transferFees = $derived(BigInt(2) * tokenDetails1.transferFee);
+    // Symbol, decimals and fee come from the swap message itself, not the registry: the
+    // message carries the TokenInfo the canister charges from (it debits token1.fee from the
+    // content), so this cannot drift from the real charge and cannot meet a ledger the registry
+    // has never heard of.
+    let symbol0 = $derived(token0.symbol);
+    let symbol1 = $derived(token1.symbol);
+    let transferFees = $derived(BigInt(2) * token1.fee);
     // An OpenChat balance which cannot cover the swap is no obstacle when an external wallet is
     // paying instead
     let insufficient = $derived(
         sourceWallet === undefined && cryptoBalance <= amount1 + transferFees,
     );
     let valid = $derived(error === undefined && !insufficient);
-    let amount0Text = $derived(client.formatTokens(amount0, tokenDetails0.decimals));
-    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, tokenDetails1.decimals));
+    let amount0Text = $derived(client.formatTokens(amount0, token0.decimals));
+    let amount1Text = $derived(client.formatTokens(amount1 + transferFees, token1.decimals));
 </script>
 
 <Sheet onDismiss={onClose}>

--- a/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
@@ -40,6 +40,9 @@
     }: Props = $props();
 
     export function refresh(allowCached: boolean = false) {
+        // Nothing to refresh for a ledger the registry does not carry, and a failure would be
+        // reported under a blank symbol. Mirrors TokenState.refreshBalance.
+        if (tokenDetails === undefined) return Promise.resolve();
         onClick?.();
         refreshing = true;
 
@@ -100,12 +103,12 @@
     <Body blur={hideBalance} width={"hug"} fontWeight={"bold"}>
         {formattedValue}
     </Body>
-    {#if showRefresh && !hideBalance}
+    {#if showRefresh && !hideBalance && tokenDetails !== undefined}
         <div class="refresh" class:refreshing onclick={() => refresh()}>
             <Refresh size={"1.5rem"} color={"var(--icon-txt)"} />
         </div>
     {/if}
-    {#if showTopUp}
+    {#if showTopUp && tokenDetails !== undefined}
         <div class="top-up" onclick={topUp} title={$_("cryptoAccount.topUp")}>
             <Plus size={"1.5rem"} color={toppingUp ? "var(--icon-selected)" : "var(--icon-txt)"} />
         </div>

--- a/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
+++ b/frontend/app/src/components_mobile/home/BalanceWithRefresh.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Body, Container } from "component-lib";
-    import type { OpenChat } from "@client";
+    import type { EnhancedTokenDetails, OpenChat } from "@client";
     import { enhancedCryptoLookup as cryptoLookup } from "@client";
     import { getContext } from "svelte";
     import { _ } from "svelte-i18n";
@@ -62,7 +62,7 @@
         toppingUp = !toppingUp;
     }
 
-    function convertValue(c: Exclude<typeof conversion, "none">, t: typeof tokenDetails): string {
+    function convertValue(c: Exclude<typeof conversion, "none">, t: EnhancedTokenDetails): string {
         switch (c) {
             case "usd":
                 return t.dollarBalance?.toFixed(2) ?? "???";
@@ -74,12 +74,16 @@
                 return t.ethBalance?.toFixed(6) ?? "???";
         }
     }
-    let tokenDetails = $derived($cryptoLookup.get(ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // An unrecognised ledger has no decimals we can trust, so a formatted figure would be
+    // wrong rather than missing. Show it as unknown instead.
+    let tokenDetails = $derived($cryptoLookup.get(ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let formattedValue = $derived(
-        conversion === "none"
-            ? client.formatTokens(value, tokenDetails.decimals)
-            : convertValue(conversion, tokenDetails),
+        tokenDetails === undefined
+            ? "?????"
+            : conversion === "none"
+              ? client.formatTokens(value, tokenDetails.decimals)
+              : convertValue(conversion, tokenDetails),
     );
     $effect(() => {
         if (ledger) {

--- a/frontend/app/src/components_mobile/home/CryptoContent.svelte
+++ b/frontend/app/src/components_mobile/home/CryptoContent.svelte
@@ -42,7 +42,7 @@
         $currentUserIdStore === senderId ? content.transfer.recipient : senderId,
     );
 
-    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)!));
+    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)));
     let transactionUrl = $derived(
         content.transfer.kind === "completed"
             ? client.buildTransactionUrl(content.transfer.blockIndex, content.transfer.ledger)

--- a/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
+++ b/frontend/app/src/components_mobile/home/P2PSwapContent.svelte
@@ -77,8 +77,8 @@
         onRemove,
     }: Props = $props();
 
-    let fromState = $derived(new TokenState($cryptoLookup.get(content.token0.ledger)!));
-    let toState = $derived(new TokenState($cryptoLookup.get(content.token1.ledger)!));
+    let fromState = $derived(new TokenState($cryptoLookup.get(content.token0.ledger)));
+    let toState = $derived(new TokenState($cryptoLookup.get(content.token1.ledger)));
     let confirming = $state(false);
     let showDetails = $state(false);
     let finished = $derived(
@@ -265,8 +265,8 @@
             action={cancel} />
     {:else}
         <AcceptP2PSwapModal
-            ledger0={content.token0.ledger}
-            ledger1={content.token1.ledger}
+            token0={content.token0}
+            token1={content.token1}
             amount0={content.token0Amount}
             amount1={content.token1Amount}
             onAccept={accept}

--- a/frontend/app/src/components_mobile/home/PrizeContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeContent.svelte
@@ -180,7 +180,7 @@
 
     let initialTokenState = $derived(
         content.kind === "prize_content_initial"
-            ? new TokenState($enhancedCryptoLookup.get(content.transfer.ledger)!)
+            ? new TokenState($enhancedCryptoLookup.get(content.transfer.ledger))
             : undefined,
     );
 
@@ -242,12 +242,18 @@
                     height={{ size: "0.25rem" }}
                     background={ColourVars.surface1}
                     borderRadius="circle">.</Row>
-                <Row padding="sm">
-                    <TransferFeesMessage
-                        symbol={initialTokenState.symbol}
-                        tokenDecimals={initialTokenState.decimals}
-                        transferFees={content.fees} />
-                </Row>
+                <!-- tokenDecimals goes straight to the formatter, bypassing formatTokens and
+                     its unknown-token guard, so an unrecognised ledger would print the fee in
+                     raw base units next to an amount rendered as "?????" - two numbers for one
+                     token. Say nothing about fees instead. -->
+                {#if !initialTokenState.unknown}
+                    <Row padding="sm">
+                        <TransferFeesMessage
+                            symbol={initialTokenState.symbol}
+                            tokenDecimals={initialTokenState.decimals}
+                            transferFees={content.fees} />
+                    </Row>
+                {/if}
             </Column>
         </Column>
     {/if}

--- a/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
+++ b/frontend/app/src/components_mobile/home/PrizeWinnerContent.svelte
@@ -36,10 +36,17 @@
         ev.stopPropagation();
     }
     let logo = $derived($cryptoLookup.get(content.transaction.ledger)?.logo ?? "");
-    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger)!);
-    let symbol = $derived(tokenDetails.symbol);
+    // The registry does not always carry the prize's ledger - it can predate the token being
+    // added, or outlive it being dropped - and asserting it does crashed the message list.
+    // Without decimals the amount cannot be stated, so say so rather than invent a scale: the
+    // same transfer must never render as two different numbers depending on which component
+    // drew it.
+    let tokenDetails = $derived($cryptoLookup.get(content.transaction.ledger));
+    let symbol = $derived(tokenDetails?.symbol ?? "");
     let amount = $derived(
-        client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
+        tokenDetails === undefined
+            ? "?????"
+            : client.formatTokens(content.transaction.amountE8s, tokenDetails.decimals),
     );
     let winner = $derived(`${username(content.transaction.recipient)}`);
     let me = $derived($currentUserIdStore === content.transaction.recipient);

--- a/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
+++ b/frontend/app/src/components_mobile/home/access/AccessGateSummary.svelte
@@ -47,7 +47,7 @@
         switch (gate.kind) {
             case "token_balance_gate":
             case "payment_gate":
-                return new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)!, "usd");
+                return new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister), "usd");
             default:
                 return undefined;
         }
@@ -138,9 +138,11 @@
     {:else}
         <MenuTrigger maskUI align={"end"} position={"bottom"} fill mobileMode={"longpress"}>
             {#snippet menuItems()}
-                <MenuItem onclick={refresh}>
-                    <Translatable resourceKey={i18nKey("Refresh balance")} />
-                </MenuItem>
+                {#if refresh}
+                    <MenuItem onclick={refresh}>
+                        <Translatable resourceKey={i18nKey("Refresh balance")} />
+                    </MenuItem>
+                {/if}
             {/snippet}
             <AccessGateBox {satisfied} satisfiable={!insufficient} {onClick}>
                 <Avatar url={logo} />
@@ -188,8 +190,8 @@
             "payment gate",
             tokenState.formatTokens(gate.amount),
             tokenState.formatTokens(balance),
-            () => onClick(gate),
-            () => tokenState.refreshBalance(client),
+            tokenState.unknown ? undefined : () => onClick(gate),
+            tokenState.unknown ? undefined : () => tokenState.refreshBalance(client),
         )}
     {:else if gate.kind === "token_balance_gate" && tokenState}
         {@const balance = accessApprovalState.balanceAfterCurrentCommitments(
@@ -204,8 +206,8 @@
             "minimum balance gate",
             tokenState.formatTokens(gate.minBalance),
             tokenState.formatTokens(balance),
-            () => onClick(gate),
-            () => tokenState.refreshBalance(client),
+            tokenState.unknown ? undefined : () => onClick(gate),
+            tokenState.unknown ? undefined : () => tokenState.refreshBalance(client),
         )}
     {:else if gate.kind === "neuron_gate" && token}
         {@render neuronGate(gate, token)}

--- a/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/BalanceGateEvaluator.svelte
@@ -29,7 +29,7 @@
 
     let { gate, onClose }: Props = $props();
 
-    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)!));
+    let tokenState = $derived(new TokenState($enhancedCryptoLookup.get(gate.ledgerCanister)));
     let cryptoBalance = $derived(
         accessApprovalState.balanceAfterCurrentCommitments(
             tokenState.ledger,
@@ -62,17 +62,21 @@
                 </Caption>
             </Column>
         </Row>
-        <Column
-            onClick={topup}
-            mainAxisAlignment={"center"}
-            crossAxisAlignment={"center"}
-            width={{ size: "4rem" }}
-            height={"fill"}
-            borderRadius={"lg"}
-            background={ColourVars.surface2}
-            padding={["sm", "md"]}>
-            <QrCode size={"2rem"} color={ColourVars.textSecondary} />
-        </Column>
+        <!-- No top-up for a ledger the registry does not carry: ReceiveCrypto would open on a
+             nameless token with no receiving address worth showing -->
+        {#if !tokenState.unknown}
+            <Column
+                onClick={topup}
+                mainAxisAlignment={"center"}
+                crossAxisAlignment={"center"}
+                width={{ size: "4rem" }}
+                height={"fill"}
+                borderRadius={"lg"}
+                background={ColourVars.surface2}
+                padding={["sm", "md"]}>
+                <QrCode size={"2rem"} color={ColourVars.textSecondary} />
+            </Column>
+        {/if}
     </Row>
 {/snippet}
 

--- a/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
+++ b/frontend/app/src/components_mobile/home/access/PaymentGateEvaluator.svelte
@@ -43,12 +43,20 @@
 
     let { gate, level, onApprovePayment, onClose }: Props = $props();
 
-    let token = $derived($enhancedCryptoLookup.get(gate.ledgerCanister)!);
+    // A gate can name a ledger the registry does not carry. `token.ledger` below then threw and
+    // took the app down; and with no decimals or fee we can neither state the amount nor build a
+    // valid approval, so the payment must not be offered at all.
+    let token = $derived($enhancedCryptoLookup.get(gate.ledgerCanister));
     let tokenState = $derived(new TokenState(token));
     let refreshingBalance = $state(false);
     let totalAmount = $derived(tokenState.formatTokens(gate.amount));
-    let toOwner = $derived(tokenState.formatTokens(BigInt(Number(gate.amount) * 0.98)));
-    let toOC = $derived(tokenState.formatTokens(BigInt(Number(gate.amount) * 0.02)));
+    // Integer arithmetic: BigInt(Number(amount) * 0.98) throws a RangeError for any amount that
+    // is not a multiple of 50, because the product is not an integer (12345678n throws;
+    // 100000000n only happens to pass). The remainder goes to the treasury so the two sum to
+    // the amount, matching how the canister splits it.
+    let ownerShare = $derived((gate.amount * 98n) / 100n);
+    let toOwner = $derived(tokenState.formatTokens(ownerShare));
+    let toOC = $derived(tokenState.formatTokens(gate.amount - ownerShare));
 
     let cryptoBalance = $derived(
         accessApprovalState.balanceAfterCurrentCommitments(
@@ -65,7 +73,7 @@
                 "access.paymentApprovalMessage",
                 {
                     amount: tokenState.formatTokens(gate.amount),
-                    token: token.symbol,
+                    token: tokenState.symbol,
                 },
                 level,
                 true,
@@ -93,7 +101,7 @@
                 </Caption>
             </Column>
         </Row>
-        {#if insufficientFunds}
+        {#if insufficientFunds && !tokenState.unknown}
             <Column
                 onClick={() => publish("receiveToken", tokenState)}
                 mainAxisAlignment={"center"}
@@ -112,22 +120,36 @@
 <Column gap={"lg"}>
     <Wallet size={"4.5rem"} color={ColourVars.primary} />
     <H2 fontWeight={"bold"}>
-        <MulticolourText
-            parts={[
-                {
-                    text: i18nKey(tokenState.symbol),
-                    colour: "primary",
-                },
-                {
-                    text: i18nKey(" payment gate"),
-                    colour: "textPrimary",
-                },
-            ]} />
+        {#if tokenState.unknown}
+            <Translatable resourceKey={i18nKey("Unrecognised token")} />
+        {:else}
+            <MulticolourText
+                parts={[
+                    {
+                        text: i18nKey(tokenState.symbol),
+                        colour: "primary",
+                    },
+                    {
+                        text: i18nKey(" payment gate"),
+                        colour: "textPrimary",
+                    },
+                ]} />
+        {/if}
     </H2>
     <Body colour={"textSecondary"}>
-        <Markdown text={approvalMessage} />
+        {#if tokenState.unknown}
+            <Translatable
+                resourceKey={i18nKey(
+                    "This gate is priced in a token OpenChat does not recognise, so the payment cannot be made here.",
+                )} />
+        {:else}
+            <Markdown text={approvalMessage} />
+        {/if}
     </Body>
 
+    <!-- Nothing below is meaningful for a token we cannot identify: the balance card would show
+         a blank symbol, and the breakdown amounts would all be "?????" -->
+    {#if !tokenState.unknown}
     <Column gap={"sm"}>
         {@render tokenBalance()}
         {#if insufficientFunds}
@@ -185,11 +207,16 @@
             </Row>
         </Column>
     </Column>
+    {/if}
 </Column>
 
-{#if insufficientFunds}
+{#if tokenState.unknown}
+    <CommonButton width={"fill"} size={"small_text"} onClick={onClose}>
+        <Translatable resourceKey={i18nKey("cancel")} />
+    </CommonButton>
+{:else if insufficientFunds}
     {@render refreshBalance()}
-{:else}
+{:else if token}
     <Button
         width={"fill"}
         onClick={() =>

--- a/frontend/app/src/components_mobile/home/insurance/StreakInsuranceBuy.svelte
+++ b/frontend/app/src/components_mobile/home/insurance/StreakInsuranceBuy.svelte
@@ -40,7 +40,7 @@
     const MAX_DAYS = 30;
     const ledger = LEDGER_CANISTER_CHAT;
     const token = $derived($enhancedCryptoLookup.get(ledger));
-    const tokenState = $derived(new TokenState(token!));
+    const tokenState = $derived(new TokenState(token));
     const currentDaysInsured = $streakInsuranceStore.daysInsured;
     const currentDaysMissed = $streakInsuranceStore.daysMissed;
     let { onClose }: Props = $props();

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.test.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { TokenState } from "./walletState.svelte";
+
+// The first version of `unknown` compared `#token === nullToken`. `#token` is `$state`, Svelte
+// proxies whatever is assigned to it, and the comparison was always false - every guard built on
+// it was inert and the crash it was meant to stop was one tap away. This pins the contract.
+describe("TokenState with a ledger the registry does not carry", () => {
+    test("reports itself as unknown", () => {
+        expect(new TokenState(undefined).unknown).toBe(true);
+    });
+
+    test("refuses to format an amount rather than inventing a scale", () => {
+        expect(new TokenState(undefined).formatTokens(123456789n)).toBe("?????");
+    });
+
+    test("does not stay unknown once a real token is assigned", () => {
+        const state = new TokenState(undefined);
+        state.token = {
+            name: "Internet Computer",
+            symbol: "ICP",
+            ledger: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+            index: undefined,
+            decimals: 8,
+            transferFee: 10000n,
+            logo: "",
+            infoUrl: "",
+            transactionUrlFormat: "",
+            supportedStandards: [],
+            added: 0n,
+            enabled: true,
+            oneSecEnabled: false,
+            evmContractAddresses: [],
+            lastUpdated: 0n,
+            balance: 0n,
+            dollarBalance: undefined,
+            icpBalance: undefined,
+            btcBalance: undefined,
+            ethBalance: undefined,
+            zero: false,
+            urlFormat: "",
+        };
+        expect(state.unknown).toBe(false);
+        expect(state.formatTokens(123456789n)).not.toBe("?????");
+        expect(state.formatTokens(123456789n)).toMatch(/^1\.23456/);
+    });
+});

--- a/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
+++ b/frontend/app/src/components_mobile/home/wallet/walletState.svelte.ts
@@ -140,7 +140,7 @@ export class TokenState {
             this.#symbol,
         ),
     );
-    #formattedTokenBalance = $derived(formatTokens(this.#remainingBalance, this.#decimals));
+    #formattedTokenBalance = $derived(this.formatTokens(this.#remainingBalance));
     #convertedValue = $derived(
         getConvertedTokenValue(this.#selectedConversion, this.#convertedBalances),
     );
@@ -166,12 +166,34 @@ export class TokenState {
         }
     });
 
-    constructor(t: EnhancedTokenDetails, c: ConversionToken = "usd") {
-        this.#token = t;
+    // Every caller looks the token up in the registry and asserts the result is there. It is not
+    // always: a message or an access gate can name a ledger the registry has never carried or has
+    // since dropped, and an undefined token here took the whole app down on the first derived read
+    // of `#token.ledger`. The null token stops the crash, but its zero decimals and empty symbol
+    // would render an amount that is wrong rather than obviously missing, so callers must consult
+    // `unknown` and refuse to show a figure or offer an action for a token we cannot identify.
+    // A plain boolean, deliberately. `#token` is `$state`, and Svelte proxies whatever is assigned
+    // to it, so `this.#token === nullToken` compares a proxy with the raw object and is always
+    // false - which made every guard keyed on it inert. Set wherever `#token` is.
+    #unknown = false;
+
+    constructor(t: EnhancedTokenDetails | undefined, c: ConversionToken = "usd") {
+        this.#token = t ?? nullToken;
+        this.#unknown = t === undefined;
         this.#selectedConversion = c;
     }
 
+    // True when the ledger is not in the registry: nothing about this token can be trusted,
+    // including any amount formatted with it.
+    get unknown() {
+        return this.#unknown;
+    }
+
+    // The null token's zero decimals would turn e8s into a number that is wrong rather than
+    // obviously missing, and every consumer of this class formats through here, so one guard
+    // covers message content, gates and the wallet alike.
     formatTokens(amount: bigint) {
+        if (this.#unknown) return "?????";
         return formatTokens(amount, this.#decimals);
     }
 
@@ -276,6 +298,7 @@ export class TokenState {
 
     set token(val: EnhancedTokenDetails) {
         this.#token = val;
+        this.#unknown = false;
     }
 
     get refreshingBalance() {
@@ -287,6 +310,9 @@ export class TokenState {
     }
 
     refreshBalance(client: OpenChat) {
+        // The null token's ledger is "", and refreshing that reaches the worker as
+        // Principal.fromText("") - one unhandled rejection per tap. Nothing to refresh anyway.
+        if (this.#unknown) return Promise.resolve();
         this.#refreshingBalance = true;
         return client
             .refreshAccountBalance(this.ledger, false)


### PR DESCRIPTION
Carved out of #9312. A message or an access gate can name a ledger the registry has never carried or has since dropped, and ~25 call sites asserted the registry lookup with `!`. The first derived read of `.ledger` then threw and took the whole app down at the boundary: `#31876`, `undefined is not an object (evaluating 's($).ledger')`. This PR is a presentation decision (what an unrecognised token looks like, and what you can't do with it), so it's reviewed on its own.

## The change

- **`TokenState` accepts an undefined token and exposes `unknown`.** It is a plain boolean set wherever `#token` is assigned. `#token` is `$state`, Svelte proxies what is assigned to it, and an identity comparison with the raw null token is *always false* — a first version did exactly that, and every guard built on it was inert for a full review round. `walletState.svelte.test.ts` pins `new TokenState(undefined).unknown === true` so it cannot silently regress.
- **`formatTokens` returns `"?????"`** for an unknown token instead of a figure built from zero decimals — one guard covering every consumer. `refreshBalance` no-ops rather than reaching the worker as `Principal.fromText("")`.
- **Components that can act refuse to.** The payment gate explains itself and offers only Cancel, in both the desktop and mobile copies (desktop was missed until the fifth review round; it's the copy every desktop-width viewport renders). Gates hide refresh and top-up. The prize fee row is skipped rather than printed in raw base units beside an amount rendered `?????`.
- **Both `AcceptP2PSwapModal` copies take the swap's own `TokenInfo` per side** instead of ledger ids. The message already carries symbol, decimals and the fee the canister actually debits (`crypto.rs:71`), so the registry lookup could drift from the real charge and could meet an unknown ledger. Now it does neither, and twenty lines of guards go with it.
- Both `BalanceWithRefresh` copies skip the on-mount refresh and hide the refresh and top-up controls for an unknown ledger, matching `TokenState.refreshBalance`. A failed refresh was otherwise logged under a blank symbol.
- `BigInt(Number(gate.amount) * 0.98)` in the mobile breakdown throws a `RangeError` for any amount not a multiple of 50 (`12345678n` throws). Pre-existing, same sheet. Integer arithmetic now.

## Left as is

`AccessGateSummary` and `BalanceGateEvaluator` render an unknown token's header with a blank symbol. Inert — no throw, no dead action — but not friendly. Mobile uses `TokenState.unknown` and the desktop components use hand-written ternaries; a helper on `OpenChat` would unify them. Both are shape, not behaviour, and belong in a follow-up.

## Testing

`npm run typecheck` 0 errors, 892 tests pass (three new, on `TokenState`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA

