### PR TITLE
Treat a cache holding a malformed direct chat as unusable

### DIFF
--- a/frontend/openchat-agent/src/utils/chatsDb.ts
+++ b/frontend/openchat-agent/src/utils/chatsDb.ts
@@ -325,18 +325,34 @@ export class ChatsDb {
         this.getDb().then((db) => db.put("bots", bots, this.principalString));
     }
 
+    // Never throws. `getUpdates` calls this from inside a `Stream` initialiser, which does not
+    // catch a rejected async initialiser: neither onResult nor onError would fire and the caller
+    // would await a load that never completes, on every launch. Returning undefined costs a full
+    // initial load; wedging the app costs everything.
     async getCachedChats(): Promise<ChatStateFull | undefined> {
-        const resolvedDb = await this.getDb();
-        const chats = await resolvedDb.get("chats", this.principalString);
+        try {
+            const resolvedDb = await this.getDb();
+            const chats = await resolvedDb.get("chats", this.principalString);
 
-        if (chats && chats.latestUserCanisterUpdates < BigInt(Date.now() - 30 * ONE_DAY)) {
-            const storeNames = resolvedDb.objectStoreNames;
-            for (let i = 0; i < storeNames.length; i++) {
-                await resolvedDb.clear(storeNames[i]);
+            // `== null`: a corrupt IndexedDB has been seen returning null rather than undefined
+            if (chats == null) return undefined;
+
+            if (chats.latestUserCanisterUpdates < BigInt(Date.now() - 30 * ONE_DAY)) {
+                const storeNames = resolvedDb.objectStoreNames;
+                for (let i = 0; i < storeNames.length; i++) {
+                    await resolvedDb.clear(storeNames[i]);
+                }
+                return undefined;
             }
+            if (!cachedChatsAreUsable(chats)) {
+                await resolvedDb.clear("chats");
+                return undefined;
+            }
+            return chats;
+        } catch (err) {
+            console.error("CACHE: unable to read cached chats, falling back to a full load", err);
             return undefined;
         }
-        return chats;
     }
 
     async setCachedChats(
@@ -1209,6 +1225,37 @@ function makeCommunitySerializable(community: CommunitySummary): CommunitySummar
         avatar,
         banner,
     };
+}
+
+// The cache is the one place a chat summary enters the agent without a mapper having built it:
+// every other route comes from candid. A record written by an older build (or a partial write)
+// can therefore be missing fields the type says are always there, and the app then dies reading
+// `them.userId` or `membership.readByMeUpTo` seconds after load.
+//
+// There is no safe local repair. `membership` cannot be invented - the role, read-up-to and mute
+// state are the server's to say. Dropping just the bad record is worse than it looks: the cached
+// list is the base `mergeDirectChatUpdates` applies deltas to, so a chat removed from it stays
+// gone until the server happens to send an update mentioning it. Treat the whole cache as
+// unusable instead and let `getUpdates` fall through to `getInitialState`, which is what the
+// staleness check above already does.
+function cachedChatsAreUsable(chats: ChatStateFull): boolean {
+    // `getUpdates` iterates all three of these inside the Stream initialiser, where a throw
+    // wedges the load rather than surfacing. No record missing groupChats or communities has
+    // been seen - the write is atomic - but the shape of the failure is the same, and checking
+    // is cheaper than the launch loop it would cause.
+    if (
+        !Array.isArray(chats.directChats) ||
+        !Array.isArray(chats.groupChats) ||
+        !Array.isArray(chats.communities) ||
+        // the staleness check above compares this with `<`; against undefined that is simply
+        // false, so a record with no timestamp would sail through as fresh
+        typeof chats.latestUserCanisterUpdates !== "bigint"
+    ) {
+        return false;
+    }
+    return chats.directChats.every(
+        (c) => c?.id?.userId !== undefined && c?.them !== undefined && c?.membership !== undefined,
+    );
 }
 
 function makeChatSummarySerializable<T extends ChatSummary>(chat: T): T {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -6791,7 +6791,7 @@ export class OpenChat {
         const webhooks = new Set<string>();
         chats.forEach((chat) => {
             if (chat.kind === "direct_chat") {
-                userIds.add(chat.them.userId);
+                userIds.add(chat.them?.userId ?? chat.id.userId);
             } else if (chat.latestMessage?.event !== undefined) {
                 const sender = chat.latestMessage.event.sender;
                 if (chat.latestMessage.event.senderContext?.kind === "webhook") {
@@ -7284,7 +7284,7 @@ export class OpenChat {
                 } else {
                     messagesRead.syncWithServer(
                         chat.id,
-                        chat.membership.readByMeUpTo,
+                        chat.membership?.readByMeUpTo,
                         [],
                         undefined,
                     );


### PR DESCRIPTION
Carved out of #9312. Small, but it decides what to do with a corrupt cache, and a false positive would cost every affected user a full reload on every launch, so it's reviewed on its own.

## The problem

Direct chat summaries were reaching the client without fields the type says are always present, and dying on them seconds after load: `#31716` `t.membership.readByMeUpTo` (14 hits, 5 IPs), `#31582` `e.them.userId`, `#31618` `n.chat.id`. Both crashing reads sit in the code path fed by the updates response, 2-10s after load at `/`.

## The change

The IndexedDB cache is the one place a chat summary enters the agent without a mapper having built it from candid. `getCachedChats` now treats a cache containing a direct chat with no `id`, `them` or `membership` — or one with no array of chats, or no bigint `latestUserCanisterUpdates` (`undefined < 123n` is false, so a record with no timestamp read as fresh forever) — as unusable, clears it, and lets `getUpdates` fall through to `getInitialState`. That's what the existing >30-day staleness check already does. Cost: one full initial load for an affected user, once.

It never throws. `getUpdates` calls it inside a `Stream` initialiser, and `Stream`'s constructor never catches a rejected async initialiser, so a throw here would fire neither `onResult` nor `onError` and wedge every launch. The `null` a corrupt IndexedDB has been seen to return (already documented in `openchatAgent.ts`) is handled for the same reason.

The two reads in `openchat.ts` that were dying are guarded with `?.`, matching the group and channel branches beside them.

## Two things this deliberately doesn't do

**Repair the fields.** `membership` is the server's to say — `nullMembership()` gives `ROLE_NONE` where a direct chat is always `ROLE_OWNER`, and an undefined `readByMeUpTo` marks the chat entirely unread. Guessing at server state to avoid a crash trades a loud bug for a quiet one.

**Drop just the bad record.** The cached list is the base `mergeDirectChatUpdates` applies deltas to (`openchatAgent.ts:1637`), so a chat removed from it never comes back until the server happens to send an update mentioning it.

Both were tried in #9312 and reverted.

## Testing

`npm run typecheck` 0 errors, `typecheck:agent` clean, 889 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA
