### PR TITLE
Make a failed source map upload stop the website deploy

### DIFF
--- a/scripts/deploy-website-prod-test.sh
+++ b/scripts/deploy-website-prod-test.sh
@@ -16,8 +16,8 @@ if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
     # Register the built maps with Rollbar before the assets go live, so traces from this
-    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
-    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+    # version demangle. A failed upload stops the deploy: fix it (usually the token) and rerun.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION || exit 1
     dfx --identity $IDENTITY deploy --network ic_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod_test - failed"

--- a/scripts/deploy-website-testnet.sh
+++ b/scripts/deploy-website-testnet.sh
@@ -17,8 +17,8 @@ if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
     # Register the built maps with Rollbar before the assets go live, so traces from this
-    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
-    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+    # version demangle. A failed upload stops the deploy: fix it (usually the token) and rerun.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION || exit 1
 
     dfx --identity $IDENTITY deploy --network $OC_DFX_NETWORK --no-wallet --with-cycles 100000000000000 website
 else

--- a/scripts/deploy-website-web-test.sh
+++ b/scripts/deploy-website-web-test.sh
@@ -17,8 +17,8 @@ if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
     # Register the built maps with Rollbar before the assets go live, so traces from this
-    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
-    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+    # version demangle. A failed upload stops the deploy: fix it (usually the token) and rerun.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION || exit 1
     dfx --identity $IDENTITY deploy --network web_test --no-wallet website
 else
   echo "npm run --prefix frontend deploy:prod - failed"

--- a/scripts/prepare-frontend-assets.sh
+++ b/scripts/prepare-frontend-assets.sh
@@ -16,8 +16,8 @@ if [ $? -eq 0 ]; then
     echo "npm deploy script succeeded - proceeding with dfx deploy"
 
     # Register the built maps with Rollbar before the assets go live, so traces from this
-    # version demangle. Warns and skips without OC_ROLLBAR_SERVER_TOKEN; never blocks the deploy.
-    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION
+    # version demangle. A failed upload stops the deploy: fix it (usually the token) and rerun.
+    node ./scripts/upload-source-maps.mjs $OC_WEBSITE_VERSION || exit 1
 
     dfx --identity $IDENTITY deploy --network ic --by-proposal website
 else

--- a/scripts/upload-source-maps.mjs
+++ b/scripts/upload-source-maps.mjs
@@ -25,18 +25,15 @@ const DYNAMIC_HOST = "http://dynamichost";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const buildDir = path.join(repoRoot, "frontend/app/build");
 
-function readDotEnv(key) {
-    try {
-        const lines = readFileSync(path.join(repoRoot, "frontend/.env"), "utf8").split("\n");
-        const line = lines.find((l) => l.startsWith(`${key}=`));
-        return line?.slice(key.length + 1).trim().replace(/^(["'])(.*)\1$/, "$2");
-    } catch {
-        return undefined;
-    }
+// Same as the build's dotenv.config(): fills in what the shell has not set, never overrides.
+try {
+    process.loadEnvFile(path.join(repoRoot, "frontend/.env"));
+} catch {
+    // No .env file; the token may still be in the environment.
 }
 
 const version = process.argv[2] ?? process.env.OC_WEBSITE_VERSION;
-const token = process.env.OC_ROLLBAR_SERVER_TOKEN || readDotEnv("OC_ROLLBAR_SERVER_TOKEN");
+const token = process.env.OC_ROLLBAR_SERVER_TOKEN;
 
 if (!version) {
     console.error("upload-source-maps: no version given (argv[2] or OC_WEBSITE_VERSION)");

--- a/scripts/upload-source-maps.mjs
+++ b/scripts/upload-source-maps.mjs
@@ -12,7 +12,8 @@
 // Usage: node scripts/upload-source-maps.mjs <version>
 // Requires OC_ROLLBAR_SERVER_TOKEN - a post_server_item token from Rollbar's
 // Settings -> Project Access Tokens. The client token in OC_ROLLBAR_ACCESS_TOKEN is a
-// post_client_item token and the endpoint rejects it.
+// post_client_item token and the endpoint rejects it. Read from the environment, falling back
+// to frontend/.env, which the build loads via dotenv but the deploy shell scripts never export.
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
@@ -24,24 +25,31 @@ const DYNAMIC_HOST = "http://dynamichost";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const buildDir = path.join(repoRoot, "frontend/app/build");
 
+function readDotEnv(key) {
+    try {
+        const lines = readFileSync(path.join(repoRoot, "frontend/.env"), "utf8").split("\n");
+        const line = lines.find((l) => l.startsWith(`${key}=`));
+        return line?.slice(key.length + 1).trim().replace(/^(["'])(.*)\1$/, "$2");
+    } catch {
+        return undefined;
+    }
+}
+
 const version = process.argv[2] ?? process.env.OC_WEBSITE_VERSION;
-const token = process.env.OC_ROLLBAR_SERVER_TOKEN;
+const token = process.env.OC_ROLLBAR_SERVER_TOKEN || readDotEnv("OC_ROLLBAR_SERVER_TOKEN");
 
 if (!version) {
     console.error("upload-source-maps: no version given (argv[2] or OC_WEBSITE_VERSION)");
     process.exit(1);
 }
 
-// Not fatal. A missing token should not sink a deploy that is otherwise fine, but it must be
-// loud, because the failure mode is silent: traces simply stay minified.
+// Fatal. This once warned and exited 0, and the warning scrolled past unread on the first real
+// deploy, leaving 2.0.2054 minified. The deploy scripts stop on a non-zero exit here.
 if (!token) {
-    console.warn("");
-    console.warn("  ****************************************************************");
-    console.warn("  OC_ROLLBAR_SERVER_TOKEN is not set - SKIPPING source map upload.");
-    console.warn(`  Stack traces for ${version} will stay minified in Rollbar.`);
-    console.warn("  ****************************************************************");
-    console.warn("");
-    process.exit(0);
+    console.error(
+        "upload-source-maps: OC_ROLLBAR_SERVER_TOKEN is not set in the environment or in frontend/.env",
+    );
+    process.exit(1);
 }
 
 function findMaps(dir) {


### PR DESCRIPTION
Follow-up to #9318. The first real run of the source map upload in the prod test deploy of 2.0.2054 printed

```
OC_ROLLBAR_SERVER_TOKEN is not set - SKIPPING source map upload.
```

and the deploy carried on. Two things were wrong.

## The token was never visible to the script

`frontend/.env` is loaded by dotenv in `rollup.extras.mjs`, inside the build process. The deploy shell scripts spawn `node scripts/upload-source-maps.mjs` separately with the plain shell environment, so `process.env.OC_ROLLBAR_SERVER_TOKEN` was always empty in the pipeline. My verification for #9318 exported the token by hand. The script now loads `frontend/.env` with Node's built-in `process.loadEnvFile` (Node 20.12+, we run 22), which has the same fill-in-never-override semantics as the build's `dotenv.config()`. dotenv itself is only installed under `frontend/node_modules`, which a script at the repo root cannot resolve.

## A skipped upload did not stop the deploy

By design in #9318, and the wrong design. The warning sat in the middle of the build output and was missed. A missing token or a failed upload now exits 1, and all four deploy scripts (`deploy-website-prod-test.sh`, `deploy-website-web-test.sh`, `deploy-website-testnet.sh`, `prepare-frontend-assets.sh`) abort on it instead of running `dfx deploy`. Previously they did not check the exit code at all.

## Re-uploads

Prod test, web test and prod all upload the same version. Checked against 2.0.2054: uploading all 175 maps a second time returns success, so the later deploys of a version do not trip over the first.

## Testing

- Fallback path: script run from the repo with the token unset in the shell finds it in `frontend/.env`, uploaded 175 maps for 2.0.2054.
- Missing token path: script copied outside the repo exits 1 with the message above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc48kzHXq2sV7yySmjAyA
