### PR TITLE
Remove the one-off WebAuthn key repair now that it has run in production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5896,7 +5896,6 @@ dependencies = [
  "canister_tracing_macros",
  "constants",
  "git_commit_id",
- "hex",
  "http_request",
  "ic-canister-sig-creation",
  "ic-captcha",

--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Removed
+
+- Remove the one-off WebAuthn key repair now that it has run in production ([#9323](https://github.com/open-chat-labs/open-chat/pull/9323))
+
+## [[2.0.2053](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2053-identity)] - 2026-09-04
+
 ### Fixed
 
 - Repair WebAuthn keys stored with trailing extension bytes and remap their auth principals ([#9279](https://github.com/open-chat-labs/open-chat/pull/9279))

--- a/backend/canisters/identity/impl/Cargo.toml
+++ b/backend/canisters/identity/impl/Cargo.toml
@@ -17,7 +17,6 @@ canister_state_macros = { path = "../../../libraries/canister_state_macros" }
 canister_tracing_macros = { path = "../../../libraries/canister_tracing_macros" }
 constants = { path = "../../../libraries/constants" }
 git_commit_id = { path = "../../../libraries/git_commit_id" }
-hex = { workspace = true }
 http_request = { path = "../../../libraries/http_request" }
 ic-canister-sig-creation = { workspace = true }
 ic-captcha = { workspace = true }

--- a/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
@@ -1,13 +1,12 @@
+use crate::Data;
 use crate::lifecycle::init_state;
 use crate::memory::get_upgrades_memory;
-use crate::{Data, mutate_state};
-use candid::Principal;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
 use ic_cdk::post_upgrade;
 use identity_canister::post_upgrade::Args;
 use stable_memory::get_reader;
-use tracing::{error, info};
+use tracing::info;
 use utils::cycles::init_cycles_dispenser_client;
 use utils::env::canister::CanisterEnv;
 
@@ -25,31 +24,6 @@ fn post_upgrade(args: Args) {
     let env = Box::new(CanisterEnv::new(data.rng_seed));
     init_cycles_dispenser_client(data.cycles_dispenser_canister_id, data.test_mode);
     init_state(env, data, args.wasm_version);
-
-    // One-off: WebAuthn keys registered by authenticators which set the ED flag (eg. YubiKeys adding a
-    // `credProtect` extension) were stored with the CBOR extensions map appended to the COSE key, so the
-    // IC rejected them and those users were locked out (#9277). Strip the trailing bytes and remap each
-    // affected auth principal to the one derived from the repaired key. The key is only updated if the
-    // principal was remapped, so a failure leaves the user exactly as they were rather than half-migrated.
-    // TODO remove after the release containing this has been deployed
-    mutate_state(|state| {
-        let user_principals = &mut state.data.user_principals;
-        for key in state.data.webauthn_keys.repair_malformed_keys(|key| {
-            user_principals.replace_auth_principal(
-                Principal::self_authenticating(&key.old_public_key),
-                Principal::self_authenticating(&key.new_public_key),
-            )
-        }) {
-            let credential_id = hex::encode(&key.credential_id);
-            let old_principal = Principal::self_authenticating(&key.old_public_key);
-            let new_principal = Principal::self_authenticating(&key.new_public_key);
-            if key.repaired {
-                info!(%credential_id, %old_principal, %new_principal, "Repaired malformed WebAuthn key");
-            } else {
-                error!(%credential_id, %old_principal, %new_principal, "Failed to remap auth principal of malformed WebAuthn key");
-            }
-        }
-    });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");

--- a/backend/canisters/identity/impl/src/model/user_principals.rs
+++ b/backend/canisters/identity/impl/src/model/user_principals.rs
@@ -17,7 +17,7 @@ pub struct UserPrincipals {
     temp_keys: HashMap<Principal, TempKey>,
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
+#[expect(dead_code)]
 pub struct UserPrincipal {
     pub index: u32,
     pub principal: Principal,
@@ -162,33 +162,6 @@ impl UserPrincipals {
         } else {
             unreachable!()
         }
-    }
-
-    /// Re-keys the auth principal `old` as `new`, leaving everything else about it unchanged.
-    /// Returns false, changing nothing, if `old` doesn't exist, `new` is already in use, or `old`
-    /// points at a user principal which doesn't exist.
-    pub fn replace_auth_principal(&mut self, old: Principal, new: Principal) -> bool {
-        if old == new || self.auth_principals.contains_key(&new) {
-            return false;
-        }
-        // Check the user exists before touching anything so a failure can't leave the auth
-        // principal map and the user's list of auth principals disagreeing
-        let Some(user) = self.user_principal_mut(&old) else {
-            return false;
-        };
-        for p in user.auth_principals.iter_mut() {
-            if *p == old {
-                *p = new;
-            }
-        }
-        let auth_principal = self.auth_principals.remove(&old).unwrap();
-        self.auth_principals.insert(new, auth_principal);
-        for temp_key in self.temp_keys.values_mut() {
-            if temp_key.auth_principal == old {
-                temp_key.auth_principal = new;
-            }
-        }
-        true
     }
 
     pub fn remove_auth_principal(&mut self, caller: Principal, linked_principal: Principal) -> RemovePrincipalResponse {
@@ -376,69 +349,5 @@ impl From<UserPrincipalsTrimmed> for UserPrincipals {
             originating_canisters: value.originating_canisters,
             temp_keys: value.temp_keys,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn principal(byte: u8) -> Principal {
-        Principal::from_slice(&[byte; 10])
-    }
-
-    #[test]
-    fn replace_auth_principal_rekeys_everything_referencing_it() {
-        let mut user_principals = UserPrincipals::default();
-        let (user, old, new, temp_key, canister) = (principal(1), principal(2), principal(3), principal(4), principal(5));
-        user_principals.push(0, user, old, canister, None, false, 100);
-        user_principals.add_temp_key(temp_key, old, 100, 200);
-
-        assert!(user_principals.replace_auth_principal(old, new));
-
-        assert!(user_principals.get_by_auth_principal(&old).is_none());
-        let by_new = user_principals.get_by_auth_principal(&new).unwrap();
-        assert_eq!(by_new.principal, user);
-        assert_eq!(by_new.auth_principals, vec![new]);
-        assert_eq!(user_principals.get_auth_principal(&new).unwrap().last_used, 100);
-        assert_eq!(user_principals.temp_keys[&temp_key].auth_principal, new);
-    }
-
-    #[test]
-    fn replace_auth_principal_rejects_unknown_old_and_in_use_new() {
-        let mut user_principals = UserPrincipals::default();
-        let (user, old, other, canister) = (principal(1), principal(2), principal(3), principal(5));
-        user_principals.push(0, user, old, canister, None, false, 100);
-        user_principals.push(1, principal(6), other, canister, None, false, 100);
-
-        assert!(!user_principals.replace_auth_principal(principal(9), principal(10)));
-        assert!(!user_principals.replace_auth_principal(old, other));
-        assert!(!user_principals.replace_auth_principal(old, old));
-        assert_eq!(
-            user_principals.get_by_auth_principal(&old).unwrap().auth_principals,
-            vec![old]
-        );
-    }
-
-    #[test]
-    fn replace_auth_principal_leaves_state_untouched_if_user_is_missing() {
-        let mut user_principals = UserPrincipals::default();
-        let (old, new, canister) = (principal(2), principal(3), principal(5));
-        // An auth principal pointing at a user principal index which doesn't exist
-        user_principals.auth_principals.insert(
-            old,
-            AuthPrincipalInternal {
-                originating_canister: canister,
-                user_principal_index: 7,
-                webauthn_credential_id: None,
-                is_ii_principal: false,
-                last_used: 100,
-            },
-        );
-
-        assert!(!user_principals.replace_auth_principal(old, new));
-
-        assert!(user_principals.auth_principal_exists(&old));
-        assert!(!user_principals.auth_principal_exists(&new));
     }
 }

--- a/backend/canisters/identity/impl/src/model/webauthn_keys.rs
+++ b/backend/canisters/identity/impl/src/model/webauthn_keys.rs
@@ -29,63 +29,12 @@ impl WebAuthnKeys {
     pub fn get(&self, credential_id: Vec<u8>) -> Option<&WebAuthnKeyInternal> {
         self.keys.get(&ByteBuf::from(credential_id))
     }
-
-    /// Finds any stored keys whose COSE key is followed by additional data (see
-    /// `strip_trailing_bytes_from_der_cose_key`) and calls `remap` with the details of each. The stored
-    /// key is only replaced with the repaired one if `remap` returns true, so that a key and the auth
-    /// principal derived from it can't be left disagreeing with each other. Returns the details of every
-    /// malformed key found, along with whether it was repaired.
-    pub fn repair_malformed_keys(&mut self, mut remap: impl FnMut(&RepairedWebAuthnKey) -> bool) -> Vec<RepairedWebAuthnKey> {
-        let mut results = Vec::new();
-        for (credential_id, key) in self.keys.iter_mut() {
-            if let Some(new_public_key) = strip_trailing_bytes_from_der_cose_key(&key.public_key) {
-                let mut repaired = RepairedWebAuthnKey {
-                    credential_id: credential_id.to_vec(),
-                    old_public_key: key.public_key.clone(),
-                    new_public_key,
-                    repaired: false,
-                };
-                if remap(&repaired) {
-                    key.public_key = repaired.new_public_key.clone();
-                    repaired.repaired = true;
-                }
-                results.push(repaired);
-            }
-        }
-        results
-    }
-}
-
-pub struct RepairedWebAuthnKey {
-    pub credential_id: Vec<u8>,
-    pub old_public_key: Vec<u8>,
-    pub new_public_key: Vec<u8>,
-    pub repaired: bool,
 }
 
 // DER encoding of `SEQUENCE { OBJECT IDENTIFIER 1.3.6.1.4.1.56387.1.1 }`, the OID the IC uses to wrap COSE keys
 const DER_COSE_OID: [u8; 14] = [
     0x30, 0x0c, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x83, 0xb8, 0x43, 0x01, 0x01,
 ];
-
-/// WebAuthn public keys are stored as DER: `SEQUENCE { DER_COSE_OID, BIT STRING { 0x00, <COSE key> } }`.
-///
-/// The frontend used to extract the COSE key by taking everything after the credential ID in the
-/// authenticator data, so when an authenticator set the ED flag (eg. YubiKeys adding a `credProtect`
-/// extension) the CBOR extensions map was included after the COSE key. The IC rejects such keys with
-/// "Failed to parse COSE public key", locking the user out.
-///
-/// If the COSE key within `der` is followed by trailing bytes, this returns the DER encoding of just the
-/// COSE key, else it returns `None`.
-pub fn strip_trailing_bytes_from_der_cose_key(der: &[u8]) -> Option<Vec<u8>> {
-    let cose_key = unwrap_der_cose_key(der).ok()?;
-    let cose_key_length = cbor_item_length(cose_key)?;
-    if cose_key_length == cose_key.len() {
-        None
-    } else {
-        Some(der_wrap_cose_key(&cose_key[..cose_key_length]))
-    }
-}
 
 /// Checks that `der` is a DER wrapped COSE key which the IC will accept when verifying WebAuthn
 /// signatures. This mirrors the checks in the IC's COSE parser so that a malformed key is rejected at
@@ -169,7 +118,8 @@ pub fn validate_der_cose_key(der: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-// Returns the COSE key contained within a DER encoded WebAuthn public key
+// Returns the COSE key contained within a DER encoded WebAuthn public key, which is stored as
+// `SEQUENCE { DER_COSE_OID, BIT STRING { 0x00, <COSE key> } }`
 fn unwrap_der_cose_key(der: &[u8]) -> Result<&[u8], String> {
     let (sequence_length, sequence) = read_der_header(der, 0x30).ok_or("Not a DER sequence")?;
     if sequence.len() != sequence_length {
@@ -186,13 +136,6 @@ fn unwrap_der_cose_key(der: &[u8]) -> Result<&[u8], String> {
     bit_string
         .strip_prefix(&[0u8])
         .ok_or_else(|| "DER bit string has unused bits".to_string())
-}
-
-// Returns the length of the first CBOR data item in `bytes`, as parsed by the same CBOR library the IC uses
-fn cbor_item_length(bytes: &[u8]) -> Option<usize> {
-    let mut deserializer = serde_cbor::Deserializer::from_slice(bytes);
-    let _: serde_cbor::Value = serde::Deserialize::deserialize(&mut deserializer).ok()?;
-    Some(deserializer.byte_offset())
 }
 
 // Returns the length and contents of a DER element with the given tag, or `None` if the tag doesn't match
@@ -214,29 +157,6 @@ fn read_der_header(bytes: &[u8], tag: u8) -> Option<(usize, &[u8])> {
             .fold(0usize, |acc, b| (acc << 8) | *b as usize);
         Some((length, &bytes[2 + length_bytes..]))
     }
-}
-
-fn der_length(length: usize) -> Vec<u8> {
-    if length < 0x80 {
-        vec![length as u8]
-    } else if length < 0x100 {
-        vec![0x81, length as u8]
-    } else {
-        vec![0x82, (length >> 8) as u8, length as u8]
-    }
-}
-
-fn der_wrap_cose_key(cose_key: &[u8]) -> Vec<u8> {
-    let mut bit_string = vec![0x03];
-    bit_string.extend(der_length(cose_key.len() + 1));
-    bit_string.push(0);
-    bit_string.extend_from_slice(cose_key);
-
-    let mut der = vec![0x30];
-    der.extend(der_length(DER_COSE_OID.len() + bit_string.len()));
-    der.extend_from_slice(&DER_COSE_OID);
-    der.extend(bit_string);
-    der
 }
 
 #[derive(Serialize, Deserialize)]
@@ -290,49 +210,33 @@ mod tests {
         hex(&format!("305e{DER_PREFIX}034e00{ES256_COSE_KEY}"))
     }
 
-    #[test]
-    fn strips_trailing_extension_bytes() {
-        let malformed = malformed_key();
-        assert_eq!(malformed.len(), 110);
-
-        let repaired = strip_trailing_bytes_from_der_cose_key(&malformed).unwrap();
-        assert_eq!(repaired.len(), 96);
-        assert_eq!(repaired, valid_key());
+    fn der_length(length: usize) -> Vec<u8> {
+        if length < 0x80 {
+            vec![length as u8]
+        } else if length < 0x100 {
+            vec![0x81, length as u8]
+        } else {
+            vec![0x82, (length >> 8) as u8, length as u8]
+        }
     }
 
-    #[test]
-    fn valid_key_is_left_unchanged() {
-        assert!(strip_trailing_bytes_from_der_cose_key(&valid_key()).is_none());
-        assert!(strip_trailing_bytes_from_der_cose_key(&der_wrap_cose_key(&hex(ES256_COSE_KEY))).is_none());
+    fn der_wrap_cose_key(cose_key: &[u8]) -> Vec<u8> {
+        let mut bit_string = vec![0x03];
+        bit_string.extend(der_length(cose_key.len() + 1));
+        bit_string.push(0);
+        bit_string.extend_from_slice(cose_key);
+
+        let mut der = vec![0x30];
+        der.extend(der_length(DER_COSE_OID.len() + bit_string.len()));
+        der.extend_from_slice(&DER_COSE_OID);
+        der.extend(bit_string);
+        der
     }
 
     #[test]
     fn der_wrap_round_trips() {
         let cose_with_extension = hex(&format!("{ES256_COSE_KEY}{CRED_PROTECT_EXTENSION}"));
         assert_eq!(der_wrap_cose_key(&cose_with_extension), malformed_key());
-    }
-
-    #[test]
-    fn handles_long_form_der_lengths() {
-        // An RSA COSE key with a 256 byte modulus: {1: 3, 3: -257, -1: n, -2: e}
-        let rsa_cose_key = hex(&format!("a40103033901002059{}{}2143010001", "0100", "33".repeat(256)));
-        let mut malformed_cose = rsa_cose_key.clone();
-        malformed_cose.extend(hex(CRED_PROTECT_EXTENSION));
-
-        let malformed = der_wrap_cose_key(&malformed_cose);
-        assert_eq!(&malformed[..4], &[0x30, 0x82, 0x01, 0x31]);
-        let repaired = strip_trailing_bytes_from_der_cose_key(&malformed).unwrap();
-        assert_eq!(repaired, der_wrap_cose_key(&rsa_cose_key));
-        assert!(strip_trailing_bytes_from_der_cose_key(&repaired).is_none());
-    }
-
-    #[test]
-    fn garbage_is_left_unchanged() {
-        assert!(strip_trailing_bytes_from_der_cose_key(&[]).is_none());
-        assert!(strip_trailing_bytes_from_der_cose_key(&[0x30]).is_none());
-        assert!(strip_trailing_bytes_from_der_cose_key(&hex("3005300306010100")).is_none());
-        // Truncated key
-        assert!(strip_trailing_bytes_from_der_cose_key(&valid_key()[..50]).is_none());
     }
 
     #[test]
@@ -415,43 +319,5 @@ mod tests {
                 .unwrap_err()
                 .contains("not valid CBOR")
         );
-    }
-
-    #[test]
-    fn repairs_only_malformed_stored_keys() {
-        let mut keys = WebAuthnKeys::default();
-        let add = |keys: &mut WebAuthnKeys, credential_id: u8, public_key: Vec<u8>| {
-            keys.add(
-                WebAuthnKey {
-                    public_key,
-                    credential_id: vec![credential_id],
-                    origin: "oc.app".to_string(),
-                    cross_platform: true,
-                    aaguid: [0; 16],
-                },
-                1,
-            );
-        };
-        add(&mut keys, 1, valid_key());
-        add(&mut keys, 2, malformed_key());
-
-        // The malformed key is left untouched if the remap fails
-        let not_remapped = keys.repair_malformed_keys(|_| false);
-        assert_eq!(not_remapped.len(), 1);
-        assert_eq!(not_remapped[0].credential_id, vec![2]);
-        assert!(!not_remapped[0].repaired);
-        assert_eq!(keys.get(vec![1]).unwrap().public_key, valid_key());
-        assert_eq!(keys.get(vec![2]).unwrap().public_key, malformed_key());
-
-        let repaired = keys.repair_malformed_keys(|_| true);
-        assert_eq!(repaired.len(), 1);
-        assert_eq!(repaired[0].credential_id, vec![2]);
-        assert_eq!(repaired[0].old_public_key, malformed_key());
-        assert_eq!(repaired[0].new_public_key, valid_key());
-        assert!(repaired[0].repaired);
-
-        assert_eq!(keys.get(vec![1]).unwrap().public_key, valid_key());
-        assert_eq!(keys.get(vec![2]).unwrap().public_key, valid_key());
-        assert!(keys.repair_malformed_keys(|_| true).is_empty());
     }
 }


### PR DESCRIPTION
The Identity canister was upgraded to v2.0.2053 via [SNS proposal 2367](https://dashboard.internetcomputer.org/sns/3e3x2-xyaaa-aaaaq-aaalq-cai/proposal/2367), which ran the one-off repair of WebAuthn keys stored with trailing extension bytes (#9279). This removes that code and tidies the changelog.

- `post_upgrade` is back to its pre-#9279 form
- `repair_malformed_keys`, `RepairedWebAuthnKey`, `strip_trailing_bytes_from_der_cose_key` and `cbor_item_length` are removed; the registration-time validation from #9280 and the DER parsing it shares stay. The DER wrapping helpers now only serve tests, so they live in the test module
- `UserPrincipals::replace_auth_principal` and its tests are removed
- The `hex` dependency is dropped from the crate
- The Identity CHANGELOG `[unreleased]` section is cut to `2.0.2053`

Verified with `cargo test -p identity_canister_impl`, `cargo fmt` and `cargo clippy --tests -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)