### PR TITLE
Remove WebAuthn keys when a passkey is unlinked or its user deleted

### DIFF
--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Remove WebAuthn keys when a passkey is unlinked or its user deleted, and drop orphaned keys on upgrade ([#9309](https://github.com/open-chat-labs/open-chat/issues/9309))
+- Remove WebAuthn keys when a passkey is unlinked or its user deleted, and drop orphaned keys on upgrade ([#9324](https://github.com/open-chat-labs/open-chat/pull/9324))
 
 ### Removed
 

--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Remove WebAuthn keys when a passkey is unlinked or its user deleted, and drop orphaned keys on upgrade ([#9324](https://github.com/open-chat-labs/open-chat/pull/9324))
+- Decrement the originating canister count when an auth principal is unlinked ([#9324](https://github.com/open-chat-labs/open-chat/pull/9324))
 
 ### Removed
 

--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Remove WebAuthn keys when a passkey is unlinked or its user deleted, and drop orphaned keys on upgrade ([#9309](https://github.com/open-chat-labs/open-chat/issues/9309))
+
 ### Removed
 
 - Remove the one-off WebAuthn key repair now that it has run in production ([#9323](https://github.com/open-chat-labs/open-chat/pull/9323))

--- a/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
@@ -51,6 +51,17 @@ fn post_upgrade(args: Args) {
         }
     });
 
+    // One-off: WebAuthn keys were never removed when the auth principal using them was unlinked or its
+    // user deleted (#9309), so drop every key no auth principal can sign in with. A key is only removed
+    // if both the auth principal derived from its public key is gone and no auth principal refers to
+    // its credential id, so nothing anyone can still sign in with is touched.
+    // TODO remove after the release containing this has been deployed
+    mutate_state(|state| {
+        let removed = state.data.webauthn_keys.remove_orphaned_keys(&state.data.user_principals);
+        let remaining = state.data.webauthn_keys.len();
+        info!(removed = removed.len(), remaining, "Removed orphaned WebAuthn keys");
+    });
+
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");
 }

--- a/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/identity/impl/src/lifecycle/post_upgrade.rs
@@ -33,7 +33,7 @@ fn post_upgrade(args: Args) {
     mutate_state(|state| {
         let removed = state.data.webauthn_keys.remove_orphaned_keys(&state.data.user_principals);
         let remaining = state.data.webauthn_keys.len();
-        info!(removed = removed.len(), remaining, "Removed orphaned WebAuthn keys");
+        info!(removed, remaining, "Removed orphaned WebAuthn keys");
     });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();

--- a/backend/canisters/identity/impl/src/model/user_principals.rs
+++ b/backend/canisters/identity/impl/src/model/user_principals.rs
@@ -186,9 +186,9 @@ impl UserPrincipals {
             return Err(RemovePrincipalResponse::IdentityLinkNotFound);
         }
         user.auth_principals.retain(|&ap| ap != linked_principal);
-        Ok(self
-            .remove_auth_principal_internal(&linked_principal, index)
-            .and_then(|a| a.webauthn_credential_id))
+        let removed = self.remove_auth_principal_internal(&linked_principal, index);
+        self.temp_keys.retain(|_, k| k.auth_principal != linked_principal);
+        Ok(removed.and_then(|a| a.webauthn_credential_id))
     }
 
     /// Unlinks every auth principal from the user at `index` and clears its user id, returning the
@@ -202,17 +202,18 @@ impl UserPrincipals {
             .filter(|u| u.user_id == Some(user_id))?;
         user.user_id = None;
         let auth_principals = std::mem::take(&mut user.auth_principals);
-        Some(
-            auth_principals
-                .iter()
-                .filter_map(|p| self.remove_auth_principal_internal(p, index))
-                .filter_map(|a| a.webauthn_credential_id)
-                .collect(),
-        )
+        let credential_ids = auth_principals
+            .iter()
+            .filter_map(|p| self.remove_auth_principal_internal(p, index))
+            .filter_map(|a| a.webauthn_credential_id)
+            .collect();
+        self.temp_keys.retain(|_, k| !auth_principals.contains(&k.auth_principal));
+        Some(credential_ids)
     }
 
-    /// Removes `auth_principal` from the lookup, provided it belongs to the user at `index`, along
-    /// with any temp keys standing in for it.
+    /// Removes `auth_principal` from the lookup, provided it belongs to the user at `index`, and
+    /// decrements the count for its originating canister. Does not touch `temp_keys`, so that a
+    /// caller removing several principals can purge their temp keys in one pass.
     fn remove_auth_principal_internal(&mut self, auth_principal: &Principal, index: u32) -> Option<AuthPrincipalInternal> {
         let Occupied(e) = self.auth_principals.entry(*auth_principal) else {
             return None;
@@ -221,7 +222,7 @@ impl UserPrincipals {
             return None;
         }
         let removed = e.remove();
-        self.temp_keys.retain(|_, k| k.auth_principal != *auth_principal);
+        self.decr_originating_canister(removed.originating_canister);
         Some(removed)
     }
 
@@ -347,6 +348,17 @@ impl UserPrincipals {
     fn incr_originating_canister(&mut self, canister_id: CanisterId) {
         *self.originating_canisters.entry(canister_id).or_default() += 1;
     }
+
+    fn decr_originating_canister(&mut self, canister_id: CanisterId) {
+        if let Occupied(mut e) = self.originating_canisters.entry(canister_id) {
+            let count = e.get().saturating_sub(1);
+            if count == 0 {
+                e.remove();
+            } else {
+                *e.get_mut() = count;
+            }
+        }
+    }
 }
 
 pub struct AuthPrincipal {
@@ -410,6 +422,7 @@ mod tests {
         user_principals.push(0, user, active, canister, None, false, 100);
         assert!(user_principals.link_auth_principal_with_existing_user(passkey, canister, Some(vec![7].into()), false, 0, 100));
         user_principals.add_temp_key(temp_key, passkey, 100, 200);
+        assert_eq!(user_principals.originating_canisters().get(&canister), Some(&2));
 
         assert!(matches!(
             user_principals.remove_auth_principal(passkey, passkey),
@@ -437,6 +450,7 @@ mod tests {
         );
         assert!(!user_principals.temp_keys.contains_key(&temp_key));
         assert!(user_principals.webauthn_credential_ids().is_empty());
+        assert_eq!(user_principals.originating_canisters().get(&canister), Some(&1));
         assert!(matches!(
             user_principals.remove_auth_principal(active, passkey),
             Err(RemovePrincipalResponse::IdentityLinkNotFound)
@@ -459,6 +473,10 @@ mod tests {
         assert!(user_principals.link_auth_principal_with_existing_user(auth2, canister, None, false, 0, 100));
         user_principals.push(1, other_user, other_auth, canister, Some(vec![2].into()), false, 100);
         assert!(user_principals.set_user_id(user, Some(user_id)));
+        user_principals.add_temp_key(principal(8), auth1, 100, 200);
+        user_principals.add_temp_key(principal(9), auth2, 100, 200);
+        user_principals.add_temp_key(principal(10), other_auth, 100, 200);
+        assert_eq!(user_principals.originating_canisters().get(&canister), Some(&3));
 
         // Refuses to touch anything if the user at the index doesn't carry the expected user id
         assert!(user_principals.delete_user(1, user_id).is_none());
@@ -470,6 +488,10 @@ mod tests {
         assert!(!user_principals.auth_principal_exists(&auth1));
         assert!(!user_principals.auth_principal_exists(&auth2));
         assert!(user_principals.auth_principal_exists(&other_auth));
+        assert!(!user_principals.temp_keys.contains_key(&principal(8)));
+        assert!(!user_principals.temp_keys.contains_key(&principal(9)));
+        assert!(user_principals.temp_keys.contains_key(&principal(10)));
+        assert_eq!(user_principals.originating_canisters().get(&canister), Some(&1));
         assert!(user_principals.find_user_principal_by_user_id(user_id).is_none());
         let deleted = user_principals.user_principal_by_index(0).unwrap();
         assert!(deleted.auth_principals.is_empty());

--- a/backend/canisters/identity/impl/src/model/user_principals.rs
+++ b/backend/canisters/identity/impl/src/model/user_principals.rs
@@ -2,8 +2,8 @@ use candid::Principal;
 use identity_canister::remove_identity_link::Response as RemovePrincipalResponse;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::collections::{HashMap, HashSet};
 use types::{CanisterId, PushIfNotContains, TimestampMillis, UserId, is_default};
 
 #[derive(Serialize, Deserialize, Default)]
@@ -191,25 +191,73 @@ impl UserPrincipals {
         true
     }
 
-    pub fn remove_auth_principal(&mut self, caller: Principal, linked_principal: Principal) -> RemovePrincipalResponse {
+    /// Unlinks `linked_principal` from the caller's user. On success returns the WebAuthn credential
+    /// id of the removed principal, if it had one, so that the caller can remove the stored key too.
+    pub fn remove_auth_principal(
+        &mut self,
+        caller: Principal,
+        linked_principal: Principal,
+    ) -> Result<Option<ByteBuf>, RemovePrincipalResponse> {
         if caller == linked_principal {
-            RemovePrincipalResponse::CannotUnlinkActivePrincipal
-        } else {
-            if let Some(user) = self.user_principal_mut(&caller) {
-                // This condition may be redundant, but in combination with the
-                // responses can provide additional context in case of an error.
-                if user.auth_principals.contains(&linked_principal) {
-                    user.auth_principals.retain(|&ap| ap != linked_principal);
-                    self.auth_principals.remove(&linked_principal);
-
-                    return RemovePrincipalResponse::Success;
-                }
-
-                return RemovePrincipalResponse::IdentityLinkNotFound;
-            }
-
-            RemovePrincipalResponse::UserNotFound
+            return Err(RemovePrincipalResponse::CannotUnlinkActivePrincipal);
         }
+        let Some(index) = self.auth_principals.get(&caller).map(|a| a.user_principal_index) else {
+            return Err(RemovePrincipalResponse::UserNotFound);
+        };
+        let Some(user) = self.user_principals.get_mut(index as usize) else {
+            return Err(RemovePrincipalResponse::UserNotFound);
+        };
+        // This condition may be redundant, but in combination with the
+        // responses can provide additional context in case of an error.
+        if !user.auth_principals.contains(&linked_principal) {
+            return Err(RemovePrincipalResponse::IdentityLinkNotFound);
+        }
+        user.auth_principals.retain(|&ap| ap != linked_principal);
+        Ok(self
+            .remove_auth_principal_internal(&linked_principal, index)
+            .and_then(|a| a.webauthn_credential_id))
+    }
+
+    /// Unlinks every auth principal from the user at `index` and clears its user id, returning the
+    /// WebAuthn credential ids of the unlinked principals so that the caller can remove their keys
+    /// too. Does nothing and returns `None` unless the user at `index` still has `user_id`, so a stale
+    /// index can never wipe a different user.
+    pub fn delete_user(&mut self, index: u32, user_id: UserId) -> Option<Vec<ByteBuf>> {
+        let user = self
+            .user_principals
+            .get_mut(index as usize)
+            .filter(|u| u.user_id == Some(user_id))?;
+        user.user_id = None;
+        let auth_principals = std::mem::take(&mut user.auth_principals);
+        Some(
+            auth_principals
+                .iter()
+                .filter_map(|p| self.remove_auth_principal_internal(p, index))
+                .filter_map(|a| a.webauthn_credential_id)
+                .collect(),
+        )
+    }
+
+    /// Removes `auth_principal` from the lookup, provided it belongs to the user at `index`, along
+    /// with any temp keys standing in for it.
+    fn remove_auth_principal_internal(&mut self, auth_principal: &Principal, index: u32) -> Option<AuthPrincipalInternal> {
+        let Occupied(e) = self.auth_principals.entry(*auth_principal) else {
+            return None;
+        };
+        if e.get().user_principal_index != index {
+            return None;
+        }
+        let removed = e.remove();
+        self.temp_keys.retain(|_, k| k.auth_principal != *auth_principal);
+        Some(removed)
+    }
+
+    /// The credential id of every WebAuthn key an auth principal refers to
+    pub fn webauthn_credential_ids(&self) -> HashSet<&ByteBuf> {
+        self.auth_principals
+            .values()
+            .filter_map(|a| a.webauthn_credential_id.as_ref())
+            .collect()
     }
 
     pub fn next_index(&self) -> u32 {
@@ -418,6 +466,81 @@ mod tests {
             user_principals.get_by_auth_principal(&old).unwrap().auth_principals,
             vec![old]
         );
+    }
+
+    #[test]
+    fn remove_auth_principal_returns_credential_id_and_drops_temp_keys() {
+        let mut user_principals = UserPrincipals::default();
+        let (user, active, passkey, temp_key, canister) =
+            (principal(1), principal(2), principal(3), principal(4), principal(5));
+        user_principals.push(0, user, active, canister, None, false, 100);
+        assert!(user_principals.link_auth_principal_with_existing_user(passkey, canister, Some(vec![7].into()), false, 0, 100));
+        user_principals.add_temp_key(temp_key, passkey, 100, 200);
+
+        assert!(matches!(
+            user_principals.remove_auth_principal(passkey, passkey),
+            Err(RemovePrincipalResponse::CannotUnlinkActivePrincipal)
+        ));
+        assert!(matches!(
+            user_principals.remove_auth_principal(principal(9), passkey),
+            Err(RemovePrincipalResponse::UserNotFound)
+        ));
+        assert!(matches!(
+            user_principals.remove_auth_principal(active, principal(9)),
+            Err(RemovePrincipalResponse::IdentityLinkNotFound)
+        ));
+
+        assert!(matches!(
+            user_principals.remove_auth_principal(active, passkey),
+            Ok(Some(id)) if id.as_ref() == [7]
+        ));
+
+        assert!(!user_principals.auth_principal_exists(&passkey));
+        assert!(user_principals.auth_principal_exists(&active));
+        assert_eq!(
+            user_principals.get_by_auth_principal(&active).unwrap().auth_principals,
+            vec![active]
+        );
+        assert!(!user_principals.temp_keys.contains_key(&temp_key));
+        assert!(user_principals.webauthn_credential_ids().is_empty());
+        assert!(matches!(
+            user_principals.remove_auth_principal(active, passkey),
+            Err(RemovePrincipalResponse::IdentityLinkNotFound)
+        ));
+    }
+
+    #[test]
+    fn delete_user_unlinks_every_auth_principal_of_that_user_only() {
+        let mut user_principals = UserPrincipals::default();
+        let (user, auth1, auth2, other_user, other_auth, canister) = (
+            principal(1),
+            principal(2),
+            principal(3),
+            principal(4),
+            principal(5),
+            principal(6),
+        );
+        let user_id = UserId::from(principal(7));
+        user_principals.push(0, user, auth1, canister, Some(vec![1].into()), false, 100);
+        assert!(user_principals.link_auth_principal_with_existing_user(auth2, canister, None, false, 0, 100));
+        user_principals.push(1, other_user, other_auth, canister, Some(vec![2].into()), false, 100);
+        assert!(user_principals.set_user_id(user, Some(user_id)));
+
+        // Refuses to touch anything if the user at the index doesn't carry the expected user id
+        assert!(user_principals.delete_user(1, user_id).is_none());
+        assert!(user_principals.delete_user(5, user_id).is_none());
+        assert!(user_principals.auth_principal_exists(&other_auth));
+
+        assert_eq!(user_principals.delete_user(0, user_id), Some(vec![vec![1].into()]));
+
+        assert!(!user_principals.auth_principal_exists(&auth1));
+        assert!(!user_principals.auth_principal_exists(&auth2));
+        assert!(user_principals.auth_principal_exists(&other_auth));
+        assert!(user_principals.find_user_principal_by_user_id(user_id).is_none());
+        let deleted = user_principals.user_principal_by_index(0).unwrap();
+        assert!(deleted.auth_principals.is_empty());
+        assert!(deleted.user_id.is_none());
+        assert_eq!(user_principals.delete_user(0, user_id), None);
     }
 
     #[test]

--- a/backend/canisters/identity/impl/src/model/webauthn_keys.rs
+++ b/backend/canisters/identity/impl/src/model/webauthn_keys.rs
@@ -39,24 +39,18 @@ impl WebAuthnKeys {
         self.keys.len()
     }
 
-    /// Removes every key which no auth principal can sign in with, returning their credential ids.
+    /// Removes every key which no auth principal can sign in with, returning how many were removed.
     /// A key is kept if the auth principal derived from its public key still exists, or if any auth
     /// principal still refers to its credential id, so a key is only dropped when both routes back
     /// to it are gone.
-    pub fn remove_orphaned_keys(&mut self, user_principals: &UserPrincipals) -> Vec<Vec<u8>> {
+    pub fn remove_orphaned_keys(&mut self, user_principals: &UserPrincipals) -> usize {
         let referenced = user_principals.webauthn_credential_ids();
-        let mut removed = Vec::new();
+        let before = self.keys.len();
         self.keys.retain(|credential_id, key| {
-            if referenced.contains(credential_id)
+            referenced.contains(credential_id)
                 || user_principals.auth_principal_exists(&Principal::self_authenticating(&key.public_key))
-            {
-                true
-            } else {
-                removed.push(credential_id.to_vec());
-                false
-            }
         });
-        removed
+        before - self.keys.len()
     }
 }
 
@@ -389,13 +383,13 @@ mod tests {
         let key4 = der_wrap_cose_key(&hex(&format!("a401010327200621{}{}", "5820", "66".repeat(32))));
         add(&mut keys, 4, key4);
 
-        assert_eq!(keys.remove_orphaned_keys(&user_principals), vec![vec![4]]);
+        assert_eq!(keys.remove_orphaned_keys(&user_principals), 1);
 
         assert!(keys.get(vec![1]).is_some());
         assert!(keys.get(vec![2]).is_some());
         assert!(keys.get(vec![3]).is_some());
         assert!(keys.get(vec![4]).is_none());
-        assert!(keys.remove_orphaned_keys(&user_principals).is_empty());
+        assert_eq!(keys.remove_orphaned_keys(&user_principals), 0);
 
         assert!(keys.remove(vec![1]));
         assert!(!keys.remove(vec![1]));

--- a/backend/canisters/identity/impl/src/model/webauthn_keys.rs
+++ b/backend/canisters/identity/impl/src/model/webauthn_keys.rs
@@ -1,4 +1,5 @@
-use candid::Deserialize;
+use crate::model::user_principals::UserPrincipals;
+use candid::{Deserialize, Principal};
 use identity_canister::WebAuthnKey;
 use serde::Serialize;
 use serde_bytes::ByteBuf;
@@ -28,6 +29,34 @@ impl WebAuthnKeys {
 
     pub fn get(&self, credential_id: Vec<u8>) -> Option<&WebAuthnKeyInternal> {
         self.keys.get(&ByteBuf::from(credential_id))
+    }
+
+    pub fn remove(&mut self, credential_id: Vec<u8>) -> bool {
+        self.keys.remove(&ByteBuf::from(credential_id)).is_some()
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Removes every key which no auth principal can sign in with, returning their credential ids.
+    /// A key is kept if the auth principal derived from its public key still exists, or if any auth
+    /// principal still refers to its credential id, so a key is only dropped when both routes back
+    /// to it are gone.
+    pub fn remove_orphaned_keys(&mut self, user_principals: &UserPrincipals) -> Vec<Vec<u8>> {
+        let referenced = user_principals.webauthn_credential_ids();
+        let mut removed = Vec::new();
+        self.keys.retain(|credential_id, key| {
+            if referenced.contains(credential_id)
+                || user_principals.auth_principal_exists(&Principal::self_authenticating(&key.public_key))
+            {
+                true
+            } else {
+                removed.push(credential_id.to_vec());
+                false
+            }
+        });
+        removed
     }
 
     /// Finds any stored keys whose COSE key is followed by additional data (see
@@ -415,6 +444,74 @@ mod tests {
                 .unwrap_err()
                 .contains("not valid CBOR")
         );
+    }
+
+    #[test]
+    fn remove_orphaned_keys_keeps_every_key_an_auth_principal_can_still_use() {
+        let mut keys = WebAuthnKeys::default();
+        let mut user_principals = UserPrincipals::default();
+        let canister = Principal::from_slice(&[9; 10]);
+        let add = |keys: &mut WebAuthnKeys, credential_id: u8, public_key: Vec<u8>| {
+            keys.add(
+                WebAuthnKey {
+                    public_key,
+                    credential_id: vec![credential_id],
+                    origin: "oc.app".to_string(),
+                    cross_platform: true,
+                    aaguid: [0; 16],
+                },
+                1,
+            );
+        };
+        // Key 1: auth principal derived from its public key exists and refers to it
+        add(&mut keys, 1, valid_key());
+        user_principals.push(
+            0,
+            Principal::from_slice(&[1; 10]),
+            Principal::self_authenticating(valid_key()),
+            canister,
+            Some(vec![1].into()),
+            false,
+            1,
+        );
+        // Key 2: only referred to by credential id, from a principal not derived from its public key
+        add(&mut keys, 2, malformed_key());
+        user_principals.push(
+            1,
+            Principal::from_slice(&[2; 10]),
+            Principal::from_slice(&[3; 10]),
+            canister,
+            Some(vec![2].into()),
+            false,
+            1,
+        );
+        // Key 3: its derived auth principal exists but the reference to it by credential id is missing
+        let key3 = der_wrap_cose_key(&hex(&format!("a401010327200621{}{}", "5820", "55".repeat(32))));
+        add(&mut keys, 3, key3.clone());
+        user_principals.push(
+            2,
+            Principal::from_slice(&[4; 10]),
+            Principal::self_authenticating(&key3),
+            canister,
+            None,
+            false,
+            1,
+        );
+        // Key 4: nothing refers to it
+        let key4 = der_wrap_cose_key(&hex(&format!("a401010327200621{}{}", "5820", "66".repeat(32))));
+        add(&mut keys, 4, key4);
+
+        assert_eq!(keys.remove_orphaned_keys(&user_principals), vec![vec![4]]);
+
+        assert!(keys.get(vec![1]).is_some());
+        assert!(keys.get(vec![2]).is_some());
+        assert!(keys.get(vec![3]).is_some());
+        assert!(keys.get(vec![4]).is_none());
+        assert!(keys.remove_orphaned_keys(&user_principals).is_empty());
+
+        assert!(keys.remove(vec![1]));
+        assert!(!keys.remove(vec![1]));
+        assert!(keys.get(vec![1]).is_none());
     }
 
     #[test]

--- a/backend/canisters/identity/impl/src/updates/delete_user.rs
+++ b/backend/canisters/identity/impl/src/updates/delete_user.rs
@@ -1,10 +1,10 @@
 use crate::{RuntimeState, mutate_state, read_state};
-use candid::Principal;
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use constants::MINUTE_IN_MS;
 use identity_canister::delete_user::*;
 use oc_error_codes::OCErrorCode;
+use tracing::error;
 use types::{CanisterId, OCResult, UserId};
 
 #[update(msgpack = true, candid = true)]
@@ -12,7 +12,7 @@ use types::{CanisterId, OCResult, UserId};
 async fn delete_user(args: Args) -> Response {
     let PrepareResult {
         user_index_canister_id,
-        principal,
+        user_principal_index,
         user_id,
     } = match read_state(|state| prepare(args, state)) {
         Ok(ok) => ok,
@@ -26,7 +26,15 @@ async fn delete_user(args: Args) -> Response {
     .await
     {
         Ok(user_index_canister::c2c_delete_user::Response::Success) => {
-            mutate_state(|state| state.data.user_principals.set_user_id(principal, None));
+            mutate_state(|state| {
+                if let Some(credential_ids) = state.data.user_principals.delete_user(user_principal_index, user_id) {
+                    for credential_id in credential_ids {
+                        state.data.webauthn_keys.remove(credential_id.into_vec());
+                    }
+                } else {
+                    error!(%user_id, user_principal_index, "Deleted user not found in identity canister");
+                }
+            });
             Response::Success
         }
         Ok(user_index_canister::c2c_delete_user::Response::Error(error)) => Response::Error(error),
@@ -36,7 +44,7 @@ async fn delete_user(args: Args) -> Response {
 
 struct PrepareResult {
     user_index_canister_id: CanisterId,
-    principal: Principal,
+    user_principal_index: u32,
     user_id: UserId,
 }
 
@@ -57,7 +65,7 @@ fn prepare(args: Args, state: &RuntimeState) -> OCResult<PrepareResult> {
     {
         Ok(PrepareResult {
             user_index_canister_id: state.data.user_index_canister_id,
-            principal: caller,
+            user_principal_index: auth_principal.user_principal_index,
             user_id,
         })
     } else {

--- a/backend/canisters/identity/impl/src/updates/remove_identity_link.rs
+++ b/backend/canisters/identity/impl/src/updates/remove_identity_link.rs
@@ -12,8 +12,17 @@ fn remove_identity_link(args: Args) -> Response {
 fn remove_identity_link_impl(args: Args, state: &mut RuntimeState) -> Response {
     let auth_principal = state.caller_auth_principal();
 
-    state
+    match state
         .data
         .user_principals
         .remove_auth_principal(auth_principal, args.linked_principal)
+    {
+        Ok(webauthn_credential_id) => {
+            if let Some(credential_id) = webauthn_credential_id {
+                state.data.webauthn_keys.remove(credential_id.into_vec());
+            }
+            Response::Success
+        }
+        Err(response) => response,
+    }
 }

--- a/backend/integration_tests/src/delete_user_tests.rs
+++ b/backend/integration_tests/src/delete_user_tests.rs
@@ -26,8 +26,8 @@ fn delete_user_succeeds_if_signed_in_recently(delay: Milliseconds, should_delete
         user_auth.auth_principal(),
         canister_ids.identity,
         &identity_canister::delete_user::Args {
-            public_key: user_auth.auth_public_key,
-            delegation: user_auth.auth_delegation,
+            public_key: user_auth.auth_public_key.clone(),
+            delegation: user_auth.auth_delegation.clone(),
         },
     );
 
@@ -61,6 +61,17 @@ fn delete_user_succeeds_if_signed_in_recently(delay: Milliseconds, should_delete
 
     let canister_status = env.canister_status(user.canister(), Some(user.local_user_index)).unwrap();
     assert_eq!(canister_status.module_hash.is_none(), should_delete_user);
+
+    // The identity canister should no longer know the auth principal of a deleted user
+    let check_auth_principal_response =
+        client::identity::check_auth_principal_v2(env, user_auth.auth_principal(), canister_ids.identity, &Empty {});
+    assert_eq!(
+        matches!(
+            check_auth_principal_response,
+            identity_canister::check_auth_principal_v2::Response::NotFound
+        ),
+        should_delete_user
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #9309.

`WebAuthnKeys` had no removal path, so unlinking a passkey or deleting an account left the credential (public key, credential id, origin, aaguid) on file forever. It also meant an unlinked passkey could never be registered again, because `create_identity` traps on a duplicate credential id.

Note on re-registration: only the device that created the passkey can re-register it. Registration needs the public key, which the frontend only has from its own IndexedDB cache. A passkey synced to another device (iCloud etc.) yields just the credential id at sign-in, and with the key gone the pubkey lookup fails. That was already the case before this PR (it trapped instead), so from the user's point of view an unlinked passkey is dead everywhere except the originating device, and the normal recovery is to register a new one.

## Changes

- `remove_identity_link` drops the stored key of the unlinked principal. `remove_auth_principal` now returns the credential id on success so the key is removed in the same message.
- `delete_user` unlinks every auth principal of the deleted user, drops their keys, purges temp keys standing in for them, and clears the user id. It keys off the user principal index captured before the async call and does nothing unless that record still carries the expected user id.
- One-off in `post_upgrade` drops orphaned keys and logs the removed and remaining counts.
- `originating_canisters` is now decremented when an auth principal is removed. It was only ever incremented, so every unlink left the metric one too high, and account deletion would have made that drift by whole accounts.

## Why this can't lock anyone out

Signing in with a passkey requires `auth_principals` to contain `self_authenticating(stored public key)`. The cleanup keeps a key if that principal exists, or if any auth principal still refers to its credential id. A key failing both checks is already unusable. Unlink and delete only remove keys belonging to principals removed in that same call. Pending link requests hold their key outside the map until approval, so none of them look orphaned.

## Pre-existing bugs fixed along the way

- `delete_user` passed the auth principal to `set_user_id`, which looks up by OC principal, so the user id was never cleared in the identity canister. Prod probably has deleted users still carrying a `user_id` here. This PR does not touch those.
- An unlinked passkey could never be re-registered from its originating device (trap on duplicate credential id). The upgrade cleanup fixes historic cases too.
- The originating canister metric never went down on unlink.

## Testing

- 3 new unit tests: unlink returns the credential id, drops temp keys and decrements the originating canister count; delete only touches the target user (including its temp keys and count); the orphan predicate across four key states.
- PocketIC: `delete_user_tests` (with a new assertion that the identity canister forgets the auth principal) and all `identity_tests` pass, 9/9.
- clippy `-D warnings` and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113HEY9s9zGY5HTmkH1chUf

