### PR TITLE
Close the Rollbar filter gaps the source maps exposed

### DIFF
--- a/frontend/openchat-client/src/workerAgent.ts
+++ b/frontend/openchat-client/src/workerAgent.ts
@@ -145,10 +145,21 @@ export class WorkerAgent {
         return this.responseHandler(correlationId);
     }
 
+    // Reported once per crossing of the limit: a wedged worker sits above it for as long as the
+    // tab stays open, and a report every poll would be one item per minute saying the same thing
+    #pendingLimitReported = false;
+
     #monitorPendingRequests() {
         const pendingRequests = this.#inflightRequests.size;
         if (pendingRequests >= 100) {
-            this.#logger.error("Pending request count exceeded limit", { count: pendingRequests });
+            if (!this.#pendingLimitReported) {
+                this.#pendingLimitReported = true;
+                this.#logger.error("Pending request count exceeded limit", {
+                    count: pendingRequests,
+                });
+            }
+        } else {
+            this.#pendingLimitReported = false;
         }
     }
 

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -157,10 +157,56 @@ describe("shouldReportError", () => {
             "Error: boom\n" +
             "    at fn (https://oc.app/main.js:1:2)\n" +
             "    at hook (chrome-extension://abc/inject.js:1:2)";
+        // a builtin threw on the extension's behalf: the first frame with a script is theirs
+        const viaBuiltin = new TypeError("Cannot redefine property: ethereum");
+        viaBuiltin.stack =
+            "TypeError: Cannot redefine property: ethereum\n" +
+            "    at Function.defineProperty (<anonymous>)\n" +
+            "    at r.inject (chrome-extension://bfnaelmomeimhlpmgjnjophhpkkoljpa/evmAsk.js:15:5093)";
+        const viaNative = new TypeError("boom");
+        viaNative.stack =
+            "parse@[native code]\n" +
+            "inject@safari-web-extension://abc/inject.js:25:10\n" +
+            "run@https://oc.app/main.js:1:2";
+        const oursViaBuiltin = new TypeError("boom");
+        oursViaBuiltin.stack =
+            "TypeError: boom\n" +
+            "    at JSON.parse (<anonymous>)\n" +
+            "    at fn (https://oc.app/main.js:1:2)\n" +
+            "    at hook (chrome-extension://abc/inject.js:1:2)";
 
         expect(shouldReportError(v8)).toBe(false);
         expect(shouldReportError(gecko)).toBe(false);
+        expect(shouldReportError(viaBuiltin)).toBe(false);
+        expect(shouldReportError(viaNative)).toBe(false);
         expect(shouldReportError(ours)).toBe(true);
+        expect(shouldReportError(oursViaBuiltin)).toBe(true);
+    });
+
+    test("silences the agent's own wrapper around a fetch that threw", () => {
+        expect(
+            shouldReportError(
+                new HttpError(0, new Error("Failed to fetch HTTP request: Failed to fetch")),
+            ),
+        ).toBe(false);
+        expect(
+            shouldReportError(new HttpError(0, new Error("Failed to fetch HTTP request: Load failed"))),
+        ).toBe(false);
+        // the same words from a plain Error are still a signal
+        expect(shouldReportError(new Error("Failed to fetch HTTP request: Failed to fetch"))).toBe(
+            true,
+        );
+    });
+
+    test("silences Safari storage and in-app browser bridge failures", () => {
+        for (const message of [
+            "Database deleted by request of the user",
+            "An internal error was encountered in the Indexed Database server",
+            "WKWebView API client did not respond to this postMessage",
+        ]) {
+            expect(shouldReportError(new Error(message))).toBe(false);
+            expect(shouldReportMessage("Error", message)).toBe(false);
+        }
     });
 });
 

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -58,6 +58,8 @@ const REQWEST_NOISE_PATTERN = /error decoding response body/i;
 
 const RETRY_EXHAUSTED_PATTERN = /retry strategy exhausted after \d+ attempts/i;
 
+const AGENT_FETCH_FAILED_PATTERN = /^failed to fetch http request/i;
+
 // Every HttpError subclass overwrites `name` with its own, so a bare `name === "HttpError"` test
 // misses them. `code` only means an HTTP status on one of these.
 const HTTP_ERROR_NAMES = new Set<string>([
@@ -85,6 +87,9 @@ function isTransientNetworkError(error: unknown): boolean {
     // The IC agent gave up after its fetch retries: every attempt failed at the transport
     // layer (a replica rejection is thrown immediately, without retrying)
     if (name === "HttpError" && RETRY_EXHAUSTED_PATTERN.test(message)) return true;
+    // The agent wraps a fetch that threw (no response at all) as an HttpError with this prefix
+    // and the browser's own text after it. Same network weather, different envelope.
+    if (HTTP_ERROR_NAMES.has(name) && AGENT_FETCH_FAILED_PATTERN.test(message)) return true;
     // Only for the browser's own TypeError: our code also throws Errors whose text happens to
     // start "Failed to fetch ...", and those must stay reportable. A bare string carries no
     // name, so it can never satisfy this and is reported like any other unrecognised failure.
@@ -112,6 +117,12 @@ const ENVIRONMENT_NOISE_PATTERNS: RegExp[] = [
     /get a record from database without an in-progress transaction/i,
     // Safari / Firefox-on-iOS dropping the IndexedDB connection; only a reload recovers it
     /connection to indexed database server lost/i,
+    // Safari's IndexedDB failing internally, or the user (or the OS reclaiming space) wiping
+    // the site's storage from under an open connection
+    /internal error was encountered in the indexed database server/i,
+    /database deleted by request of the user/i,
+    // Safari's in-app browser bridge complaining about its own injected script
+    /wkwebview api client did not respond to this postmessage/i,
     // The client's clock is wrong, so the replica certificate looks like it is from the future
     /certificate is signed more than 5 minutes in the future/i,
     // The same wrong clock seen from the other side: the ingress expiry the agent computed from
@@ -145,8 +156,12 @@ function thrownByExtension(error: unknown): boolean {
     if (error == null || typeof error !== "object" || !("stack" in error)) return false;
     if (typeof error.stack !== "string") return false;
     // V8 puts "Name: message" on the first line and frames below ("    at fn (url)"); JSC and
-    // Gecko start with frames ("fn@url"). Either way the first frame line is the throw site.
-    const frame = error.stack.split("\n").find((line) => /^\s*at |@/.test(line));
+    // Gecko start with frames ("fn@url"). The throw site is the first frame that names a script:
+    // a builtin throwing on the extension's behalf (Object.defineProperty, JSON.parse, ...) shows
+    // up first as "(<anonymous>)" or "[native code]" and says nothing about whose code it was.
+    const frame = error.stack
+        .split("\n")
+        .find((line) => /^\s*at |@/.test(line) && /[a-z-]+:\/\//i.test(line));
     return frame !== undefined && EXTENSION_FRAME_PATTERN.test(frame);
 }
 


### PR DESCRIPTION
First sweep with working source maps (2.0.2054 is live and every 2054 trace now demangles, worker frames included). This PR is the noise half: four classes that were reaching Rollbar because the filter could not see what the traces now show.

**Extension errors thrown through a builtin.** `#31822` is a wallet extension doing `Object.defineProperty(window, "ethereum")`. Its stack starts `at Function.defineProperty (<anonymous>)`, and `thrownByExtension` only looked at that first frame line, so the `chrome-extension://` frame under it never matched. The throw site is now the first frame that names a script. Test covers V8 and JSC shapes, and an error of ours that merely passes through a builtin still reports.

**The agent's fetch wrapper.** `#31702` (135 hits, one offline client) and `#30955` are `HttpError: Failed to fetch HTTP request: Failed to fetch`. That is the agent wrapping a fetch that threw, the same network weather the filter already drops when it arrives as the browser's bare `TypeError`. Accepted only with the agent's exact prefix and only on an HttpError-family name, so a plain `Error` with those words still reports.

**Safari storage and bridge messages.** `Database deleted by request of the user`, `An internal error was encountered in the Indexed Database server` (`#8268`), and `WKWebView API client did not respond to this postMessage` (`#31069`). Environment, nothing to fix per occurrence.

**Pending request count.** `#30622`: one wedged tab reported the same thing every minute for 33 hours (106 in a day). The report now fires once per crossing of the limit and re-arms when the count drops back.

Verification: `error.spec.ts` (21 tests, three new). `#31481` ThreadNotFound, the crashes, and the chunk-load reloads are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3TRyA35YpsnNYkjW8Utm
