### PR TITLE
Guard the crash sites the demangled traces pointed at

### DIFF
--- a/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components/home/AcceptP2PSwapModal.svelte
@@ -40,7 +40,7 @@
     let approving = $state(false);
 
     function reset() {
-        balanceWithRefresh.refresh();
+        balanceWithRefresh?.refresh();
     }
 
     function accept() {

--- a/frontend/app/src/components/home/CryptoTransferBuilder.svelte
+++ b/frontend/app/src/components/home/CryptoTransferBuilder.svelte
@@ -99,7 +99,7 @@
 
     function reset() {
         confirming = false;
-        balanceWithRefresh.refresh();
+        balanceWithRefresh?.refresh();
     }
 
     function maxAmount(balance: bigint): bigint {

--- a/frontend/app/src/components/home/PrizeContentBuilder.svelte
+++ b/frontend/app/src/components/home/PrizeContentBuilder.svelte
@@ -162,7 +162,7 @@
     });
 
     function reset() {
-        balanceWithRefresh.refresh();
+        balanceWithRefresh?.refresh();
     }
 
     function onDiamondChanged() {

--- a/frontend/app/src/components/home/TipBuilder.svelte
+++ b/frontend/app/src/components/home/TipBuilder.svelte
@@ -110,7 +110,7 @@
     }
 
     function reset() {
-        balanceWithRefresh.refresh();
+        balanceWithRefresh?.refresh();
     }
 
     function cancel() {

--- a/frontend/app/src/components/home/profile/SendCrypto.svelte
+++ b/frontend/app/src/components/home/profile/SendCrypto.svelte
@@ -236,7 +236,7 @@
             .then((resp) => {
                 if (resp.kind === "completed" || resp.kind === "success") {
                     amountToSend = BigInt(0);
-                    balanceWithRefresh.refresh();
+                    balanceWithRefresh?.refresh();
                     toastStore.showSuccessToast(
                         i18nKey("cryptoAccount.sendSucceeded", {
                             symbol,

--- a/frontend/app/src/components/home/proposal/MakeProposalModal.svelte
+++ b/frontend/app/src/components/home/proposal/MakeProposalModal.svelte
@@ -138,7 +138,7 @@
 
     async function onClickPrimary(): Promise<void> {
         if (step === 0) {
-            balanceWithRefresh.refresh();
+            balanceWithRefresh?.refresh();
         } else if (canSubmit) {
             onSubmit();
         } else if (step === 1) {

--- a/frontend/app/src/components_mobile/Router.svelte
+++ b/frontend/app/src/components_mobile/Router.svelte
@@ -80,7 +80,14 @@
     const svt = (document as any).startViewTransition;
     const supportsObjectForm = (() => {
         try {
-            (document as any).startViewTransition({ update: () => {} });
+            const probe = (document as any).startViewTransition({ update: () => {} });
+            // A feature probe, not a transition: skip it, and swallow the rejections a skipped
+            // transition settles its promises with. Left alone they surface at startup as an
+            // unhandled "InvalidStateError: Transition was aborted because of invalid state".
+            probe.skipTransition?.();
+            probe.ready?.catch(() => {});
+            probe.finished?.catch(() => {});
+            probe.updateCallbackDone?.catch(() => {});
             return true;
         } catch {
             return false;

--- a/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
+++ b/frontend/app/src/components_mobile/home/AcceptP2PSwapModal.svelte
@@ -37,7 +37,7 @@
     let approving = $state(false);
 
     function reset() {
-        balanceWithRefresh.refresh();
+        balanceWithRefresh?.refresh();
     }
 
     function accept() {

--- a/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
+++ b/frontend/app/src/components_mobile/home/communities/explore/Explore.svelte
@@ -67,6 +67,10 @@
     let view = $state<View>("communities");
     let showingFilters = $state(false);
     let selectedCommunity = $state<CommunityMatch>();
+    // Sheet keeps rendering its children while it animates closed, so the community it shows
+    // has to outlive the dismiss. Clearing it on dismiss left the card reading props off
+    // undefined mid-animation ("Cannot read properties of undefined (reading 'primaryLanguage')")
+    let showSelectedCommunity = $state(false);
 
     let searchState = $derived<SearchState<CommunityMatch | BotMatch>>(
         view === "communities" ? communitySearchState : botSearchState,
@@ -217,6 +221,7 @@
 
     function showCommunity(community: CommunityMatch) {
         selectedCommunity = community;
+        showSelectedCommunity = true;
     }
 
     function scrolledToBottom(fromEnd: number) {
@@ -226,8 +231,8 @@
     }
 </script>
 
-{#if selectedCommunity !== undefined}
-    <Sheet onDismiss={() => (selectedCommunity = undefined)}>
+{#if showSelectedCommunity && selectedCommunity !== undefined}
+    <Sheet onDismiss={() => (showSelectedCommunity = false)}>
         <Container padding={"lg"} direction={"vertical"} gap={"md"}>
             {@const community = selectedCommunity}
             <CommunityCard

--- a/frontend/app/src/components_mobile/home/proposal/MakeProposalModal.svelte
+++ b/frontend/app/src/components_mobile/home/proposal/MakeProposalModal.svelte
@@ -144,7 +144,7 @@
 
     async function onClickPrimary(): Promise<void> {
         if (step === 0) {
-            balanceWithRefresh.refresh();
+            balanceWithRefresh?.refresh();
         } else if (canSubmit) {
             onSubmit();
         } else if (step === 1) {

--- a/frontend/app/src/components_shared/ChatEventList.svelte
+++ b/frontend/app/src/components_shared/ChatEventList.svelte
@@ -1216,6 +1216,8 @@
         await scrollToMessageIndex(context, messageIndex, false);
         if (messageContextsEqual(context, messageContext)) {
             await scrollBottom();
+            // the user may have navigated away while the loads were in flight
+            if (chat === undefined) return;
             // Release the go-to-latest pin once it has completed with nothing
             // left to catch up on; it must not linger and snap a later load.
             if (!client.moreNewMessagesAvailable(chat.id, threadRootEvent)) {

--- a/frontend/app/src/stores/search.svelte.test.ts
+++ b/frontend/app/src/stores/search.svelte.test.ts
@@ -1,0 +1,25 @@
+import type { CommunityMatch } from "@client";
+import { describe, expect, test } from "vitest";
+import { communitySearchState } from "./search.svelte";
+
+function match(communityId: string): CommunityMatch {
+    return { id: { kind: "community", communityId } } as CommunityMatch;
+}
+
+describe("SearchState.appendResults", () => {
+    test("drops items a previous page already delivered", () => {
+        communitySearchState.results = [match("a"), match("b")];
+        communitySearchState.appendResults([match("b"), match("c"), match("c")]);
+        expect(communitySearchState.results.map((c) => c.id.communityId)).toEqual([
+            "a",
+            "b",
+            "c",
+        ]);
+    });
+
+    test("replacing the results does not dedupe against the old page", () => {
+        communitySearchState.results = [match("a")];
+        communitySearchState.results = [match("a"), match("b")];
+        expect(communitySearchState.results).toHaveLength(2);
+    });
+});

--- a/frontend/app/src/stores/search.svelte.ts
+++ b/frontend/app/src/stores/search.svelte.ts
@@ -35,7 +35,7 @@ export const communitySearchStore = createSearchStore<CommunityMatch>();
 
 export const botSearchStore = createSearchStore<BotMatch>();
 
-function createSearchState<T>() {
+function createSearchState<T>(keyOf: KeyOf<T>) {
     const state: Search<T> = $state({
         scrollPos: 0,
         term: "",
@@ -44,11 +44,19 @@ function createSearchState<T>() {
         index: 0,
     });
 
-    return new SearchState<T>(state);
+    return new SearchState<T>(state, keyOf);
 }
 
+// Method-style so the parameter is bivariant: with a plain function-typed field
+// `SearchState<CommunityMatch> | SearchState<BotMatch>` no longer widens to
+// `SearchState<CommunityMatch | BotMatch>`, which Explore relies on.
+type KeyOf<T> = { keyOf(item: T): string }["keyOf"];
+
 export class SearchState<T> {
-    constructor(private state: Search<T>) {}
+    constructor(
+        private state: Search<T>,
+        private keyOf: KeyOf<T>,
+    ) {}
 
     public reset() {
         this.state.index = 0;
@@ -58,8 +66,19 @@ export class SearchState<T> {
         this.state.index += 1;
     }
 
+    // Pages are served against a ranking that can shift between requests, so a later page can
+    // repeat an item from an earlier one. The keyed {#each} rendering the list throws on a
+    // repeated key (svelte's each_key_duplicate), taking the whole page down with it.
     public appendResults(results: T[]) {
-        this.state.results = [...this.state.results, ...results];
+        const seen = new Set(this.state.results.map(this.keyOf));
+        const fresh: T[] = [];
+        for (const item of results) {
+            const key = this.keyOf(item);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            fresh.push(item);
+        }
+        this.state.results = [...this.state.results, ...fresh];
     }
 
     public get term(): string {
@@ -103,6 +122,6 @@ export class SearchState<T> {
     }
 }
 
-export const communitySearchState = createSearchState<CommunityMatch>();
-export const groupSearchState = createSearchState<GroupMatch>();
-export const botSearchState = createSearchState<BotMatch>();
+export const communitySearchState = createSearchState<CommunityMatch>((c) => c.id.communityId);
+export const groupSearchState = createSearchState<GroupMatch>((g) => g.chatId.groupId);
+export const botSearchState = createSearchState<BotMatch>((b) => b.id);

--- a/frontend/app/src/utils/share.ts
+++ b/frontend/app/src/utils/share.ts
@@ -123,6 +123,15 @@ export function shareMessage(
 }
 
 export function shareLink(url: string): void {
+    // The native Android app runs in the system WebView, which has no Web Share API. Copying
+    // the link is the nearest thing to sharing it there.
+    if (!canShare()) {
+        navigator.clipboard.writeText(url).then(
+            () => toastStore.showSuccessToast(i18nKey("linkCopiedToClipboard")),
+            () => toastStore.showFailureToast(i18nKey("failedToCopyUrlToClipboard")),
+        );
+        return;
+    }
     const share = {
         url,
         files: [],


### PR DESCRIPTION
Crash fixes from the first Rollbar sweep with demangled traces. Every item below is a 2.0.2054 (or 2.0.2052) production crash read straight off the source-mapped frame.

- **`#31837` / `#31620`** (10 IPs): `ChatEventList.loadIndexThenScrollToBottom` reads `chat.id` after two awaits. `chat` is gone if the user navigated away meanwhile. Same guard the file already uses after `loadNewMessages`.
- **`#31885`**: `SendCrypto` calls `balanceWithRefresh.refresh()` in the withdraw promise's `.then`; the bound child can have unmounted by then. Seven more builders (desktop and mobile twins) have the identical shape, so all eight take `?.`.
- **`#31890`**: mobile `Explore` sets `selectedCommunity = undefined` on sheet dismiss, but `Sheet` mounts its children out of tree and keeps rendering them through the close animation. The `{@const community = selectedCommunity}` inside re-evaluates to undefined and `CommunityCard` reads `primaryLanguage` off it. Dismiss now flips a separate `showSelectedCommunity` flag and the community stays put until the sheet is gone.
- **`#31889`**: `shareLink` calls `navigator.share` unconditionally. The Android system WebView (native app) has no Web Share API. Falls back to copying the link with the existing toast.
- **`#30972`**: the mobile Router's feature probe `document.startViewTransition({ update })` runs a real transition at startup and drops it. Its promises reject with `InvalidStateError: Transition was aborted` as an unhandled rejection. The probe now skips itself and swallows those.
- **`#30881` / `#30941`** (18 IPs): `each_key_duplicate` on `/communities`. A later page of explore results can repeat a community from an earlier page (ranking moves between requests), and the keyed `{#each}` throws into the top-level error boundary. `SearchState.appendResults` now dedupes by key; new `search.svelte.test.ts` covers cross-page and within-page repeats.

Verification: `svelte-check` clean, `search.svelte.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3TRyA35YpsnNYkjW8Utm
