### PR TITLE
Stop requesting a new thread's events before its first reply has landed

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -3622,6 +3622,21 @@ export class OpenChat {
         return threadEventsStore.value.length === 0 ? undefined : threadEventsStore.value[0].index;
     }
 
+    // Thread events start at index 0, so a thread whose latest event index is 0 holds one event
+    // at most. When that event is our own unconfirmed message, the send that creates the thread
+    // on the server is still in flight: the local summary written by `afterSendMessage` is what
+    // made the thread exist here, and asking the server for its events now gets ThreadNotFound.
+    // Once the send lands the event is confirmed and there is still nothing older to fetch.
+    #firstThreadReplyInFlight(
+        chatId: ChatIdentifier,
+        threadRootEvent: EventWrapper<Message>,
+    ): boolean {
+        const thread = threadRootEvent.event.thread;
+        if (thread === undefined || thread.latestEventIndex > 0) return false;
+        const context = { chatId, threadRootMessageIndex: threadRootEvent.event.messageIndex };
+        return localUpdates.unconfirmedMessages(context).length > 0;
+    }
+
     previousThreadMessagesCriteria(thread: ThreadSummary): [number, boolean] | undefined {
         const minLoadedEventIndex = this.earliestLoadedThreadIndex();
         if (minLoadedEventIndex === undefined) {
@@ -3648,6 +3663,7 @@ export class OpenChat {
         }
 
         if (threadRootEvent !== undefined && threadRootEvent.event.thread !== undefined) {
+            if (this.#firstThreadReplyInFlight(chatId, threadRootEvent)) return;
             const thread = threadRootEvent.event.thread;
             const threadCriteria = this.previousThreadMessagesCriteria(thread);
             if (threadCriteria === undefined) {
@@ -3849,6 +3865,7 @@ export class OpenChat {
         threadRootEvent?: EventWrapper<Message>,
     ): boolean {
         if (threadRootEvent !== undefined) {
+            if (this.#firstThreadReplyInFlight(chatId, threadRootEvent)) return false;
             const earliestIndex = this.earliestLoadedThreadIndex();
             return earliestIndex === undefined || earliestIndex > 0;
         }

--- a/frontend/openchat-shared/src/utils/error.spec.ts
+++ b/frontend/openchat-shared/src/utils/error.spec.ts
@@ -220,6 +220,9 @@ describe("shouldReportMessage", () => {
                 'Events response error: {"kind":"error","code":103,"message":null}',
             ),
         ).toBe(false);
+        expect(
+            shouldReportMessage("Error", 'Events response error: {"kind":"error","code":203}'),
+        ).toBe(false);
     });
 
     test("reports everything else", () => {

--- a/frontend/openchat-shared/src/utils/error.ts
+++ b/frontend/openchat-shared/src/utils/error.ts
@@ -163,7 +163,8 @@ function isEnvironmentNoise(error: unknown): boolean {
 // code (100-106) which `assertSuccessfulEventsResponse` turns into a thrown Error embedding the
 // response JSON. Expected client state, not a defect.
 // ChatNotFound is the same race for a chat that no longer exists on the server (a deleted
-// direct chat partner, say) while the local summary still does.
+// direct chat partner, say) while the local summary still does, and ThreadNotFound the same for
+// a thread whose root message was deleted, or whose first reply has not reached the server yet.
 // Deliberately scoped to that one message: a NotAuthorized code reaching us from anywhere else -
 // a mutation, say - means our local view of the user's permissions is wrong, which is a defect.
 const EVENTS_RESPONSE_ERROR_PREFIX = "Events response error:";
@@ -175,7 +176,8 @@ function isExpectedAccessError(error: unknown): boolean {
     const code = Number(match[1]);
     return (
         (code >= ErrorCode.InitiatorNotFound && code <= ErrorCode.InitiatorBlocked) ||
-        code === ErrorCode.ChatNotFound
+        code === ErrorCode.ChatNotFound ||
+        code === ErrorCode.ThreadNotFound
     );
 }
 


### PR DESCRIPTION
`#31481`: `WORKER: request failed: chatEvents` with `{"kind":"error","code":203}` (ThreadNotFound). 544 hits from 70 IPs over three weeks, still going on 2.0.2054, and 97% of them ask for the event range `[0, 0]`.

**Data flow.** Sending the first reply in a thread has `ChatEventList.afterSendMessage` write a local thread summary with `latestEventIndex: event.index`, which for a brand-new thread is 0. That makes `threadRootEvent.event.thread` defined, `morePreviousMessagesAvailable` sees nothing confirmed loaded and returns true, `loadPreviousMessages` asks the server for thread events `[0, 0]`, and that request races the send that creates the thread on the server. The server has no thread yet, so ThreadNotFound.

**Fix.** Thread events start at index 0, so a thread at index 0 holds one event at most. When that one event is our own unconfirmed message there is nothing the server could return that we do not already have. A new `#firstThreadReplyInFlight` check makes `morePreviousMessagesAvailable` say no and `loadPreviousMessages` return early until the send confirms; after that the event is confirmed at index 0 and the existing "nothing earlier than 0" rule applies.

**The other 3%** are non-zero ranges: a thread whose root message was deleted while the local summary lingered. That is the same race the filter already recognises for whole chats as ChatNotFound, so ThreadNotFound joins `isExpectedAccessError`, scoped to the events-response message like the others (a ThreadNotFound from a mutation still reports).

Verification: `error.spec.ts` green (new case for code 203), `svelte-check` clean. No behavioural test for the client half: it needs the unconfirmed-message store and the thread events store populated together, and `openchat.ts` has no harness for that today. I checked the two call sites by reading them; happy to add one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3TRyA35YpsnNYkjW8Utm
