### PR TITLE
Reload once when a deploy has replaced the chunks this page points at

### DIFF
--- a/frontend/app/src/main.ts
+++ b/frontend/app/src/main.ts
@@ -26,6 +26,24 @@ import { selectLayout } from "./utils/layout";
 // is downloaded and parsed. The decision is made synchronously before either
 // import starts, and the native side queues cold-start events until the mobile
 // App signals svelteReady, so deferring the mount by one chunk load is safe.
+// A dynamic import fails when the deploy that just went out replaced the hashed chunks this
+// page's index.html still points at (or the network dropped mid-load). Vite raises
+// vite:preloadError for it; a reload fetches the new index.html and the chunks it names.
+// Once per version, so a chunk that is genuinely missing surfaces as the error it is rather
+// than a reload loop.
+window.addEventListener("vite:preloadError", (event) => {
+    const key = "oc_chunk_reload_version";
+    const version = import.meta.env.OC_WEBSITE_VERSION;
+    try {
+        if (sessionStorage.getItem(key) === version) return;
+        sessionStorage.setItem(key, version);
+    } catch {
+        return;
+    }
+    event.preventDefault();
+    window.location.reload();
+});
+
 const layout = selectLayout(import.meta.env.OC_MOBILE_LAYOUT, mobileWidth.value);
 
 if (layout === "v2") {


### PR DESCRIPTION
`#8268` / `#8267` carry a steady trickle of `Failed to fetch dynamically imported module: https://oc.app/bundler-D3w4UT0T.js`, `Importing a module script failed.` and `error loading dynamically imported module: https://oc.app/en-CI6SWFLH.js`, at the `https://oc.app/` entry and on route changes.

That is a tab whose `index.html` predates the last deploy asking for hashed chunks that no longer exist (or a network drop mid-load). Nothing handles it today: the user is left with a blank page or a dead route until they reload by hand.

Vite raises `vite:preloadError` on `window` for exactly this, with `preventDefault()` suppressing the throw. The new listener in `main.ts` reloads the page, which fetches the current `index.html` and the chunks it names. It fires once per website version (a `sessionStorage` mark) so a chunk that is genuinely missing still surfaces as the error it is rather than a reload loop.

Verification: `svelte-check` clean; the listener is registered before the app's own dynamic import, so the layout chunk itself is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3TRyA35YpsnNYkjW8Utm
