### PR TITLE
Add a stable memory map with 256 byte pages for small entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5496,8 +5496,7 @@ dependencies = [
 [[package]]
 name = "ic-stable-structures"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee3372ddc0cf2a747fc26ce2d075a240ed6bfab151e63bc70109e8967f7ce6f"
+source = "git+https://github.com/hpeebles/stable-structures?rev=b88706bd6dd4f7463e75886ec10c58fddb810c37#b88706bd6dd4f7463e75886ec10c58fddb810c37"
 dependencies = [
  "ic_principal",
 ]
@@ -7191,6 +7190,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "stable_memory",
+ "stable_memory_map",
  "tracing",
  "types",
  "utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,5 +305,6 @@ ic-cbor = { git = "https://github.com/dfinity/response-verification", rev = "85d
 ic-certificate-verification = { git = "https://github.com/dfinity/response-verification", rev = "85dd37f54b882dc5c490a02f467023470ac6faf4" }
 ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "85dd37f54b882dc5c490a02f467023470ac6faf4" }
 ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "85dd37f54b882dc5c490a02f467023470ac6faf4" }
+ic-stable-structures = { git = "https://github.com/hpeebles/stable-structures", rev = "b88706bd6dd4f7463e75886ec10c58fddb810c37" }
 rmp-serde = { git = "https://github.com/hpeebles/msgpack-rust", rev = "832a3f48e67eea56c869715ae6e1045583dd011b" }
 ts-rs = { git = "https://github.com/hpeebles/ts-rs", rev = "96e2b23ee8fb6131fefb504a0795af38fb2d01fb" }

--- a/backend/canisters/airdrop_bot/CHANGELOG.md
+++ b/backend/canisters/airdrop_bot/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/cycles_dispenser/CHANGELOG.md
+++ b/backend/canisters/cycles_dispenser/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.2006](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2006-cycles_dispenser)] - 2026-08-06
 
 ### Changed

--- a/backend/canisters/escrow/CHANGELOG.md
+++ b/backend/canisters/escrow/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ### Fixed
 
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/event_relay/CHANGELOG.md
+++ b/backend/canisters/event_relay/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.1939](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1939-event_relay)] - 2025-12-31
 
 ### Changed

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/identity/CHANGELOG.md
+++ b/backend/canisters/identity/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ### Fixed
 
 - Remove WebAuthn keys when a passkey is unlinked or its user deleted, and drop orphaned keys on upgrade ([#9324](https://github.com/open-chat-labs/open-chat/pull/9324))

--- a/backend/canisters/local_user_index/CHANGELOG.md
+++ b/backend/canisters/local_user_index/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Harden the message-classification job against API throttling: rate-limit and outage rejections no longer count towards the drop-after-3-attempts limit (queue residency is bounded at 24h instead), the API's Retry-After is honoured, error bodies are logged so throttle and quota failures are distinguishable, and batches are token-capped and paced to stay under the moderation model's tokens-per-minute limit while a deep queue drains ([#9176](https://github.com/open-chat-labs/open-chat/pull/9176))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/market_maker/CHANGELOG.md
+++ b/backend/canisters/market_maker/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.1890](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1890-market_maker)] - 2025-09-11
 
 ### Changed

--- a/backend/canisters/multi_user/CHANGELOG.md
+++ b/backend/canisters/multi_user/CHANGELOG.md
@@ -9,3 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add the MultiUser canister skeleton with its lifecycle endpoints ([#9310](https://github.com/open-chat-labs/open-chat/pull/9310))
+- Initialise the stable memory map, alongside a second map with 256 byte pages for small entries ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))

--- a/backend/canisters/multi_user/impl/Cargo.toml
+++ b/backend/canisters/multi_user/impl/Cargo.toml
@@ -24,6 +24,7 @@ multi_user_canister = { path = "../api" }
 rand = { workspace = true }
 serde = { workspace = true }
 stable_memory = { path = "../../../libraries/stable_memory" }
+stable_memory_map = { path = "../../../libraries/stable_memory_map" }
 tracing = { workspace = true }
 types = { path = "../../../libraries/types" }
 utils = { path = "../../../libraries/utils" }

--- a/backend/canisters/multi_user/impl/src/lifecycle/init.rs
+++ b/backend/canisters/multi_user/impl/src/lifecycle/init.rs
@@ -1,5 +1,6 @@
 use crate::Data;
 use crate::lifecycle::init_state;
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory};
 use canister_tracing_macros::trace;
 use ic_cdk::init;
 use multi_user_canister::init::Args;
@@ -10,6 +11,10 @@ use utils::env::canister::CanisterEnv;
 #[trace]
 fn init(args: Args) {
     canister_logger::init(args.test_mode);
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let env = Box::new(CanisterEnv::new(args.rng_seed));
     let data = Data::new(

--- a/backend/canisters/multi_user/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/multi_user/impl/src/lifecycle/post_upgrade.rs
@@ -1,6 +1,6 @@
 use crate::Data;
 use crate::lifecycle::init_state;
-use crate::memory::get_upgrades_memory;
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory, get_upgrades_memory};
 use canister_api_macros::post_upgrade;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
@@ -12,6 +12,11 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade(msgpack = true)]
 #[trace]
 fn post_upgrade(args: Args) {
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
+
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);
 

--- a/backend/canisters/multi_user/impl/src/memory.rs
+++ b/backend/canisters/multi_user/impl/src/memory.rs
@@ -5,6 +5,8 @@ use ic_stable_structures::{
 use std::collections::BTreeMap;
 
 const UPGRADES: MemoryId = MemoryId::new(0);
+const STABLE_MEMORY_MAP: MemoryId = MemoryId::new(1);
+const STABLE_MEMORY_MAP_SMALL_ENTRIES: MemoryId = MemoryId::new(2);
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -17,8 +19,16 @@ pub fn get_upgrades_memory() -> Memory {
     get_memory(UPGRADES)
 }
 
+pub fn get_stable_memory_map_memory() -> Memory {
+    get_memory(STABLE_MEMORY_MAP)
+}
+
+pub fn get_stable_memory_map_small_entries_memory() -> Memory {
+    get_memory(STABLE_MEMORY_MAP_SMALL_ENTRIES)
+}
+
 pub fn memory_sizes() -> BTreeMap<u8, u64> {
-    (0u8..=0).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
+    (0u8..=2).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
 }
 
 fn get_memory(id: MemoryId) -> Memory {

--- a/backend/canisters/neuron_controller/CHANGELOG.md
+++ b/backend/canisters/neuron_controller/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.1924](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1924-neuron_controller)] - 2025-11-26
 
 ### Changed

--- a/backend/canisters/notifications_index/CHANGELOG.md
+++ b/backend/canisters/notifications_index/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `remove_fcm_tokens` endpoint so the notification pusher can drop FCM tokens that Firebase reports as `UNREGISTERED`
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ### Fixed
 
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/online_users/CHANGELOG.md
+++ b/backend/canisters/online_users/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/openchat_installer/CHANGELOG.md
+++ b/backend/canisters/openchat_installer/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.1984](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.1984-openchat_installer)] - 2026-05-20
 
 ### Removed

--- a/backend/canisters/proposals_bot/CHANGELOG.md
+++ b/backend/canisters/proposals_bot/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/registry/CHANGELOG.md
+++ b/backend/canisters/registry/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/sign_in_with_email/CHANGELOG.md
+++ b/backend/canisters/sign_in_with_email/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[0.14.0](https://github.com/open-chat-labs/ic-sign-in-with-email/releases/tag/v0.14.0)] - 2025-11-25
 
 ### Added

--- a/backend/canisters/storage_bucket/CHANGELOG.md
+++ b/backend/canisters/storage_bucket/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.2048](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2048-storage_bucket)] - 2026-08-31
 
 ### Added

--- a/backend/canisters/storage_index/CHANGELOG.md
+++ b/backend/canisters/storage_index/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ## [[2.0.2049](https://github.com/open-chat-labs/open-chat/releases/tag/v2.0.2049-storage_index)] - 2026-08-31
 
 ### Added

--- a/backend/canisters/translations/CHANGELOG.md
+++ b/backend/canisters/translations/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+
 ### Fixed
 
 - Fix detection of when to retry c2c calls ([#9106](https://github.com/open-chat-labs/open-chat/pull/9106))

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Support P2P swaps for users whose wallets use subaccounts (to support multiple users per canister) ([#9273](https://github.com/open-chat-labs/open-chat/pull/9273))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Fixed
 

--- a/backend/canisters/user_index/CHANGELOG.md
+++ b/backend/canisters/user_index/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
+- Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 
 ### Removed
 

--- a/backend/integration_tests/src/multi_user_canister_tests.rs
+++ b/backend/integration_tests/src/multi_user_canister_tests.rs
@@ -4,6 +4,7 @@ use crate::{TestEnv, client, wasms};
 use candid::Principal;
 use pocket_ic::PocketIc;
 use sha256::sha256;
+use std::collections::BTreeMap;
 use std::ops::Deref;
 use types::{BuildVersion, CanisterId, CanisterWasm, HttpRequest, UpgradesFilter};
 
@@ -24,6 +25,7 @@ fn create_then_upgrade_multi_user_canister() {
     let status = env.canister_status(canister_id, Some(local_user_index)).unwrap();
     assert_eq!(status.module_hash, Some(sha256(&wasms::MULTI_USER.module).to_vec()));
     assert_eq!(wasm_version(env, canister_id), BuildVersion::min());
+    assert_stable_memory_maps_initialised(env, canister_id);
 
     // The canister id -> LocalUserIndex mapping reaches the UserIndex over the idempotent event
     // queue rather than in the reply, so it takes a few rounds to arrive
@@ -47,6 +49,7 @@ fn create_then_upgrade_multi_user_canister() {
     tick_many(env, 20);
 
     assert_eq!(wasm_version(env, canister_id), new_version);
+    assert_stable_memory_maps_initialised(env, canister_id);
 }
 
 #[test]
@@ -113,6 +116,19 @@ fn multi_user_canisters_enabled_flag_fans_out_to_local_user_indexes() {
 
 fn multi_user_canisters_enabled(env: &PocketIc, canister_id: CanisterId) -> bool {
     serde_json::from_value(metrics(env, canister_id)["multi_user_canisters_enabled"].clone()).unwrap()
+}
+
+// Creating a map writes its header, so each map's memory is non-empty once it has been initialised
+fn assert_stable_memory_maps_initialised(env: &PocketIc, canister_id: CanisterId) {
+    let stable_memory_sizes: BTreeMap<u8, u64> =
+        serde_json::from_value(metrics(env, canister_id)["stable_memory_sizes"].clone()).unwrap();
+
+    for memory_id in [1, 2] {
+        assert!(
+            stable_memory_sizes.get(&memory_id).is_some_and(|size| *size > 0),
+            "Stable memory map {memory_id} not initialised: {stable_memory_sizes:?}"
+        );
+    }
 }
 
 fn wasm_version(env: &PocketIc, canister_id: CanisterId) -> BuildVersion {

--- a/backend/libraries/stable_memory_map/src/lib.rs
+++ b/backend/libraries/stable_memory_map/src/lib.rs
@@ -14,8 +14,16 @@ pub use keys::*;
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 
+// The page size of the map for small entries. Keys and values are unbounded so the main map uses
+// the default of 1024 bytes, which suits chat events but wastes most of each page on small,
+// index-like entries (~30-60 bytes). Nodes hold 5-11 entries, so 256 byte pages fit those nodes in
+// 1-2 pages. This is fixed once the map is created.
+pub const SMALL_ENTRIES_MAP_PAGE_SIZE: u32 = 256;
+
 pub struct StableMemoryMapInner {
     map: StableBTreeMap<BaseKey, Vec<u8>, Memory>,
+    #[expect(dead_code, reason = "Nothing is stored in the small entries map yet")]
+    small_entries_map: Option<StableBTreeMap<BaseKey, Vec<u8>, Memory>>,
 }
 
 thread_local! {
@@ -25,6 +33,19 @@ thread_local! {
 pub fn init(memory: Memory) {
     MAP.set(Some(StableMemoryMapInner {
         map: StableBTreeMap::init(memory),
+        small_entries_map: None,
+    }));
+}
+
+// Only use this in canisters which will hold a lot of data, since the small entries map claims its
+// own memory, which is at least one bucket of the memory manager.
+pub fn init_with_small_entries_map(memory: Memory, small_entries_memory: Memory) {
+    MAP.set(Some(StableMemoryMapInner {
+        map: StableBTreeMap::init(memory),
+        small_entries_map: Some(StableBTreeMap::init_with_page_size(
+            small_entries_memory,
+            SMALL_ENTRIES_MAP_PAGE_SIZE,
+        )),
     }));
 }
 
@@ -190,4 +211,38 @@ impl<K: Key, I: DoubleEndedIterator<Item = (BaseKey, Vec<u8>)>> DoubleEndedItera
 
 fn try_map_key_value<K: Key>((key, value): (BaseKey, Vec<u8>)) -> Option<(K, Vec<u8>)> {
     K::try_from(key).ok().map(|k| (k, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_stable_structures::Memory as _;
+    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
+
+    #[test]
+    fn small_entries_map_uses_small_page_size() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
+
+        assert_eq!(page_size(&memory_manager.get(MemoryId::new(0))), 1024);
+        assert_eq!(page_size(&memory_manager.get(MemoryId::new(1))), SMALL_ENTRIES_MAP_PAGE_SIZE);
+    }
+
+    #[test]
+    fn small_entries_map_can_be_reloaded() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
+        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
+
+        assert_eq!(page_size(&memory_manager.get(MemoryId::new(1))), SMALL_ENTRIES_MAP_PAGE_SIZE);
+    }
+
+    // A v2 map header is the magic "BTR", the layout version, then the page size as a
+    // little-endian u32
+    fn page_size(memory: &Memory) -> u32 {
+        let mut header = [0; 8];
+        memory.read(0, &mut header);
+        assert_eq!(&header[..4], b"BTR\x02");
+        u32::from_le_bytes(header[4..8].try_into().unwrap())
+    }
 }

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1378453149
+      instructions: 1378858022
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 210298892
+      instructions: 170236417
       heap_increase: 12
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
## Summary

- Patch `ic-stable-structures` to [hpeebles/stable-structures@b88706b](https://github.com/hpeebles/stable-structures/commit/b88706bd6dd4f7463e75886ec10c58fddb810c37), which adds `BTreeMap::init_with_page_size` / `new_with_page_size`.
- `stable_memory_map` gains `init_with_small_entries_map(memory, small_entries_memory)`, which creates a second map using 256 byte pages (`SMALL_ENTRIES_MAP_PAGE_SIZE`) alongside the existing 1024 byte one. **Nothing is stored in it yet**, routing key types to it will come later. `init` is unchanged, so every existing canister keeps a single map.
- The MultiUser canister now initialises both maps (`MemoryId` 1 and 2) in `init` and `post_upgrade`, and includes them in `stable_memory_sizes`.

### Why 256 bytes

Keys and values in the stable memory map are unbounded, so the map uses the default 1024 byte page. That suits chat events, but index-like entries (message id map, last updated timestamps, user id sets, principal to user id, etc) are ~30-60 bytes, so a 5-11 entry node wastes most of its page. Modelling bytes per entry for 40 byte entries:

| Page size | Random keys | Append-ordered keys |
|---|---|---|
| 128 | 59 B, 3.5 page reads per node | 58 B, 2.0 reads |
| **256** | **59 B, 1.8 reads** | **54 B, 1.0 reads** |
| 384 | 63 B, 1.3 reads | 80 B, 1.0 reads |
| 1024 | 122 B, 1.0 reads | 208 B, 1.0 reads |

### Note on the dependency bump

The fork is 33 commits ahead of the 0.7.2 release, so this also pulls in unreleased upstream changes for every canister (a node cache for reads with 16 slots per map by default, batched node reads and writes, `insert_many`). The on-disk layout constants are unchanged.

## Test plan

- [x] `cargo clippy --workspace --exclude open-chat --exclude tauri-plugin-oc --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Unit tests for `stable_memory_map`, `chat_events`, `group_chat_core`, `stable_memory` and the user, group, community, storage_bucket and multi_user canisters
- [x] New unit tests checking the small entries map is created with 256 byte pages and can be reloaded
- [x] MultiUser integration tests, with `create_then_upgrade_multi_user_canister` now asserting both map memories are initialised after create and after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
