### PR TITLE
Route stable memory map entries between the main and small entries maps

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
-- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 
 ### Fixed
 

--- a/backend/canisters/community/impl/src/lifecycle/init.rs
+++ b/backend/canisters/community/impl/src/lifecycle/init.rs
@@ -1,5 +1,5 @@
 use crate::lifecycle::init_state;
-use crate::memory::get_stable_memory_map_memory;
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory};
 use crate::updates::import_group::commit_group_to_import;
 use crate::{Data, mutate_state};
 use canister_api_macros::init;
@@ -14,7 +14,10 @@ use utils::env::canister::CanisterEnv;
 #[trace]
 fn init(args: Args) {
     canister_logger::init(args.test_mode);
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let mut env = Box::new(CanisterEnv::new(args.rng_seed));
 

--- a/backend/canisters/community/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/community/impl/src/lifecycle/post_upgrade.rs
@@ -1,6 +1,6 @@
 use crate::jobs::import_groups::finalize_group_import;
 use crate::lifecycle::init_state;
-use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory, get_upgrades_memory};
 use crate::{Data, read_state};
 use canister_api_macros::post_upgrade;
 use canister_logger::LogEntry;
@@ -14,7 +14,10 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade(msgpack = true)]
 #[trace]
 fn post_upgrade(args: Args) {
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);

--- a/backend/canisters/community/impl/src/memory.rs
+++ b/backend/canisters/community/impl/src/memory.rs
@@ -8,6 +8,7 @@ const UPGRADES: MemoryId = MemoryId::new(0);
 const INSTRUCTION_COUNTS_INDEX: MemoryId = MemoryId::new(1);
 const INSTRUCTION_COUNTS_DATA: MemoryId = MemoryId::new(2);
 const STABLE_MEMORY_MAP: MemoryId = MemoryId::new(3);
+const STABLE_MEMORY_MAP_SMALL_ENTRIES: MemoryId = MemoryId::new(4);
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -32,8 +33,12 @@ pub fn get_stable_memory_map_memory() -> Memory {
     get_memory(STABLE_MEMORY_MAP)
 }
 
+pub fn get_stable_memory_map_small_entries_memory() -> Memory {
+    get_memory(STABLE_MEMORY_MAP_SMALL_ENTRIES)
+}
+
 pub fn memory_sizes() -> BTreeMap<u8, u64> {
-    (0u8..=3).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
+    (0u8..=4).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
 }
 
 fn get_memory(id: MemoryId) -> Memory {

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Encode the index of a user within their canister into `UserId`, so that a canister can hold many users ([#9259](https://github.com/open-chat-labs/open-chat/pull/9259))
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
-- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 
 ### Fixed
 

--- a/backend/canisters/group/impl/src/lifecycle/init.rs
+++ b/backend/canisters/group/impl/src/lifecycle/init.rs
@@ -1,6 +1,6 @@
 use crate::Data;
 use crate::lifecycle::init_state;
-use crate::memory::get_stable_memory_map_memory;
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory};
 use canister_api_macros::init;
 use canister_tracing_macros::trace;
 use group_canister::init::Args;
@@ -13,7 +13,10 @@ use utils::env::canister::CanisterEnv;
 #[trace]
 fn init(args: Args) {
     canister_logger::init(args.test_mode);
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let mut env = Box::new(CanisterEnv::new(args.rng_seed));
 

--- a/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -1,5 +1,5 @@
 use crate::lifecycle::init_state;
-use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory, get_upgrades_memory};
 use crate::{Data, read_state};
 use canister_api_macros::post_upgrade;
 use canister_logger::LogEntry;
@@ -13,7 +13,10 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade(msgpack = true)]
 #[trace]
 fn post_upgrade(args: Args) {
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);

--- a/backend/canisters/group/impl/src/memory.rs
+++ b/backend/canisters/group/impl/src/memory.rs
@@ -8,6 +8,7 @@ const UPGRADES: MemoryId = MemoryId::new(0);
 const INSTRUCTION_COUNTS_INDEX: MemoryId = MemoryId::new(1);
 const INSTRUCTION_COUNTS_DATA: MemoryId = MemoryId::new(2);
 const STABLE_MEMORY_MAP: MemoryId = MemoryId::new(3);
+const STABLE_MEMORY_MAP_SMALL_ENTRIES: MemoryId = MemoryId::new(4);
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -32,8 +33,12 @@ pub fn get_stable_memory_map_memory() -> Memory {
     get_memory(STABLE_MEMORY_MAP)
 }
 
+pub fn get_stable_memory_map_small_entries_memory() -> Memory {
+    get_memory(STABLE_MEMORY_MAP_SMALL_ENTRIES)
+}
+
 pub fn memory_sizes() -> BTreeMap<u8, u64> {
-    (0u8..=3).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
+    (0u8..=4).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
 }
 
 fn get_memory(id: MemoryId) -> Memory {

--- a/backend/canisters/multi_user/CHANGELOG.md
+++ b/backend/canisters/multi_user/CHANGELOG.md
@@ -14,3 +14,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+- Route stable memory map entries by key type to either the main map or the map for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))

--- a/backend/canisters/multi_user/CHANGELOG.md
+++ b/backend/canisters/multi_user/CHANGELOG.md
@@ -14,4 +14,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
-- Route stable memory map entries by key type to either the main map or the map for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Route stable memory map entries by key type to either the main map or the map for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Support P2P swaps for users whose wallets use subaccounts (to support multiple users per canister) ([#9273](https://github.com/open-chat-labs/open-chat/pull/9273))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Take the user a transfer is being made for rather than the sending canister, so that transfers can be sent from a subaccount ([#9260](https://github.com/open-chat-labs/open-chat/pull/9260))
 - Support P2P swaps for users whose wallets use subaccounts (to support multiple users per canister) ([#9273](https://github.com/open-chat-labs/open-chat/pull/9273))
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
-- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/lifecycle/init.rs
+++ b/backend/canisters/user/impl/src/lifecycle/init.rs
@@ -1,5 +1,5 @@
 use crate::lifecycle::init_state;
-use crate::memory::get_stable_memory_map_memory;
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory};
 use crate::{Data, mutate_state, openchat_bot};
 use canister_tracing_macros::trace;
 use ic_cdk::init;
@@ -12,7 +12,10 @@ use utils::env::canister::CanisterEnv;
 #[trace]
 fn init(args: Args) {
     canister_logger::init(args.test_mode);
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let env = Box::new(CanisterEnv::new(args.rng_seed));
     let now = env.now();

--- a/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -1,6 +1,6 @@
 use crate::Data;
 use crate::lifecycle::init_state;
-use crate::memory::{get_stable_memory_map_memory, get_upgrades_memory};
+use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory, get_upgrades_memory};
 use canister_api_macros::post_upgrade;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
@@ -12,7 +12,10 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade(msgpack = true)]
 #[trace]
 fn post_upgrade(args: Args) {
-    stable_memory_map::init(get_stable_memory_map_memory());
+    stable_memory_map::init_with_small_entries_map(
+        get_stable_memory_map_memory(),
+        get_stable_memory_map_small_entries_memory(),
+    );
 
     let memory = get_upgrades_memory();
     let reader = get_reader(&memory);

--- a/backend/canisters/user/impl/src/memory.rs
+++ b/backend/canisters/user/impl/src/memory.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 const UPGRADES: MemoryId = MemoryId::new(0);
 const STABLE_MEMORY_MAP: MemoryId = MemoryId::new(3);
+const STABLE_MEMORY_MAP_SMALL_ENTRIES: MemoryId = MemoryId::new(4);
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -22,8 +23,12 @@ pub fn get_stable_memory_map_memory() -> Memory {
     get_memory(STABLE_MEMORY_MAP)
 }
 
+pub fn get_stable_memory_map_small_entries_memory() -> Memory {
+    get_memory(STABLE_MEMORY_MAP_SMALL_ENTRIES)
+}
+
 pub fn memory_sizes() -> BTreeMap<u8, u64> {
-    (0u8..=3).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
+    (0u8..=4).map(|id| (id, get_memory(MemoryId::new(id)).size())).collect()
 }
 
 fn get_memory(id: MemoryId) -> Memory {

--- a/backend/integration_tests/src/lib.rs
+++ b/backend/integration_tests/src/lib.rs
@@ -52,6 +52,7 @@ mod set_message_reminder_tests;
 mod setup;
 mod sign_in_with_email_tests;
 mod stable_memory;
+mod stable_memory_map_upgrade_tests;
 mod storage;
 mod storage_tests;
 mod suspend_user_tests;

--- a/backend/integration_tests/src/multi_user_canister_tests.rs
+++ b/backend/integration_tests/src/multi_user_canister_tests.rs
@@ -1,12 +1,12 @@
 use crate::env::ENV;
-use crate::utils::tick_many;
+use crate::utils::{metrics, tick_many};
 use crate::{TestEnv, client, wasms};
 use candid::Principal;
 use pocket_ic::PocketIc;
 use sha256::sha256;
 use std::collections::BTreeMap;
 use std::ops::Deref;
-use types::{BuildVersion, CanisterId, CanisterWasm, HttpRequest, UpgradesFilter};
+use types::{BuildVersion, CanisterId, CanisterWasm, UpgradesFilter};
 
 #[test]
 fn create_then_upgrade_multi_user_canister() {
@@ -137,21 +137,4 @@ fn wasm_version(env: &PocketIc, canister_id: CanisterId) -> BuildVersion {
 
 fn multi_user_canisters(env: &PocketIc, user_index_canister_id: CanisterId) -> Vec<(CanisterId, CanisterId)> {
     serde_json::from_value(metrics(env, user_index_canister_id)["multi_user_canisters"].clone()).unwrap()
-}
-
-fn metrics(env: &PocketIc, canister_id: CanisterId) -> serde_json::Value {
-    let response = client::http_request(
-        env,
-        Principal::anonymous(),
-        canister_id,
-        &HttpRequest {
-            method: "GET".to_string(),
-            url: "/metrics".to_string(),
-            headers: Vec::new(),
-            body: Vec::new(),
-        },
-    );
-    assert_eq!(response.status_code, 200);
-
-    serde_json::from_slice(&response.body).unwrap()
 }

--- a/backend/integration_tests/src/stable_memory_map_upgrade_tests.rs
+++ b/backend/integration_tests/src/stable_memory_map_upgrade_tests.rs
@@ -1,0 +1,91 @@
+use crate::env::ENV;
+use crate::utils::{metrics, tick_many};
+use crate::{TestEnv, client, wasms};
+use pocket_ic::PocketIc;
+use std::collections::BTreeMap;
+use std::ops::Deref;
+use testing::rng::random_string;
+use types::{BuildVersion, CanisterId, CanisterWasm, ChatEvent};
+
+const STABLE_MEMORY_MAP: u8 = 3;
+const STABLE_MEMORY_MAP_SMALL_ENTRIES: u8 = 4;
+
+#[test]
+fn stable_memory_maps_survive_upgrades() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+    } = wrapper.env();
+
+    let user1 = client::register_diamond_user(env, canister_ids, *controller);
+    let user2 = client::register_user(env, canister_ids);
+    let group_id = client::user::happy_path::create_group(env, &user1, &random_string(), false, true);
+    let community_id = client::user::happy_path::create_community(env, &user1, &random_string(), false, vec![random_string()]);
+    let channel_id = client::community::happy_path::create_channel(env, user1.principal, community_id, false, random_string());
+
+    let direct_event = client::user::happy_path::send_text_message(env, &user1, user2.user_id, "direct", None).event_index;
+    let group_event = client::group::happy_path::send_text_message(env, &user1, group_id, None, "group", None).event_index;
+    let channel_event =
+        client::community::happy_path::send_text_message(env, &user1, community_id, channel_id, None, "channel", None)
+            .event_index;
+    tick_many(env, 3);
+
+    let canisters: [CanisterId; 3] = [user1.canister(), group_id.into(), community_id.into()];
+    for canister_id in canisters {
+        assert_stable_memory_maps_initialised(env, canister_id);
+    }
+
+    let version = BuildVersion::new(0, 0, 1);
+    let wasm = |module: &CanisterWasm| CanisterWasm {
+        version,
+        module: module.module.clone(),
+    };
+    client::user_index::happy_path::upgrade_user_canister_wasm(env, *controller, canister_ids.user_index, wasm(&wasms::USER));
+    client::group_index::happy_path::upgrade_group_canister_wasm(
+        env,
+        *controller,
+        canister_ids.group_index,
+        wasm(&wasms::GROUP),
+    );
+    client::group_index::happy_path::upgrade_community_canister_wasm(
+        env,
+        *controller,
+        canister_ids.group_index,
+        wasm(&wasms::COMMUNITY),
+    );
+    tick_many(env, 30);
+
+    for canister_id in canisters {
+        assert_eq!(wasm_version(env, canister_id), version, "{canister_id} not upgraded");
+        assert_stable_memory_maps_initialised(env, canister_id);
+    }
+
+    let direct = client::user::happy_path::events_by_index(env, &user1, user2.user_id, vec![direct_event]);
+    let group = client::group::happy_path::events_by_index(env, &user1, group_id, vec![group_event]);
+    let channel = client::community::happy_path::events_by_index(env, &user1, community_id, channel_id, vec![channel_event]);
+    for response in [direct, group, channel] {
+        assert_eq!(response.events.len(), 1);
+        assert!(matches!(response.events[0].event, ChatEvent::Message(_)));
+    }
+
+    // Upgrading every canister to a new version would break later tests which draw this env
+    wrapper.discard();
+}
+
+// Creating a map writes its header, so each map's memory is non-empty once it has been initialised
+fn assert_stable_memory_maps_initialised(env: &PocketIc, canister_id: CanisterId) {
+    let sizes: BTreeMap<u8, u64> = serde_json::from_value(metrics(env, canister_id)["stable_memory_sizes"].clone()).unwrap();
+
+    for memory_id in [STABLE_MEMORY_MAP, STABLE_MEMORY_MAP_SMALL_ENTRIES] {
+        assert!(
+            sizes.get(&memory_id).is_some_and(|size| *size > 0),
+            "{canister_id}: stable memory map {memory_id} not initialised: {sizes:?}"
+        );
+    }
+}
+
+fn wasm_version(env: &PocketIc, canister_id: CanisterId) -> BuildVersion {
+    serde_json::from_value(metrics(env, canister_id)["wasm_version"].clone()).unwrap()
+}

--- a/backend/integration_tests/src/utils.rs
+++ b/backend/integration_tests/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::client;
 use candid::Principal;
 use constants::{
     CHAT_LEDGER_CANISTER_ID, CHAT_SYMBOL, CHAT_TRANSFER_FEE, ICP_LEDGER_CANISTER_ID, ICP_SYMBOL, ICP_TRANSFER_FEE,
@@ -6,7 +7,7 @@ use pocket_ic::PocketIc;
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 use std::time::SystemTime;
 use std::{path::PathBuf, time::UNIX_EPOCH};
-use types::{Hash, TimestampMillis, TimestampNanos, TokenInfo};
+use types::{CanisterId, Hash, HttpRequest, TimestampMillis, TimestampNanos, TokenInfo};
 
 pub fn principal_to_username(principal: Principal) -> String {
     principal.to_string()[0..5].to_string()
@@ -54,4 +55,21 @@ pub fn icp_token_info() -> TokenInfo {
         decimals: 8,
         fee: ICP_TRANSFER_FEE,
     }
+}
+
+pub fn metrics(env: &PocketIc, canister_id: CanisterId) -> serde_json::Value {
+    let response = client::http_request(
+        env,
+        Principal::anonymous(),
+        canister_id,
+        &HttpRequest {
+            method: "GET".to_string(),
+            url: "/metrics".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+        },
+    );
+    assert_eq!(response.status_code, 200);
+
+    serde_json::from_slice(&response.body).unwrap()
 }

--- a/backend/libraries/stable_memory_map/src/keys.rs
+++ b/backend/libraries/stable_memory_map/src/keys.rs
@@ -83,7 +83,7 @@ fn validate_key<F: FnOnce(KeyType) -> bool>(key: &[u8], validator: F) -> Result<
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum KeyType {
     DirectChatEvent = 1,
@@ -102,6 +102,63 @@ pub enum KeyType {
     FilesPerAccessor = 14,
     UserStorageRecord = 15,
     BlockedUsers = 16,
+    #[cfg(test)]
+    TestSmallEntries = 255,
+}
+
+// Which of the two underlying maps a key type's entries are stored in
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MapClass {
+    // The main map, which uses the default page size of 1024 bytes
+    Default,
+    // The map for small entries, which uses pages of `SMALL_ENTRIES_MAP_PAGE_SIZE` bytes
+    SmallEntries,
+}
+
+impl KeyType {
+    // Once a canister holds data under a key type, that key type's class must never change, since
+    // its existing entries would no longer be found. Every key type below already holds data in the
+    // main map in production, so they must all stay as `Default`.
+    //
+    // All key types sharing a `KeyPrefix` must have the same class, so that a range over a prefix
+    // stays within one map.
+    pub const fn map_class(self) -> MapClass {
+        match self {
+            KeyType::DirectChatEvent
+            | KeyType::GroupChatEvent
+            | KeyType::ChannelEvent
+            | KeyType::DirectChatThreadEvent
+            | KeyType::GroupChatThreadEvent
+            | KeyType::ChannelThreadEvent
+            | KeyType::GroupMember
+            | KeyType::ChannelMember
+            | KeyType::CommunityMember
+            | KeyType::CommunityEvent
+            | KeyType::PrincipalToUserId
+            | KeyType::FileIdToFile
+            | KeyType::FileReferenceCount
+            | KeyType::FilesPerAccessor
+            | KeyType::UserStorageRecord
+            | KeyType::BlockedUsers => MapClass::Default,
+            #[cfg(test)]
+            KeyType::TestSmallEntries => MapClass::SmallEntries,
+        }
+    }
+
+    pub(crate) fn all() -> impl Iterator<Item = KeyType> {
+        (0..=u8::MAX).filter_map(|b| KeyType::try_from(b).ok())
+    }
+}
+
+// Keys whose first byte isn't a known key type are routed to the main map
+pub(crate) fn map_class(key_bytes: &[u8]) -> MapClass {
+    extract_key_type(key_bytes).map_or(MapClass::Default, KeyType::map_class)
+}
+
+impl BaseKeyPrefix {
+    pub(crate) fn from_key_type(key_type: KeyType) -> Self {
+        BaseKeyPrefix(vec![key_type as u8])
+    }
 }
 
 fn extract_key_type(bytes: &[u8]) -> Option<KeyType> {
@@ -129,7 +186,34 @@ impl TryFrom<u8> for KeyType {
             14 => Ok(KeyType::FilesPerAccessor),
             15 => Ok(KeyType::UserStorageRecord),
             16 => Ok(KeyType::BlockedUsers),
+            #[cfg(test)]
+            255 => Ok(KeyType::TestSmallEntries),
             _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_small_entries {
+    use crate::keys::macros::key;
+    use crate::{KeyPrefix, KeyType};
+
+    key!(TestSmallEntriesKey, TestSmallEntriesKeyPrefix, KeyType::TestSmallEntries);
+
+    impl TestSmallEntriesKeyPrefix {
+        pub fn new() -> Self {
+            TestSmallEntriesKeyPrefix(vec![KeyType::TestSmallEntries as u8])
+        }
+    }
+
+    impl KeyPrefix for TestSmallEntriesKeyPrefix {
+        type Key = TestSmallEntriesKey;
+        type Suffix = u32;
+
+        fn create_key(&self, value: &u32) -> Self::Key {
+            let mut bytes = self.0.clone();
+            bytes.extend_from_slice(&value.to_be_bytes());
+            TestSmallEntriesKey(bytes)
         }
     }
 }

--- a/backend/libraries/stable_memory_map/src/lib.rs
+++ b/backend/libraries/stable_memory_map/src/lib.rs
@@ -20,10 +20,14 @@ pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 // 1-2 pages. This is fixed once the map is created.
 pub const SMALL_ENTRIES_MAP_PAGE_SIZE: u32 = 256;
 
+type Map = StableBTreeMap<BaseKey, Vec<u8>, Memory>;
+
+// Entries are split between two underlying maps based on their `KeyType`'s `MapClass`. Every
+// key type sharing a prefix has the same class, so every operation touches exactly one map.
 pub struct StableMemoryMapInner {
-    map: StableBTreeMap<BaseKey, Vec<u8>, Memory>,
-    #[expect(dead_code, reason = "Nothing is stored in the small entries map yet")]
-    small_entries_map: Option<StableBTreeMap<BaseKey, Vec<u8>, Memory>>,
+    map: Map,
+    // `None` if the canister was initialised without a memory for the small entries map
+    small_entries_map: Option<Map>,
 }
 
 thread_local! {
@@ -31,22 +35,35 @@ thread_local! {
 }
 
 pub fn init(memory: Memory) {
-    MAP.set(Some(StableMemoryMapInner {
-        map: StableBTreeMap::init(memory),
-        small_entries_map: None,
-    }));
+    init_inner(memory, None);
 }
 
-// Only use this in canisters which will hold a lot of data, since the small entries map claims its
-// own memory, which is at least one bucket of the memory manager.
 pub fn init_with_small_entries_map(memory: Memory, small_entries_memory: Memory) {
-    MAP.set(Some(StableMemoryMapInner {
-        map: StableBTreeMap::init(memory),
-        small_entries_map: Some(StableBTreeMap::init_with_page_size(
-            small_entries_memory,
-            SMALL_ENTRIES_MAP_PAGE_SIZE,
-        )),
-    }));
+    init_inner(
+        memory,
+        Some(Map::init_with_page_size(small_entries_memory, SMALL_ENTRIES_MAP_PAGE_SIZE)),
+    );
+}
+
+fn init_inner(memory: Memory, small_entries_map: Option<Map>) {
+    let map = Map::init(memory);
+
+    // Guards against a key type's class being changed after data has been stored under it, which
+    // would otherwise leave that data in a map where it would never be found
+    for key_type in KeyType::all().filter(|kt| kt.map_class() == MapClass::SmallEntries) {
+        let prefix = BaseKeyPrefix::from_key_type(key_type);
+        let found = map
+            .range(BaseKey::from(prefix.clone())..)
+            .next()
+            .is_some_and(|e| e.key().matches_prefix(&prefix));
+
+        assert!(
+            !found,
+            "Found entries for {key_type:?} in the main map, but it is in the small entries map"
+        );
+    }
+
+    MAP.set(Some(StableMemoryMapInner { map, small_entries_map }));
 }
 
 pub trait StableMemoryMap<KeyPrefix: crate::KeyPrefix, Value> {
@@ -129,39 +146,80 @@ pub fn with_map_mut<F: FnOnce(&mut StableMemoryMapInner) -> R, R>(f: F) -> R {
 
 impl StableMemoryMapInner {
     pub fn get<K: Key>(&self, key: K) -> Option<Vec<u8>> {
-        self.map.get(&key.into())
+        let key = key.into();
+        self.map(map_class(key.as_slice())).get(&key)
     }
 
     pub fn contains_key<K: Key>(&self, key: K) -> bool {
-        self.map.contains_key(&key.into())
+        let key = key.into();
+        self.map(map_class(key.as_slice())).contains_key(&key)
     }
 
     pub fn insert<K: Key>(&mut self, key: K, value: Vec<u8>) -> Option<Vec<u8>> {
-        self.map.insert(key.into(), value)
+        let key = key.into();
+        self.map_mut(map_class(key.as_slice())).insert(key, value)
     }
 
     pub fn remove<K: Key>(&mut self, key: K) -> Option<Vec<u8>> {
-        self.map.remove(&key.into())
+        let key = key.into();
+        self.map_mut(map_class(key.as_slice())).remove(&key)
     }
 
     pub fn range<'a, K: Key + 'a, R: RangeBounds<K>>(&'a self, range: R) -> impl DoubleEndedIterator<Item = (K, Vec<u8>)> + 'a {
         let start = map_bound(range.start_bound());
         let end = map_bound(range.end_bound());
+        let map = self.map(range_map_class(&start, &end));
 
         Iter {
-            inner: self.map.range((start, end)).map(|e| e.into_pair()),
+            inner: map.range((start, end)).map(|e| e.into_pair()),
             _phantom: PhantomData,
         }
+    }
+
+    fn map(&self, class: MapClass) -> &Map {
+        match class {
+            MapClass::Default => &self.map,
+            MapClass::SmallEntries => self.small_entries_map.as_ref().expect(SMALL_ENTRIES_MAP_UNAVAILABLE),
+        }
+    }
+
+    fn map_mut(&mut self, class: MapClass) -> &mut Map {
+        match class {
+            MapClass::Default => &mut self.map,
+            MapClass::SmallEntries => self.small_entries_map.as_mut().expect(SMALL_ENTRIES_MAP_UNAVAILABLE),
+        }
+    }
+}
+
+const SMALL_ENTRIES_MAP_UNAVAILABLE: &str =
+    "The small entries map is unavailable, initialise the stable memory map using `init_with_small_entries_map`";
+
+// Both bounds of a range must be of the same class, and at least one must be bounded, otherwise we
+// can't tell which map the range is over
+fn range_map_class(start: &Bound<BaseKey>, end: &Bound<BaseKey>) -> MapClass {
+    let class = |bound: &Bound<BaseKey>| match bound {
+        Bound::Included(k) | Bound::Excluded(k) => Some(map_class(k.as_slice())),
+        Bound::Unbounded => None,
+    };
+
+    match (class(start), class(end)) {
+        (Some(s), Some(e)) => {
+            assert_eq!(s, e, "Range bounds are in different maps");
+            s
+        }
+        (Some(c), None) | (None, Some(c)) => c,
+        (None, None) => panic!("Ranges over the stable memory map must be bounded on at least one side"),
     }
 }
 
 pub fn garbage_collect(prefix: BaseKeyPrefix) -> Result<u32, u32> {
     let mut total_count = 0;
     with_map_mut(|m| {
+        let map = m.map_mut(map_class(prefix.as_slice()));
+
         // If < 2B instructions have been used so far, delete another 100 keys, or exit if complete
         while ic_cdk::api::instruction_counter() < 2_000_000_000 {
-            let keys: Vec<_> = m
-                .map
+            let keys: Vec<_> = map
                 .range(BaseKey::from(prefix.clone())..)
                 .take_while(|e| e.key().matches_prefix(&prefix))
                 .take(100)
@@ -171,7 +229,7 @@ pub fn garbage_collect(prefix: BaseKeyPrefix) -> Result<u32, u32> {
             let batch_count = keys.len() as u32;
             total_count += batch_count;
             for key in keys {
-                m.map.remove(&key);
+                map.remove(&key);
             }
             // If batch count < 100 then we are finished
             if batch_count < 100 {
@@ -216,25 +274,116 @@ fn try_map_key_value<K: Key>((key, value): (BaseKey, Vec<u8>)) -> Option<(K, Vec
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::keys::test_small_entries::{TestSmallEntriesKey, TestSmallEntriesKeyPrefix};
+    use ic_principal::Principal;
     use ic_stable_structures::Memory as _;
     use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
+
+    const MAIN: MemoryId = MemoryId::new(0);
+    const SMALL: MemoryId = MemoryId::new(1);
 
     #[test]
     fn small_entries_map_uses_small_page_size() {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
 
-        assert_eq!(page_size(&memory_manager.get(MemoryId::new(0))), 1024);
-        assert_eq!(page_size(&memory_manager.get(MemoryId::new(1))), SMALL_ENTRIES_MAP_PAGE_SIZE);
+        assert_eq!(page_size(&memory_manager.get(MAIN)), 1024);
+        assert_eq!(page_size(&memory_manager.get(SMALL)), SMALL_ENTRIES_MAP_PAGE_SIZE);
+    }
+
+    #[test]
+    fn entries_are_routed_by_key_type() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
+
+        with_map_mut(|m| {
+            for i in 0..100 {
+                m.insert(small_key(i), i.to_be_bytes().to_vec());
+            }
+            m.insert(default_key(), vec![1]);
+        });
+
+        with_map(|m| {
+            assert_eq!(m.map.len(), 1);
+            assert_eq!(m.small_entries_map.as_ref().unwrap().len(), 100);
+
+            assert_eq!(m.get(small_key(7)), Some(7u32.to_be_bytes().to_vec()));
+            assert!(m.contains_key(small_key(99)));
+            assert!(!m.contains_key(small_key(100)));
+            assert_eq!(m.get(default_key()), Some(vec![1]));
+
+            let forward: Vec<_> = m.range(small_key(10)..small_key(15)).map(|(k, _)| suffix(&k)).collect();
+            assert_eq!(forward, vec![10, 11, 12, 13, 14]);
+
+            let backward: Vec<_> = m.range(..=small_key(3)).rev().map(|(k, _)| suffix(&k)).collect();
+            assert_eq!(backward, vec![3, 2, 1, 0]);
+        });
+
+        with_map_mut(|m| {
+            assert_eq!(m.remove(small_key(7)), Some(7u32.to_be_bytes().to_vec()));
+            assert!(m.get(small_key(7)).is_none());
+            assert_eq!(m.small_entries_map.as_ref().unwrap().len(), 99);
+        });
     }
 
     #[test]
     fn small_entries_map_can_be_reloaded() {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
-        init_with_small_entries_map(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)));
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
+        with_map_mut(|m| m.insert(small_key(1), vec![1]));
 
-        assert_eq!(page_size(&memory_manager.get(MemoryId::new(1))), SMALL_ENTRIES_MAP_PAGE_SIZE);
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
+
+        assert_eq!(with_map(|m| m.get(small_key(1))), Some(vec![1]));
+        assert_eq!(page_size(&memory_manager.get(SMALL)), SMALL_ENTRIES_MAP_PAGE_SIZE);
+    }
+
+    #[test]
+    #[should_panic(expected = "The small entries map is unavailable")]
+    fn inserting_small_entry_without_small_entries_map_panics() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        init(memory_manager.get(MAIN));
+
+        with_map_mut(|m| m.insert(small_key(1), vec![1]));
+    }
+
+    #[test]
+    #[should_panic(expected = "Found entries for TestSmallEntries in the main map")]
+    fn init_panics_if_main_map_contains_small_entries() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        let mut map = Map::init(memory_manager.get(MAIN));
+        map.insert(small_key(1).into(), vec![1]);
+        drop(map);
+
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
+    }
+
+    #[test]
+    #[should_panic(expected = "Range bounds are in different maps")]
+    fn range_across_maps_panics() {
+        range_map_class(&Bound::Included(default_key().into()), &Bound::Excluded(small_key(1).into()));
+    }
+
+    // Moving a key type which already holds data to the other map would orphan that data, so the
+    // key types which existed before the small entries map was introduced must stay in the main map
+    #[test]
+    fn existing_key_types_stay_in_main_map() {
+        for key_type in KeyType::all().filter(|kt| (*kt as u8) <= KeyType::BlockedUsers as u8) {
+            assert_eq!(key_type.map_class(), MapClass::Default, "{key_type:?}");
+        }
+        assert_eq!(KeyType::all().filter(|kt| kt.map_class() == MapClass::Default).count(), 16);
+    }
+
+    fn small_key(i: u32) -> TestSmallEntriesKey {
+        TestSmallEntriesKeyPrefix::new().create_key(&i)
+    }
+
+    fn default_key() -> PrincipalKey {
+        PrincipalKeyPrefix::new_for_principal_to_user_id_map().create_key(&Principal::anonymous())
+    }
+
+    fn suffix(key: &TestSmallEntriesKey) -> u32 {
+        u32::from_be_bytes(BaseKey::from(key.clone()).as_slice()[1..].try_into().unwrap())
     }
 
     // A v2 map header is the magic "BTR", the layout version, then the page size as a


### PR DESCRIPTION
Follows #9347, which added the small entries map.

This is the first step towards moving `ChatEvents`' heap indexes into stable memory. It adds the routing between the two underlying maps and wires the small entries map into the User, Group and Community canisters. Every existing key type stays in the main map, so nothing changes behaviour yet.

## Routing

- **Each `KeyType` now has a `MapClass`.** `KeyType::map_class()` returns either `Default` (the 1024 byte map) or `SmallEntries` (the 256 byte map). The match is exhaustive, so each new key type has to choose its map.
- **Every operation touches exactly one map.** `get`, `contains_key`, `insert`, `remove` and `garbage_collect` route by the key's first byte. A range routes by whichever of its bounds are set. It panics if both are unbounded or if the bounds are in different maps. Every existing caller sets at least one bound.
- **Existing key types stay in the main map for good.** Moving a key type which already holds data would orphan it. A unit test pins key types 1 to 16 to `Default`. On init, we also panic if the main map holds entries for any small-class key type.

Canisters initialised with plain `init` have no small entries map, and panic if they touch a small-class key. They are storage_bucket, user_index, local_user_index, notifications_index and online_users. That keeps a misconfiguration loud rather than silently dropping data.

## Wiring

- **User, Group and Community** create the small entries map in MemoryId 4, alongside the main map, in both `init` and `post_upgrade`. None of them has ever used MemoryId 4. `memory_sizes` in metrics now includes it.
- **MultiUser** already did this in #9347.

## Test plan

- [x] `cargo test -p stable_memory_map` covers page sizes, routing, get and contains_key, forward and reverse ranges, remove, reload, the panic when no small entries memory was given, the init guard, ranges across maps, and existing key types staying in the main map
- [x] Unit tests for chat_events, group_chat_core and the user, group, community, multi_user and storage_bucket canisters
- [x] New integration test: User, Group and Community canisters holding messages are upgraded, both maps are initialised before and after, and the messages are still readable
- [x] `multi_user_canister_tests`
- [x] Integration tests which read the stable memory map directly: disappearing messages, delete history, delete channel, convert group into community, plus send direct message
- [x] `cargo clippy --workspace --exclude open-chat --exclude tauri-plugin-oc --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
