### PR TITLE
Move each chat's expiring events into the stable memory map for small entries

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
-- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/community/impl/src/jobs/import_groups.rs
+++ b/backend/canisters/community/impl/src/jobs/import_groups.rs
@@ -192,8 +192,10 @@ pub(crate) fn finalize_group_import(group_id: ChatId) {
             let mut chat: GroupChatCore = msgpack::deserialize_then_unwrap(group.bytes());
             chat.events.set_chat(Chat::Channel(community_id, channel_id));
             chat.members.set_chat(MultiUserChat::Channel(community_id, channel_id));
-            // The message ids were written to stable memory as the events were imported
+            // The message ids and expiring events were written to stable memory as the events were
+            // imported
             chat.events.discard_message_ids_on_heap();
+            chat.events.discard_expiring_events_on_heap();
 
             let blocked: Vec<_> = chat.members.blocked();
             if !blocked.is_empty() {

--- a/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,10 +11,17 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves each chat's MessageId -> EventIndex map from the heap into stable memory.
-// This can be removed once every canister has been migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
+// and its expiring events) into stable memory. This can be removed once every canister has been
+// migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
-    if TIMER_ID.get().is_none() && state.data.chat.events.message_ids_on_heap_count() > 0 {
+    if TIMER_ID.get().is_none()
+        && state
+            .data
+            .channels
+            .iter()
+            .any(|c| c.chat.events.heap_entries_to_migrate_count() > 0)
+    {
         let timer_id = ic_cdk_timers::set_timer(Duration::ZERO, async { run() });
         TIMER_ID.set(Some(timer_id));
         true
@@ -24,13 +31,13 @@ pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
 }
 
 fn run() {
-    trace!("'migrate_message_ids_to_stable_memory' job running");
+    trace!("'migrate_chat_events_to_stable_memory' job running");
     TIMER_ID.set(None);
     mutate_state(|state| {
         let mut count = 0;
-        'outer: for events in std::iter::once(&mut state.data.chat.events) {
+        'outer: for events in state.data.channels.iter_mut().map(|c| &mut c.chat.events) {
             loop {
-                let moved = events.migrate_message_ids_to_stable_memory(BATCH_SIZE);
+                let moved = events.migrate_to_stable_memory(BATCH_SIZE);
                 count += moved;
                 if ic_cdk::api::instruction_counter() > MAX_INSTRUCTIONS_PER_RUN {
                     break 'outer;
@@ -41,6 +48,6 @@ fn run() {
             }
         }
         let complete = !start_job_if_required(state);
-        info!(count, complete, "Migrated message ids to stable memory");
+        info!(count, complete, "Migrated chat events data to stable memory");
     });
 }

--- a/backend/canisters/community/impl/src/jobs/mod.rs
+++ b/backend/canisters/community/impl/src/jobs/mod.rs
@@ -4,7 +4,7 @@ pub mod expire_members;
 pub mod garbage_collect_stable_memory;
 pub mod import_groups;
 pub mod make_pending_payments;
-pub mod migrate_message_ids_to_stable_memory;
+pub mod migrate_chat_events_to_stable_memory;
 pub mod process_expire_member_actions;
 
 pub(crate) fn start(state: &RuntimeState) {
@@ -12,6 +12,6 @@ pub(crate) fn start(state: &RuntimeState) {
     garbage_collect_stable_memory::start_job_if_required(state);
     import_groups::start_job_if_required(state);
     make_pending_payments::start_job_if_required(state);
-    migrate_message_ids_to_stable_memory::start_job_if_required(state);
+    migrate_chat_events_to_stable_memory::start_job_if_required(state);
     process_expire_member_actions::start_job_if_required(state);
 }

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
-- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,16 +11,11 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves each chat's MessageId -> EventIndex map from the heap into stable memory.
-// This can be removed once every canister has been migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
+// and its expiring events) into stable memory. This can be removed once every canister has been
+// migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
-    if TIMER_ID.get().is_none()
-        && state
-            .data
-            .channels
-            .iter()
-            .any(|c| c.chat.events.message_ids_on_heap_count() > 0)
-    {
+    if TIMER_ID.get().is_none() && state.data.chat.events.heap_entries_to_migrate_count() > 0 {
         let timer_id = ic_cdk_timers::set_timer(Duration::ZERO, async { run() });
         TIMER_ID.set(Some(timer_id));
         true
@@ -30,13 +25,13 @@ pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
 }
 
 fn run() {
-    trace!("'migrate_message_ids_to_stable_memory' job running");
+    trace!("'migrate_chat_events_to_stable_memory' job running");
     TIMER_ID.set(None);
     mutate_state(|state| {
         let mut count = 0;
-        'outer: for events in state.data.channels.iter_mut().map(|c| &mut c.chat.events) {
+        'outer: for events in std::iter::once(&mut state.data.chat.events) {
             loop {
-                let moved = events.migrate_message_ids_to_stable_memory(BATCH_SIZE);
+                let moved = events.migrate_to_stable_memory(BATCH_SIZE);
                 count += moved;
                 if ic_cdk::api::instruction_counter() > MAX_INSTRUCTIONS_PER_RUN {
                     break 'outer;
@@ -47,6 +42,6 @@ fn run() {
             }
         }
         let complete = !start_job_if_required(state);
-        info!(count, complete, "Migrated message ids to stable memory");
+        info!(count, complete, "Migrated chat events data to stable memory");
     });
 }

--- a/backend/canisters/group/impl/src/jobs/mod.rs
+++ b/backend/canisters/group/impl/src/jobs/mod.rs
@@ -3,13 +3,13 @@ use crate::RuntimeState;
 pub mod expire_members;
 pub mod garbage_collect_stable_memory;
 pub mod make_pending_payments;
-pub mod migrate_message_ids_to_stable_memory;
+pub mod migrate_chat_events_to_stable_memory;
 pub mod process_expire_member_actions;
 
 pub(crate) fn start(state: &RuntimeState) {
     expire_members::start_job_if_required(state);
     garbage_collect_stable_memory::start_job_if_required(state);
     make_pending_payments::start_job_if_required(state);
-    migrate_message_ids_to_stable_memory::start_job_if_required(state);
+    migrate_chat_events_to_stable_memory::start_job_if_required(state);
     process_expire_member_actions::start_job_if_required(state);
 }

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `ic-stable-structures` to a fork which supports choosing the page size of a map ([#9347](https://github.com/open-chat-labs/open-chat/pull/9347))
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
-- Move each chat's expiring events from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,15 +11,16 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves each chat's MessageId -> EventIndex map from the heap into stable memory.
-// This can be removed once every canister has been migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
+// and its expiring events) into stable memory. This can be removed once every canister has been
+// migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none()
         && state
             .data
             .direct_chats
             .iter()
-            .any(|c| c.events.message_ids_on_heap_count() > 0)
+            .any(|c| c.events.heap_entries_to_migrate_count() > 0)
     {
         let timer_id = ic_cdk_timers::set_timer(Duration::ZERO, async { run() });
         TIMER_ID.set(Some(timer_id));
@@ -30,13 +31,13 @@ pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
 }
 
 fn run() {
-    trace!("'migrate_message_ids_to_stable_memory' job running");
+    trace!("'migrate_chat_events_to_stable_memory' job running");
     TIMER_ID.set(None);
     mutate_state(|state| {
         let mut count = 0;
         'outer: for events in state.data.direct_chats.iter_mut().map(|c| &mut c.events) {
             loop {
-                let moved = events.migrate_message_ids_to_stable_memory(BATCH_SIZE);
+                let moved = events.migrate_to_stable_memory(BATCH_SIZE);
                 count += moved;
                 if ic_cdk::api::instruction_counter() > MAX_INSTRUCTIONS_PER_RUN {
                     break 'outer;
@@ -47,6 +48,6 @@ fn run() {
             }
         }
         let complete = !start_job_if_required(state);
-        info!(count, complete, "Migrated message ids to stable memory");
+        info!(count, complete, "Migrated chat events data to stable memory");
     });
 }

--- a/backend/canisters/user/impl/src/jobs/mod.rs
+++ b/backend/canisters/user/impl/src/jobs/mod.rs
@@ -1,9 +1,9 @@
 use crate::RuntimeState;
 
 pub mod garbage_collect_stable_memory;
-pub mod migrate_message_ids_to_stable_memory;
+pub mod migrate_chat_events_to_stable_memory;
 
 pub(crate) fn start(state: &RuntimeState) {
     garbage_collect_stable_memory::start_job_if_required(state);
-    migrate_message_ids_to_stable_memory::start_job_if_required(state);
+    migrate_chat_events_to_stable_memory::start_job_if_required(state);
 }

--- a/backend/integration_tests/src/communities/convert_group_into_community_tests.rs
+++ b/backend/integration_tests/src/communities/convert_group_into_community_tests.rs
@@ -5,13 +5,18 @@ use crate::utils::tick_many;
 use crate::{CanisterIds, TestEnv, User, client};
 use candid::Principal;
 use chat_events::ChatEventInternal;
+use constants::DAY_IN_MS;
 use itertools::Itertools;
 use oc_error_codes::OCErrorCode;
 use pocket_ic::PocketIc;
-use stable_memory_map::{ChatEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix};
+use stable_memory_map::{ChatEventKeyPrefix, ExpiringEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix};
 use std::ops::Deref;
+use std::time::Duration;
 use testing::rng::{random_from_u128, random_string};
-use types::{Chat, ChatId, EventIndex, EventWrapperInternal, MessageId, Rules};
+use types::{
+    ChannelId, Chat, ChatId, CommunityId, EventIndex, EventWrapperInternal, MAX_EVENT_INDEX, MIN_EVENT_INDEX, MessageId,
+    OptionUpdate, Rules,
+};
 
 #[test]
 fn convert_into_community_succeeds() {
@@ -119,6 +124,77 @@ fn convert_into_community_succeeds() {
 }
 
 #[test]
+fn disappearing_messages_still_expire_after_conversion() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+        ..
+    } = wrapper.env();
+
+    let TestData { user1, group_id, .. } = init_test_data(env, canister_ids, *controller);
+
+    client::group::update_group_v2(
+        env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::update_group_v2::Args {
+            events_ttl: OptionUpdate::SetToSome(DAY_IN_MS),
+            ..Default::default()
+        },
+    );
+
+    let event_indexes: Vec<_> = (0..5)
+        .map(|_| client::group::happy_path::send_text_message(env, &user1, group_id, None, random_string(), None).event_index)
+        .collect();
+
+    let convert_into_community_response = client::group::convert_into_community(
+        env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::convert_into_community::Args {
+            rules: Rules::default(),
+            permissions: None,
+            primary_language: None,
+            history_visible_to_new_joiners: true,
+        },
+    );
+
+    let group_canister::convert_into_community::Response::Success(result) = convert_into_community_response else {
+        panic!("'convert_into_community' error: {convert_into_community_response:?}");
+    };
+    tick_many(env, 20);
+
+    // The expiring events should have been written to stable memory as the events were imported
+    assert_eq!(
+        expiring_event_indexes(env, result.community_id, result.channel_id),
+        event_indexes
+    );
+
+    // Nothing schedules the expiry job when a group is imported, so send a message to schedule it
+    client::community::happy_path::send_text_message(
+        env,
+        &user1,
+        result.community_id,
+        result.channel_id,
+        None,
+        random_string(),
+        None,
+    );
+
+    env.advance_time(Duration::from_millis(DAY_IN_MS));
+    env.tick();
+
+    assert!(
+        client::community::happy_path::events_by_index(env, &user1, result.community_id, result.channel_id, event_indexes)
+            .events
+            .is_empty()
+    );
+    assert!(expiring_event_indexes(env, result.community_id, result.channel_id).is_empty());
+}
+
+#[test]
 fn not_group_owner_returns_unauthorized() {
     let mut wrapper = ENV.deref().get();
     let TestEnv {
@@ -146,6 +222,18 @@ fn not_group_owner_returns_unauthorized() {
         convert_into_community_response,
         group_canister::convert_into_community::Response::Error(e) if e.matches_code(OCErrorCode::InitiatorNotAuthorized)
     ));
+}
+
+fn expiring_event_indexes(env: &PocketIc, community_id: CommunityId, channel_id: ChannelId) -> Vec<EventIndex> {
+    let small_entries_map = get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
+    let prefix = ExpiringEventKeyPrefix::new_from_chat(Chat::Channel(community_id, channel_id));
+    let range_start = prefix.create_key(&(u64::MIN, MIN_EVENT_INDEX));
+    let range_end = prefix.create_key(&(u64::MAX, MAX_EVENT_INDEX));
+
+    small_entries_map
+        .keys_range(range_start.as_ref().to_vec()..=range_end.as_ref().to_vec())
+        .map(|key| u32::from_be_bytes(key[key.len() - 4..].try_into().unwrap()).into())
+        .collect()
 }
 
 fn init_test_data(env: &mut PocketIc, canister_ids: &CanisterIds, controller: Principal) -> TestData {

--- a/backend/integration_tests/src/communities/delete_channel_tests.rs
+++ b/backend/integration_tests/src/communities/delete_channel_tests.rs
@@ -4,13 +4,14 @@ use crate::stable_memory::{STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID, get_stable
 use crate::utils::now_millis;
 use crate::{CanisterIds, TestEnv, User, client};
 use candid::Principal;
+use constants::DAY_IN_MS;
 use oc_error_codes::OCErrorCode;
 use pocket_ic::PocketIc;
 use std::ops::Deref;
 use std::time::Duration;
 use test_case::test_case;
 use testing::rng::random_string;
-use types::{ChannelId, CommunityId};
+use types::{ChannelId, CommunityId, OptionUpdate};
 
 #[test_case(true)]
 #[test_case(false)]
@@ -84,6 +85,27 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
         ..
     } = init_test_data(env, canister_ids, *controller);
 
+    // Make the messages in the first channel expire (though not within this test), so that the
+    // channel has expiring events
+    client::community::happy_path::update_channel(
+        env,
+        user1.principal,
+        community_id,
+        &community_canister::update_channel::Args {
+            channel_id: channel_id1,
+            name: None,
+            description: None,
+            rules: None,
+            avatar: OptionUpdate::NoChange,
+            permissions_v2: None,
+            events_ttl: OptionUpdate::SetToSome(DAY_IN_MS),
+            gate_config: OptionUpdate::NoChange,
+            public: None,
+            messages_visible_to_non_members: None,
+            external_url: OptionUpdate::NoChange,
+        },
+    );
+
     let initial_stable_memory_map_keys = get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len();
     let initial_small_entries_keys = get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
 
@@ -97,7 +119,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 100
+        initial_small_entries_keys + 200
     );
 
     for _ in 0..80 {
@@ -110,7 +132,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 180
+        initial_small_entries_keys + 280
     );
 
     client::community::happy_path::delete_channel(env, user1.principal, community_id, channel_id1);
@@ -120,7 +142,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
 
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
-        initial_stable_memory_map_keys + 77
+        initial_stable_memory_map_keys + 76
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
@@ -134,7 +156,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
 
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
-        initial_stable_memory_map_keys - 6
+        initial_stable_memory_map_keys - 7
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),

--- a/backend/integration_tests/src/communities/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/communities/disappearing_message_tests.rs
@@ -169,9 +169,10 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
+    // A message id for each message, plus an expiring event for each message in the main events list
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 30
+        initial_small_entries_keys + 35
     );
 
     // Tick once to expire the messages
@@ -186,8 +187,8 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
         initial_stable_memory_map_keys
     );
-    // The message ids of the expired threads are garbage collected, but those of the expired
-    // messages in the main events list are retained
+    // The expiring events are removed and the message ids of the expired threads are garbage
+    // collected, but the message ids of the expired messages in the main events list are retained
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
         initial_small_entries_keys + 5

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -2,11 +2,12 @@ use crate::env::ENV;
 use crate::stable_memory::{STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID, get_stable_memory_map};
 use crate::utils::{now_millis, tick_many};
 use crate::{TestEnv, client};
+use constants::DAY_IN_MS;
 use ic_stable_structures::memory_manager::MemoryId;
 use std::ops::Deref;
 use std::time::Duration;
 use testing::rng::random_string;
-use types::{ChatId, MessageContentInitial, TextContent};
+use types::{ChatId, MessageContentInitial, OptionUpdate, TextContent};
 
 #[test]
 fn delete_direct_chat_succeeds() {
@@ -77,6 +78,18 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     let initial_small_entries_keys =
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
 
+    // Make the messages expire (though not within this test), so that the chat has expiring events
+    client::user::happy_path::update_chat_settings(
+        env,
+        &user1,
+        &user_canister::update_chat_settings::Args {
+            user_id: user2.user_id,
+            events_ttl: OptionUpdate::SetToSome(DAY_IN_MS),
+        },
+    );
+    let small_entries_keys_before_messages =
+        get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
+
     let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
     for _ in 0..3 {
         client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
@@ -95,9 +108,10 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     tick_many(env, 3);
 
     assert!(get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_MEMORY_ID).len() > initial_stable_memory_map_keys);
+    // A message id for each message, plus an expiring event for each message in the main events list
     assert_eq!(
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 6
+        small_entries_keys_before_messages + 10
     );
 
     let delete_direct_chat_response = client::user::delete_direct_chat(

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -408,9 +408,10 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, group_id, CHAT_EVENTS_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
+    // A message id for each message, plus an expiring event for each message in the main events list
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 30
+        initial_small_entries_keys + 35
     );
 
     // Tick once to expire the messages
@@ -425,8 +426,8 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, group_id, CHAT_EVENTS_MEMORY_ID).len(),
         initial_stable_memory_map_keys
     );
-    // The message ids of the expired threads are garbage collected, but those of the expired
-    // messages in the main events list are retained
+    // The expiring events are removed and the message ids of the expired threads are garbage
+    // collected, but the message ids of the expired messages in the main events list are retained
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
         initial_small_entries_keys + 5

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -10,7 +10,7 @@ use oc_error_codes::{OCError, OCErrorCode};
 use search::simple::{Document, Query};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use stable_memory_map::{BaseKeyPrefix, ChatEventKeyPrefix, MessageIdKeyPrefix};
+use stable_memory_map::{BaseKeyPrefix, ChatEventKeyPrefix, ExpiringEventKeyPrefix, MessageIdKeyPrefix};
 use std::cmp::max;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -65,9 +65,13 @@ impl ChatEvents {
 
     // The prefixes of all the stable memory entries belonging to a single events list (ie. the
     // main events list or a thread), so that they can all be garbage collected once it is deleted
-    pub fn stable_memory_key_prefixes(events_prefix: ChatEventKeyPrefix) -> [BaseKeyPrefix; 2] {
+    pub fn stable_memory_key_prefixes(events_prefix: ChatEventKeyPrefix) -> Vec<BaseKeyPrefix> {
         let message_ids_prefix = MessageIdKeyPrefix::from(&events_prefix);
-        [events_prefix.into(), message_ids_prefix.into()]
+        // Only the main events list has expiring events
+        let expiring_events_prefix = ExpiringEventKeyPrefix::try_from(&events_prefix).ok();
+        let mut prefixes = vec![events_prefix.into(), message_ids_prefix.into()];
+        prefixes.extend(expiring_events_prefix.map(BaseKeyPrefix::from));
+        prefixes
     }
 
     pub fn new_direct_chat(
@@ -149,6 +153,7 @@ impl ChatEvents {
         for (message_index, events_list) in self.threads.iter_mut() {
             events_list.set_stable_memory_prefix(chat, Some(*message_index));
         }
+        self.expiring_events.refresh_next_expiry(chat);
     }
 
     pub fn read_events_as_bytes_from_stable_memory(&self, after: Option<EventContext>) -> Vec<(EventContext, ByteBuf)> {
@@ -161,10 +166,13 @@ impl ChatEvents {
         self.last_updated_timestamps.iter()
     }
 
-    // Moves up to `max_count` message ids from the heap into stable memory, returning how many
-    // were moved
-    pub fn migrate_message_ids_to_stable_memory(&mut self, max_count: usize) -> usize {
-        let mut moved = self.main.migrate_message_ids_to_stable_memory(max_count);
+    // Moves up to `max_count` entries from the heap into stable memory, returning how many were
+    // moved
+    pub fn migrate_to_stable_memory(&mut self, max_count: usize) -> usize {
+        let mut moved = self.expiring_events.migrate_to_stable_memory(self.chat, max_count);
+        if moved < max_count {
+            moved += self.main.migrate_message_ids_to_stable_memory(max_count - moved);
+        }
         for thread in self.threads.values_mut() {
             if moved >= max_count {
                 break;
@@ -184,8 +192,17 @@ impl ChatEvents {
         }
     }
 
-    pub fn message_ids_on_heap_count(&self) -> usize {
-        self.main.message_ids_on_heap_count() + self.threads.values().map(|t| t.message_ids_on_heap_count()).sum::<usize>()
+    // Similarly, `import_events` writes an expiring event for every imported event which has an
+    // expiry date, so any expiring events left on the heap are duplicates of those
+    pub fn discard_expiring_events_on_heap(&mut self) {
+        self.expiring_events.discard_on_heap();
+    }
+
+    // The number of entries on the heap which are yet to be moved into stable memory
+    pub fn heap_entries_to_migrate_count(&self) -> usize {
+        self.expiring_events.on_heap_count()
+            + self.main.message_ids_on_heap_count()
+            + self.threads.values().map(|t| t.message_ids_on_heap_count()).sum::<usize>()
     }
 
     pub fn thread_keys(&self) -> impl Iterator<Item = MessageIndex> + '_ {
@@ -1891,7 +1908,7 @@ impl ChatEvents {
         let event_index = events_list.push_event(event.clone(), expires_at, now);
 
         if let Some(timestamp) = expires_at {
-            self.expiring_events.insert(event_index, timestamp);
+            self.expiring_events.insert(self.chat, event_index, timestamp);
         }
 
         let bots_to_notify = self.bots_to_notify(&event_type);
@@ -2119,7 +2136,7 @@ impl ChatEvents {
     pub fn remove_expired_events(&mut self, now: TimestampMillis) -> RemoveEventsResult {
         let mut results = RemoveEventsResult::default();
 
-        while let Some(event_index) = self.expiring_events.take_next_expired_event(now) {
+        while let Some(event_index) = self.expiring_events.take_next_expired_event(self.chat, now) {
             if let Some(result) = self.remove_event(event_index, now) {
                 results.merge_result(event_index, result);
             }

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -930,15 +930,15 @@ mod tests {
         move_message_ids_to_heap(&mut events);
         let expected = expected_message_id_event_indexes(&events);
 
-        assert_eq!(events.message_ids_on_heap_count(), 100);
+        assert_eq!(events.heap_entries_to_migrate_count(), 100);
         assert_message_id_lookups(&events, &expected);
 
-        assert_eq!(events.migrate_message_ids_to_stable_memory(30), 30);
-        assert_eq!(events.message_ids_on_heap_count(), 70);
+        assert_eq!(events.migrate_to_stable_memory(30), 30);
+        assert_eq!(events.heap_entries_to_migrate_count(), 70);
         assert_message_id_lookups(&events, &expected);
 
-        assert_eq!(events.migrate_message_ids_to_stable_memory(1000), 70);
-        assert_eq!(events.message_ids_on_heap_count(), 0);
+        assert_eq!(events.migrate_to_stable_memory(1000), 70);
+        assert_eq!(events.heap_entries_to_migrate_count(), 0);
         assert_message_id_lookups(&events, &expected);
 
         let events_list = events.main_events_list();
@@ -946,7 +946,7 @@ mod tests {
             assert_eq!(events_list.message_ids().get(&message_id), Some(event_index));
         }
 
-        assert_eq!(events.migrate_message_ids_to_stable_memory(1000), 0);
+        assert_eq!(events.migrate_to_stable_memory(1000), 0);
     }
 
     #[test]
@@ -1028,7 +1028,7 @@ mod tests {
         imported.set_chat(channel);
         imported.discard_message_ids_on_heap();
 
-        assert_eq!(imported.message_ids_on_heap_count(), 0);
+        assert_eq!(imported.heap_entries_to_migrate_count(), 0);
         assert_message_id_lookups(&imported, remaining);
         for (message_id, _) in removed {
             assert!(
@@ -1037,6 +1037,52 @@ mod tests {
                     .event_index(EventKey::MessageId(*message_id))
                     .is_none()
             );
+        }
+    }
+
+    #[test]
+    fn expired_events_are_removed() {
+        let mut events = setup_events(Some(1000));
+        assert_eq!(events.heap_entries_to_migrate_count(), 0);
+
+        // The messages were pushed at 2..102, so expire at 1002..1102
+        assert_eq!(events.next_event_expiry(), Some(1002));
+        assert_eq!(events.remove_expired_events(1001).events.len(), 0);
+
+        let result = events.remove_expired_events(1051);
+        assert_eq!(result.events.len(), 50);
+        assert_eq!(events.next_event_expiry(), Some(1052));
+
+        let events_list = events.main_events_list();
+        for i in 1..=100u32 {
+            let event = events_list.get_event(EventKey::EventIndex(i.into()), EventIndex::default(), None);
+            assert_eq!(event.is_some(), i > 50);
+        }
+
+        assert_eq!(events.remove_expired_events(2000).events.len(), 50);
+        assert_eq!(events.next_event_expiry(), None);
+    }
+
+    #[test]
+    fn import_events_writes_expiring_events() {
+        let events = setup_events(Some(1000));
+        let channel = Chat::Channel(Principal::from_slice(&[3]).into(), ChannelId::from(1u32));
+        ChatEvents::import_events(channel, export_events(&events));
+
+        let mut imported: ChatEvents = msgpack::deserialize_then_unwrap(&msgpack::serialize_then_unwrap(&events));
+        imported.set_chat(channel);
+        imported.discard_message_ids_on_heap();
+        imported.discard_expiring_events_on_heap();
+        assert_eq!(imported.heap_entries_to_migrate_count(), 0);
+        assert_eq!(imported.next_event_expiry(), Some(1002));
+
+        // Every message expires, but the `DirectChatCreated` event doesn't
+        assert_eq!(imported.remove_expired_events(u64::MAX).events.len(), 100);
+        assert_eq!(imported.next_event_expiry(), None);
+        let events_list = imported.main_events_list();
+        for i in 0..=100u32 {
+            let event = events_list.get_event(EventKey::EventIndex(i.into()), EventIndex::default(), None);
+            assert_eq!(event.is_some(), i == 0);
         }
     }
 

--- a/backend/libraries/chat_events/src/expiring_events.rs
+++ b/backend/libraries/chat_events/src/expiring_events.rs
@@ -1,26 +1,257 @@
 use serde::{Deserialize, Serialize};
+use stable_memory_map::{ExpiringEventKeyPrefix, KeyPrefix, with_map, with_map_mut};
 use std::collections::BTreeSet;
-use types::{EventIndex, TimestampMillis};
+use types::{Chat, EventIndex, MAX_EVENT_INDEX, MIN_EVENT_INDEX, TimestampMillis};
 
+// The events which are due to expire, ordered by their expiry dates. The entries are stored in the
+// stable memory map for small entries.
 #[derive(Serialize, Deserialize, Default)]
 pub struct ExpiringEvents {
-    event_expiry_dates: BTreeSet<(TimestampMillis, EventIndex)>,
+    // Entries which haven't yet been moved into stable memory. New entries are always written to
+    // stable memory, and existing ones are moved across in batches by `migrate_to_stable_memory`.
+    // This can be removed once every chat has been migrated. It is always serialized so that a
+    // canister can still be rolled back to a version expecting it.
+    #[serde(rename = "event_expiry_dates", default)]
+    on_heap: BTreeSet<(TimestampMillis, EventIndex)>,
+    // A lower bound for the expiry dates of the entries in stable memory, or `None` if there are
+    // none, so that checking when the next event expires doesn't require reading from stable
+    // memory. This is exact other than while expired events are being taken.
+    #[serde(rename = "n", default, skip_serializing_if = "Option::is_none")]
+    next_expiry_in_stable_memory: Option<TimestampMillis>,
 }
 
 impl ExpiringEvents {
-    pub fn insert(&mut self, event_index: EventIndex, expires_at: TimestampMillis) {
-        self.event_expiry_dates.insert((expires_at, event_index));
+    pub fn insert(&mut self, chat: Chat, event_index: EventIndex, expires_at: TimestampMillis) {
+        let key = ExpiringEventKeyPrefix::new_from_chat(chat).create_key(&(expires_at, event_index));
+        with_map_mut(|m| m.insert(key, Vec::new()));
+
+        if self.next_expiry_in_stable_memory.is_none_or(|ts| expires_at < ts) {
+            self.next_expiry_in_stable_memory = Some(expires_at);
+        }
     }
 
     pub fn next_event_expiry(&self) -> Option<TimestampMillis> {
-        self.event_expiry_dates.first().map(|(ts, _)| *ts)
+        let next_on_heap = self.on_heap.first().map(|(ts, _)| *ts);
+        [next_on_heap, self.next_expiry_in_stable_memory].into_iter().flatten().min()
     }
 
-    pub fn take_next_expired_event(&mut self, now: TimestampMillis) -> Option<EventIndex> {
-        if self.next_event_expiry().is_some_and(|ts| ts <= now) {
-            self.event_expiry_dates.pop_first().map(|(_, i)| i)
-        } else {
-            None
+    pub fn take_next_expired_event(&mut self, chat: Chat, now: TimestampMillis) -> Option<EventIndex> {
+        if self.on_heap.first().is_some_and(|(ts, _)| *ts <= now) {
+            return self.on_heap.pop_first().map(|(_, i)| i);
         }
+
+        if self.next_expiry_in_stable_memory.is_none_or(|ts| ts > now) {
+            return None;
+        }
+
+        let prefix = ExpiringEventKeyPrefix::new_from_chat(chat);
+        match first_entry_in_stable_memory(&prefix) {
+            Some((expires_at, event_index)) if expires_at <= now => {
+                with_map_mut(|m| m.remove(prefix.create_key(&(expires_at, event_index))));
+                // The removed entry's expiry date is still a lower bound for the remaining entries,
+                // and the exact value is set once there are no more expired entries to take
+                self.next_expiry_in_stable_memory = Some(expires_at);
+                Some(event_index)
+            }
+            next => {
+                self.next_expiry_in_stable_memory = next.map(|(ts, _)| ts);
+                None
+            }
+        }
+    }
+
+    // Recalculates the next expiry date of the entries in stable memory, which is needed after
+    // entries have been written directly to stable memory (eg. when importing a group into a
+    // community)
+    pub fn refresh_next_expiry(&mut self, chat: Chat) {
+        let prefix = ExpiringEventKeyPrefix::new_from_chat(chat);
+        self.next_expiry_in_stable_memory = first_entry_in_stable_memory(&prefix).map(|(ts, _)| ts);
+    }
+
+    // Moves up to `max_count` entries from the heap into stable memory, returning how many were
+    // moved
+    pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
+        let mut count = 0;
+        while count < max_count
+            && let Some((expires_at, event_index)) = self.on_heap.pop_first()
+        {
+            self.insert(chat, event_index, expires_at);
+            count += 1;
+        }
+        count
+    }
+
+    pub fn on_heap_count(&self) -> usize {
+        self.on_heap.len()
+    }
+
+    pub fn discard_on_heap(&mut self) {
+        self.on_heap = BTreeSet::new();
+    }
+}
+
+fn first_entry_in_stable_memory(prefix: &ExpiringEventKeyPrefix) -> Option<(TimestampMillis, EventIndex)> {
+    let start = prefix.create_key(&(TimestampMillis::MIN, MIN_EVENT_INDEX));
+    let end = prefix.create_key(&(TimestampMillis::MAX, MAX_EVENT_INDEX));
+    with_map(|m| m.range(start..=end).next().map(|(k, _)| (k.expires_at(), k.event_index())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use ic_stable_structures::DefaultMemoryImpl;
+    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
+    use rand::{Rng, rng};
+
+    #[test]
+    fn expired_events_are_taken_in_expiry_order() {
+        init_stable_memory_map();
+        let chat1 = Chat::Direct(Principal::from_slice(&[1]).into());
+        let chat2 = Chat::Direct(Principal::from_slice(&[2]).into());
+        let mut expiring_events1 = ExpiringEvents::default();
+        let mut expiring_events2 = ExpiringEvents::default();
+
+        let mut expected1 = BTreeSet::new();
+        for i in 0..100u32 {
+            let expires_at = 1000 + (rng().next_u64() % 1000);
+            expiring_events1.insert(chat1, i.into(), expires_at);
+            expiring_events2.insert(chat2, i.into(), expires_at + 5000);
+            expected1.insert((expires_at, EventIndex::from(i)));
+        }
+
+        assert_eq!(expiring_events1.next_event_expiry(), expected1.first().map(|(ts, _)| *ts));
+        assert_eq!(expiring_events1.take_next_expired_event(chat1, 999), None);
+
+        for now in [1250, 1500, 2000] {
+            let mut taken = Vec::new();
+            while let Some(event_index) = expiring_events1.take_next_expired_event(chat1, now) {
+                taken.push(event_index);
+            }
+            let expected_taken: Vec<_> = expected1.iter().take_while(|(ts, _)| *ts <= now).map(|(_, i)| *i).collect();
+            expected1.retain(|(ts, _)| *ts > now);
+
+            assert_eq!(taken, expected_taken);
+            assert_eq!(expiring_events1.next_event_expiry(), expected1.first().map(|(ts, _)| *ts));
+        }
+        assert!(expected1.is_empty());
+        assert_eq!(expiring_events1.next_event_expiry(), None);
+
+        // The other chat's entries are unaffected
+        assert!(expiring_events2.next_event_expiry().is_some_and(|ts| ts > 5000));
+        assert_eq!(expiring_events2.take_next_expired_event(chat2, 5999), None);
+        let mut taken_count = 0;
+        while expiring_events2.take_next_expired_event(chat2, 10000).is_some() {
+            taken_count += 1;
+        }
+        assert_eq!(taken_count, 100);
+    }
+
+    #[test]
+    fn heap_entries_are_migrated_to_stable_memory() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::from_slice(&[1]).into());
+        let mut expiring_events = ExpiringEvents::default();
+
+        // Recreate the state of a chat from before expiring events were stored in stable memory
+        for i in 0..100u32 {
+            expiring_events.on_heap.insert((1000 + i as u64, i.into()));
+        }
+        // Plus some entries added since then
+        for i in 100..110u32 {
+            expiring_events.insert(chat, i.into(), 2000 + i as u64);
+        }
+        assert_eq!(expiring_events.on_heap_count(), 100);
+        assert_eq!(expiring_events.next_event_expiry(), Some(1000));
+
+        let bytes = msgpack::serialize_then_unwrap(&expiring_events);
+        // Must keep the field name used by the previous version so that upgrades and rollbacks both work
+        assert!(bytes.windows(18).any(|w| w == b"event_expiry_dates"));
+        let mut expiring_events: ExpiringEvents = msgpack::deserialize_then_unwrap(&bytes);
+        assert_eq!(expiring_events.on_heap_count(), 100);
+        assert_eq!(expiring_events.next_event_expiry(), Some(1000));
+
+        assert_eq!(expiring_events.migrate_to_stable_memory(chat, 30), 30);
+        assert_eq!(expiring_events.on_heap_count(), 70);
+        assert_eq!(expiring_events.migrate_to_stable_memory(chat, 1000), 70);
+        assert_eq!(expiring_events.on_heap_count(), 0);
+        assert_eq!(expiring_events.migrate_to_stable_memory(chat, 1000), 0);
+        assert_eq!(expiring_events.next_event_expiry(), Some(1000));
+
+        let mut taken = Vec::new();
+        while let Some(event_index) = expiring_events.take_next_expired_event(chat, 3000) {
+            taken.push(u32::from(event_index));
+        }
+        assert_eq!(taken, (0..110).collect::<Vec<_>>());
+        assert_eq!(expiring_events.next_event_expiry(), None);
+    }
+
+    #[test]
+    fn heap_and_stable_memory_entries_are_both_taken() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::from_slice(&[1]).into());
+        let mut expiring_events = ExpiringEvents::default();
+
+        expiring_events.on_heap.insert((1000, 1.into()));
+        expiring_events.on_heap.insert((3000, 3.into()));
+        expiring_events.insert(chat, 2.into(), 2000);
+        expiring_events.insert(chat, 4.into(), 4000);
+
+        let mut next_expiry_dates = Vec::new();
+        let mut taken = Vec::new();
+        for now in [1000, 2000, 3000, 4000] {
+            next_expiry_dates.push(expiring_events.next_event_expiry().unwrap());
+            while let Some(event_index) = expiring_events.take_next_expired_event(chat, now) {
+                taken.push(u32::from(event_index));
+            }
+        }
+        assert_eq!(next_expiry_dates, vec![1000, 2000, 3000, 4000]);
+        assert_eq!(taken, vec![1, 2, 3, 4]);
+        assert_eq!(expiring_events.next_event_expiry(), None);
+    }
+
+    #[test]
+    fn refresh_next_expiry_reads_from_stable_memory() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::from_slice(&[1]).into());
+        let mut expiring_events = ExpiringEvents::default();
+
+        let prefix = ExpiringEventKeyPrefix::new_from_chat(chat);
+        with_map_mut(|m| {
+            m.insert(prefix.create_key(&(2000, 2.into())), Vec::new());
+            m.insert(prefix.create_key(&(1000, 1.into())), Vec::new());
+        });
+        assert_eq!(expiring_events.next_event_expiry(), None);
+
+        expiring_events.refresh_next_expiry(chat);
+        assert_eq!(expiring_events.next_event_expiry(), Some(1000));
+    }
+
+    #[test]
+    fn discarding_heap_entries_keeps_stable_memory_entries() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::from_slice(&[1]).into());
+        let mut expiring_events = ExpiringEvents::default();
+
+        // Recreate an imported group whose heap entries are duplicates of those written to stable
+        // memory during the import
+        for i in 0..10u32 {
+            expiring_events.on_heap.insert((1000 + i as u64, i.into()));
+            expiring_events.insert(chat, i.into(), 1000 + i as u64);
+        }
+        expiring_events.discard_on_heap();
+        assert_eq!(expiring_events.on_heap_count(), 0);
+        assert_eq!(expiring_events.next_event_expiry(), Some(1000));
+
+        let mut taken = Vec::new();
+        while let Some(event_index) = expiring_events.take_next_expired_event(chat, u64::MAX) {
+            taken.push(u32::from(event_index));
+        }
+        assert_eq!(taken, (0..10).collect::<Vec<_>>());
+    }
+
+    fn init_stable_memory_map() {
+        let memory = MemoryManager::init(DefaultMemoryImpl::default());
+        stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
     }
 }

--- a/backend/libraries/chat_events/src/stable_memory/mod.rs
+++ b/backend/libraries/chat_events/src/stable_memory/mod.rs
@@ -3,7 +3,8 @@ use crate::{ChatEventInternal, EventsMap};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use stable_memory_map::{
-    ChatEventKey, ChatEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix, StableMemoryMap, with_map, with_map_mut,
+    ChatEventKey, ChatEventKeyPrefix, ExpiringEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix, StableMemoryMap, with_map,
+    with_map_mut,
 };
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -55,6 +56,12 @@ pub fn write_events_as_bytes(chat: Chat, events: Vec<(EventContext, ByteBuf)>) {
             if let ChatEventInternal::Message(message) = &event.event {
                 let message_id_key = MessageIdKeyPrefix::from(&prefix).create_key(&message.message_id);
                 m.insert(message_id_key, MessageIdsStableStorage::value_to_bytes(context.event_index));
+            }
+            if let Some(expires_at) = event.expires_at
+                && let Ok(expiring_events_prefix) = ExpiringEventKeyPrefix::try_from(&prefix)
+            {
+                let expiring_event_key = expiring_events_prefix.create_key(&(expires_at, context.event_index));
+                m.insert(expiring_event_key, Vec::new());
             }
             m.insert(key, value);
         }

--- a/backend/libraries/stable_memory_map/src/keys.rs
+++ b/backend/libraries/stable_memory_map/src/keys.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 
 mod chat_event;
 mod community_event;
+mod expiring_event;
 mod macros;
 mod message_id;
 mod principal;
@@ -13,6 +14,7 @@ mod user_id;
 
 pub use chat_event::*;
 pub use community_event::*;
+pub use expiring_event::*;
 pub use message_id::*;
 pub use principal::*;
 pub use storage::*;
@@ -110,6 +112,9 @@ pub enum KeyType {
     DirectChatThreadMessageId = 20,
     GroupChatThreadMessageId = 21,
     ChannelThreadMessageId = 22,
+    DirectChatExpiringEvent = 23,
+    GroupChatExpiringEvent = 24,
+    ChannelExpiringEvent = 25,
     #[cfg(test)]
     TestSmallEntries = 255,
 }
@@ -153,7 +158,10 @@ impl KeyType {
             | KeyType::ChannelMessageId
             | KeyType::DirectChatThreadMessageId
             | KeyType::GroupChatThreadMessageId
-            | KeyType::ChannelThreadMessageId => MapClass::SmallEntries,
+            | KeyType::ChannelThreadMessageId
+            | KeyType::DirectChatExpiringEvent
+            | KeyType::GroupChatExpiringEvent
+            | KeyType::ChannelExpiringEvent => MapClass::SmallEntries,
             #[cfg(test)]
             KeyType::TestSmallEntries => MapClass::SmallEntries,
         }
@@ -206,6 +214,9 @@ impl TryFrom<u8> for KeyType {
             20 => Ok(KeyType::DirectChatThreadMessageId),
             21 => Ok(KeyType::GroupChatThreadMessageId),
             22 => Ok(KeyType::ChannelThreadMessageId),
+            23 => Ok(KeyType::DirectChatExpiringEvent),
+            24 => Ok(KeyType::GroupChatExpiringEvent),
+            25 => Ok(KeyType::ChannelExpiringEvent),
             #[cfg(test)]
             255 => Ok(KeyType::TestSmallEntries),
             _ => Err(()),

--- a/backend/libraries/stable_memory_map/src/keys/expiring_event.rs
+++ b/backend/libraries/stable_memory_map/src/keys/expiring_event.rs
@@ -1,0 +1,137 @@
+use crate::keys::extract_key_type;
+use crate::keys::macros::key;
+use crate::{BaseKeyPrefix, ChatEventKeyPrefix, KeyPrefix, KeyType};
+use types::{Chat, EventIndex, TimestampMillis};
+
+// The events in a chat's main events list which are due to expire, ordered by their expiry date.
+// Only events in the main events list can expire, so there is a single set of entries per chat.
+//
+// The prefixes have the same layout as the `ChatEventKeyPrefix` of the chat's main events list,
+// with only the key type differing.
+key!(
+    ExpiringEventKey,
+    ExpiringEventKeyPrefix,
+    KeyType::DirectChatExpiringEvent | KeyType::GroupChatExpiringEvent | KeyType::ChannelExpiringEvent
+);
+
+impl ExpiringEventKeyPrefix {
+    pub fn new_from_chat(chat: Chat) -> Self {
+        Self::try_from(&ChatEventKeyPrefix::new_from_chat(chat, None)).unwrap()
+    }
+}
+
+// Fails if the events prefix is for a thread, since thread events never expire
+impl TryFrom<&ChatEventKeyPrefix> for ExpiringEventKeyPrefix {
+    type Error = ();
+
+    fn try_from(value: &ChatEventKeyPrefix) -> Result<Self, Self::Error> {
+        let mut bytes = BaseKeyPrefix::from(value.clone()).0;
+        bytes[0] = match extract_key_type(&bytes).unwrap() {
+            KeyType::DirectChatEvent => KeyType::DirectChatExpiringEvent,
+            KeyType::GroupChatEvent => KeyType::GroupChatExpiringEvent,
+            KeyType::ChannelEvent => KeyType::ChannelExpiringEvent,
+            _ => return Err(()),
+        } as u8;
+        Ok(ExpiringEventKeyPrefix(bytes))
+    }
+}
+
+impl KeyPrefix for ExpiringEventKeyPrefix {
+    type Key = ExpiringEventKey;
+    type Suffix = (TimestampMillis, EventIndex);
+
+    fn create_key(&self, (expires_at, event_index): &(TimestampMillis, EventIndex)) -> ExpiringEventKey {
+        let mut bytes = Vec::with_capacity(self.0.len() + 12);
+        bytes.extend_from_slice(self.0.as_slice());
+        bytes.extend_from_slice(&expires_at.to_be_bytes());
+        bytes.extend_from_slice(&u32::from(*event_index).to_be_bytes());
+        ExpiringEventKey(bytes)
+    }
+}
+
+impl ExpiringEventKey {
+    pub fn expires_at(&self) -> TimestampMillis {
+        let start = self.0.len() - 12;
+        let end = start + 8;
+        u64::from_be_bytes(self.0[start..end].try_into().unwrap())
+    }
+
+    pub fn event_index(&self) -> EventIndex {
+        let start = self.0.len() - 4;
+        u32::from_be_bytes(self.0[start..].try_into().unwrap()).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BaseKey, Key, MapClass};
+    use ic_principal::Principal;
+    use rand::{Rng, RngExt, rng};
+    use types::{ChannelId, MessageIndex};
+
+    #[test]
+    fn expiring_event_key_e2e() {
+        for _ in 0..100 {
+            let user_id_bytes: [u8; 10] = rng().random();
+            let user_id = Principal::from_slice(&user_id_bytes).into();
+            let channel_id = ChannelId::from(rng().next_u32());
+            let expires_at = rng().next_u64();
+            let event_index = EventIndex::from(rng().next_u32());
+
+            for (chat, key_type, len) in [
+                (Chat::Direct(user_id), KeyType::DirectChatExpiringEvent, 24),
+                (
+                    Chat::Group(Principal::anonymous().into()),
+                    KeyType::GroupChatExpiringEvent,
+                    13,
+                ),
+                (
+                    Chat::Channel(Principal::anonymous().into(), channel_id),
+                    KeyType::ChannelExpiringEvent,
+                    17,
+                ),
+            ] {
+                let prefix = ExpiringEventKeyPrefix::new_from_chat(chat);
+                let key = BaseKey::from(prefix.create_key(&(expires_at, event_index)));
+                let expiring_event_key = ExpiringEventKey::try_from(key.clone()).unwrap();
+
+                assert_eq!(*expiring_event_key.0.first().unwrap(), key_type as u8);
+                assert_eq!(key_type.map_class(), MapClass::SmallEntries);
+                assert_eq!(expiring_event_key.0.len(), len);
+                assert!(expiring_event_key.matches_prefix(&prefix));
+                assert_eq!(expiring_event_key.expires_at(), expires_at);
+                assert_eq!(expiring_event_key.event_index(), event_index);
+
+                // Other than the key type, the prefix matches the prefix of the chat's main events
+                let events_prefix = ChatEventKeyPrefix::new_from_chat(chat, None);
+                assert_eq!(prefix.0[1..], BaseKeyPrefix::from(events_prefix).as_slice()[1..]);
+
+                // Thread events never expire
+                let thread_events_prefix = ChatEventKeyPrefix::new_from_chat(chat, Some(MessageIndex::from(1)));
+                assert!(ExpiringEventKeyPrefix::try_from(&thread_events_prefix).is_err());
+
+                let serialized = msgpack::serialize_then_unwrap(&expiring_event_key);
+                let deserialized: ExpiringEventKey = msgpack::deserialize_then_unwrap(&serialized);
+                assert_eq!(deserialized, expiring_event_key);
+            }
+        }
+    }
+
+    #[test]
+    fn expiring_event_keys_are_ordered_by_expiry_date() {
+        let prefix = ExpiringEventKeyPrefix::new_from_chat(Chat::Group(Principal::anonymous().into()));
+        let mut entries: Vec<(TimestampMillis, EventIndex)> = (0..100)
+            .map(|_| (rng().next_u64(), EventIndex::from(rng().next_u32())))
+            .collect();
+        let mut keys: Vec<_> = entries.iter().map(|e| prefix.create_key(e)).collect();
+
+        entries.sort();
+        keys.sort();
+
+        assert_eq!(
+            keys.iter().map(|k| (k.expires_at(), k.event_index())).collect::<Vec<_>>(),
+            entries
+        );
+    }
+}


### PR DESCRIPTION
Follows #9349. Moves each chat's expiring events (`ExpiringEvents`) off the heap and into the stable memory map for small entries.

## Changes

- **New key types** (`SmallEntries` class): `DirectChatExpiringEvent` (23), `GroupChatExpiringEvent` (24) and `ChannelExpiringEvent` (25). Each chat has one prefix, with the same layout as its main events list's `ChatEventKeyPrefix` apart from the key type, because only main-list events can expire. A key is the prefix, then the expiry date (u64 BE), then the event index (u32 BE), so a chat's entries sort by expiry. Values are empty.
- **`ExpiringEvents`**:
  - New entries go to stable memory.
  - Legacy heap entries stay under their old serde name (`event_expiry_dates`) until migrated, and are always serialized so a rollback still works.
  - A new serialized field, `next_expiry_in_stable_memory`, holds a lower bound on the earliest stable entry. This keeps `next_event_expiry()` heap-only, since the User canister calls it for every direct chat on each expiry run. The bound is lowered on insert and made exact once `take_next_expired_event` finds nothing more due.
- **Migration job**: renamed to `migrate_chat_events_to_stable_memory` in the user, group and community canisters. It now calls `ChatEvents::migrate_to_stable_memory`, which moves expiring events and then message ids. `heap_entries_to_migrate_count` replaces `message_ids_on_heap_count`.
- **Group → community conversion**: `write_events_as_bytes` rebuilds the expiring entries from each imported main-list event's `expires_at`, and `set_chat` refreshes the cached next expiry. As with message ids in #9349, `finalize_group_import` then discards the imported group's heap entries, which are now duplicates, via the new `ChatEvents::discard_expiring_events_on_heap`.
- **GC**: when a direct chat or channel is deleted, `ChatEvents::stable_memory_key_prefixes` now also returns the chat's expiring-events prefix. It only does this for main-list prefixes.

## Testing

- **Unit tests**:
  - key round trip and ordering
  - expiry ordering across chats
  - mixed heap and stable entries
  - heap migration and serde field name
  - `refresh_next_expiry`
  - `ChatEvents::remove_expired_events`
  - import rebuild of expiring entries, end to end through `ChatEvents`, including expiring the imported events
  - discarding heap entries keeps the stable entries
- **Integration tests**:
  - The disappearing-message GC tests now count the expiring entries: +5 while pending, removed on expiry.
  - The direct chat and channel deletion GC tests set a one-day TTL, so the expiring entries are also shown to be garbage collected.
  - New test `disappearing_messages_still_expire_after_conversion`.
- canbench: no significant change.

## Rollout notes

- **Upgrade the community canisters before the group canisters.** A group on this version keeps its expiring events only in stable memory, so its heap field is empty. A community on the previous version rebuilds expiring events from that heap field alone, because its `write_events_as_bytes` doesn't write expiring entries. So if a group is converted into a community, or imported into one, while the community is still on the old version, the imported disappearing messages never expire.
  - Both entry points need to be upgraded first: the community wasm that the local indexes use to create communities from converted groups, and every existing community canister, since `import_group` can target any of them.
  - #9349 already needs the same order for message ids.
  - Once every canister is on this version, the constraint goes away.
- An existing issue I found while writing the conversion test: nothing schedules the community's expiry job when a group is imported. Imported disappearing messages only expire once something else schedules the job, such as a new message being sent. The new test works around this, and this PR doesn't change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
