### PR TITLE
Move each chat's last updated timestamps into the stable memory map for small entries

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
-- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,9 +11,9 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
-// and its expiring events) into stable memory. This can be removed once every canister has been
-// migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
+// its expiring events and its events' last updated timestamps) into stable memory. This can be
+// removed once every canister has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none()
         && state

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
-- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,9 +11,9 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
-// and its expiring events) into stable memory. This can be removed once every canister has been
-// migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
+// its expiring events and its events' last updated timestamps) into stable memory. This can be
+// removed once every canister has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none() && state.data.chat.events.heap_entries_to_migrate_count() > 0 {
         let timer_id = ic_cdk_timers::set_timer(Duration::ZERO, async { run() });

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Route stable memory map entries by key type to either the main map or a map with 256 byte pages for small entries ([#9348](https://github.com/open-chat-labs/open-chat/pull/9348))
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
-- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -11,9 +11,9 @@ thread_local! {
     static TIMER_ID: Cell<Option<TimerId>> = Cell::default();
 }
 
-// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map
-// and its expiring events) into stable memory. This can be removed once every canister has been
-// migrated.
+// Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
+// its expiring events and its events' last updated timestamps) into stable memory. This can be
+// removed once every canister has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none()
         && state

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -129,8 +129,8 @@ impl DirectChat {
         let events_ttl = self.events.get_events_time_to_live();
         let updated_events: Vec<_> = self
             .events
-            .iter_recently_updated_events()
-            .take_while(|(_, _, ts)| *ts > updates_since)
+            .recently_updated_events(updates_since, usize::MAX)
+            .into_iter()
             .map(|(_, e, ts)| (e, ts))
             .collect();
 

--- a/backend/integration_tests/src/communities/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/communities/disappearing_message_tests.rs
@@ -169,10 +169,11 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
-    // A message id for each message, plus an expiring event for each message in the main events list
+    // A message id for each message, an expiring event for each message in the main events list, plus
+    // two entries (keyed by event and by timestamp) recording when each thread root was last updated
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 35
+        initial_small_entries_keys + 45
     );
 
     // Tick once to expire the messages
@@ -188,9 +189,10 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         initial_stable_memory_map_keys
     );
     // The expiring events are removed and the message ids of the expired threads are garbage
-    // collected, but the message ids of the expired messages in the main events list are retained
+    // collected, but the message ids of the expired messages in the main events list are retained, as
+    // are the thread roots' last updated timestamps until they are pruned
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 5
+        initial_small_entries_keys + 15
     );
 }

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -108,10 +108,11 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     tick_many(env, 3);
 
     assert!(get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_MEMORY_ID).len() > initial_stable_memory_map_keys);
-    // A message id for each message, plus an expiring event for each message in the main events list
+    // A message id for each message, an expiring event for each message in the main events list, plus
+    // two entries (keyed by event and by timestamp) recording when the thread root was last updated
     assert_eq!(
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        small_entries_keys_before_messages + 10
+        small_entries_keys_before_messages + 12
     );
 
     let delete_direct_chat_response = client::user::delete_direct_chat(

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -408,10 +408,11 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, group_id, CHAT_EVENTS_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
-    // A message id for each message, plus an expiring event for each message in the main events list
+    // A message id for each message, an expiring event for each message in the main events list, plus
+    // two entries (keyed by event and by timestamp) recording when each thread root was last updated
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 35
+        initial_small_entries_keys + 45
     );
 
     // Tick once to expire the messages
@@ -427,9 +428,10 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         initial_stable_memory_map_keys
     );
     // The expiring events are removed and the message ids of the expired threads are garbage
-    // collected, but the message ids of the expired messages in the main events list are retained
+    // collected, but the message ids of the expired messages in the main events list are retained, as
+    // are the thread roots' last updated timestamps until they are pruned
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 5
+        initial_small_entries_keys + 15
     );
 }

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -10,7 +10,10 @@ use oc_error_codes::{OCError, OCErrorCode};
 use search::simple::{Document, Query};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use stable_memory_map::{BaseKeyPrefix, ChatEventKeyPrefix, ExpiringEventKeyPrefix, MessageIdKeyPrefix};
+use stable_memory_map::{
+    BaseKeyPrefix, ChatEventKeyPrefix, EventLastUpdatedKeyPrefix, EventsByLastUpdatedKeyPrefix, ExpiringEventKeyPrefix,
+    MessageIdKeyPrefix,
+};
 use std::cmp::max;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -67,10 +70,15 @@ impl ChatEvents {
     // main events list or a thread), so that they can all be garbage collected once it is deleted
     pub fn stable_memory_key_prefixes(events_prefix: ChatEventKeyPrefix) -> Vec<BaseKeyPrefix> {
         let message_ids_prefix = MessageIdKeyPrefix::from(&events_prefix);
-        // Only the main events list has expiring events
+        // Only the main events list has expiring events and last updated timestamps (the last
+        // updated timestamps of events in threads are stored under the main events list's prefixes)
         let expiring_events_prefix = ExpiringEventKeyPrefix::try_from(&events_prefix).ok();
+        let last_updated_prefix = EventLastUpdatedKeyPrefix::try_from(&events_prefix).ok();
+        let by_last_updated_prefix = EventsByLastUpdatedKeyPrefix::try_from(&events_prefix).ok();
         let mut prefixes = vec![events_prefix.into(), message_ids_prefix.into()];
         prefixes.extend(expiring_events_prefix.map(BaseKeyPrefix::from));
+        prefixes.extend(last_updated_prefix.map(BaseKeyPrefix::from));
+        prefixes.extend(by_last_updated_prefix.map(BaseKeyPrefix::from));
         prefixes
     }
 
@@ -160,16 +168,25 @@ impl ChatEvents {
         stable_memory::read_events_as_bytes(self.chat, after, ONE_MB as usize)
     }
 
-    pub fn iter_recently_updated_events(
+    // The events which were last updated after `since`, most recently updated first
+    pub fn recently_updated_events(
         &self,
-    ) -> impl Iterator<Item = (Option<MessageIndex>, EventIndex, TimestampMillis)> + '_ {
-        self.last_updated_timestamps.iter()
+        since: TimestampMillis,
+        max_count: usize,
+    ) -> Vec<(Option<MessageIndex>, EventIndex, TimestampMillis)> {
+        self.last_updated_timestamps
+            .recently_updated_events(self.chat, since, max_count)
     }
 
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
     // moved
     pub fn migrate_to_stable_memory(&mut self, max_count: usize) -> usize {
         let mut moved = self.expiring_events.migrate_to_stable_memory(self.chat, max_count);
+        if moved < max_count {
+            moved += self
+                .last_updated_timestamps
+                .migrate_to_stable_memory(self.chat, max_count - moved);
+        }
         if moved < max_count {
             moved += self.main.migrate_message_ids_to_stable_memory(max_count - moved);
         }
@@ -201,6 +218,7 @@ impl ChatEvents {
     // The number of entries on the heap which are yet to be moved into stable memory
     pub fn heap_entries_to_migrate_count(&self) -> usize {
         self.expiring_events.on_heap_count()
+            + self.last_updated_timestamps.on_heap_count()
             + self.main.message_ids_on_heap_count()
             + self.threads.values().map(|t| t.message_ids_on_heap_count()).sum::<usize>()
     }
@@ -455,7 +473,7 @@ impl ChatEvents {
     pub fn last_updated(&self) -> Option<TimestampMillis> {
         max(
             self.main.latest_event_timestamp(),
-            self.iter_recently_updated_events().next().map(|(_, _, ts)| ts),
+            self.last_updated_timestamps.latest_update(),
         )
     }
 
@@ -2204,11 +2222,12 @@ impl ChatEvents {
     }
 
     pub fn main_events_reader(&self) -> ChatEventsListReader<'_> {
-        ChatEventsListReader::new(&self.main, &self.last_updated_timestamps)
+        ChatEventsListReader::new(self.chat, &self.main, &self.last_updated_timestamps)
     }
 
     pub fn visible_main_events_reader(&self, min_visible_event_index: EventIndex) -> ChatEventsListReader<'_> {
         ChatEventsListReader::with_min_visible_event_index(
+            self.chat,
             &self.main,
             &self.last_updated_timestamps,
             min_visible_event_index,
@@ -2225,9 +2244,14 @@ impl ChatEvents {
         let events_list = self.events_list(min_visible_event_index, thread_root_message_index)?;
 
         if thread_root_message_index.is_some() {
-            Some(ChatEventsListReader::new(events_list, &self.last_updated_timestamps))
+            Some(ChatEventsListReader::new(
+                self.chat,
+                events_list,
+                &self.last_updated_timestamps,
+            ))
         } else {
             Some(ChatEventsListReader::with_min_visible_event_index(
+                self.chat,
                 events_list,
                 &self.last_updated_timestamps,
                 min_visible_event_index,
@@ -2598,7 +2622,7 @@ impl ChatEvents {
             && let Ok(success) = &result
         {
             self.last_updated_timestamps
-                .mark_updated(thread_root_message_index, success.event_index, now);
+                .mark_updated(self.chat, thread_root_message_index, success.event_index, now);
         }
 
         result.map(|success| UpdateEventSuccess {

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -334,6 +334,7 @@ impl ChatEventsList {
 }
 
 pub struct ChatEventsListReader<'r> {
+    chat: Chat,
     events_list: &'r ChatEventsList,
     last_updated_timestamps: &'r LastUpdatedTimestamps,
     min_visible_event_index: EventIndex,
@@ -350,19 +351,22 @@ impl Deref for ChatEventsListReader<'_> {
 
 impl<'r> ChatEventsListReader<'r> {
     pub(crate) fn new(
+        chat: Chat,
         events_list: &'r ChatEventsList,
         last_updated_timestamps: &'r LastUpdatedTimestamps,
     ) -> ChatEventsListReader<'r> {
-        Self::with_min_visible_event_index(events_list, last_updated_timestamps, EventIndex::default(), None)
+        Self::with_min_visible_event_index(chat, events_list, last_updated_timestamps, EventIndex::default(), None)
     }
 
     pub(crate) fn with_min_visible_event_index(
+        chat: Chat,
         events_list: &'r ChatEventsList,
         last_updated_timestamps: &'r LastUpdatedTimestamps,
         min_visible_event_index: EventIndex,
         bot_permitted_event_types: Option<HashSet<ChatEventCategory>>,
     ) -> ChatEventsListReader<'r> {
         ChatEventsListReader {
+            chat,
             events_list,
             last_updated_timestamps,
             min_visible_event_index,
@@ -574,7 +578,12 @@ impl Reader for ChatEventsListReader<'_> {
         my_user_id: Option<UserId>,
     ) -> Option<EventWrapper<Message>> {
         self.latest_message_event(my_user_id).filter(|m| {
-            m.timestamp > since || self.last_updated_timestamps.last_updated(None, m.index).unwrap_or_default() > since
+            m.timestamp > since
+                || (self.last_updated_timestamps.latest_update().is_some_and(|ts| ts > since)
+                    && self
+                        .last_updated_timestamps
+                        .last_updated(self.chat, None, m.index)
+                        .is_some_and(|ts| ts > since))
         })
     }
 }

--- a/backend/libraries/chat_events/src/last_updated_timestamps.rs
+++ b/backend/libraries/chat_events/src/last_updated_timestamps.rs
@@ -1,63 +1,191 @@
 use constants::calculate_summary_updates_data_removal_cutoff;
 use serde::{Deserialize, Serialize};
+use stable_memory_map::{EventLastUpdatedKeyPrefix, EventsByLastUpdatedKeyPrefix, KeyPrefix, with_map, with_map_mut};
+use std::cmp::{Reverse, max};
 use std::collections::{BTreeMap, BTreeSet};
-use types::{EventIndex, MessageIndex, TimestampMillis};
+use types::{Chat, EventIndex, MAX_EVENT_INDEX, MIN_EVENT_INDEX, MessageIndex, TimestampMillis};
 
+// The maximum number of expired entries to remove from stable memory each time an event is marked
+// as updated, so that the cost of marking an event as updated stays bounded
+const MAX_STABLE_MEMORY_ENTRIES_TO_PRUNE: usize = 100;
+
+// When each event (including events in threads) was last updated. The entries are stored in the
+// stable memory map for small entries, both keyed by event and ordered by timestamp.
 #[derive(Serialize, Deserialize, Default)]
 #[serde(from = "LastUpdatedTimestampsTrimmed")]
 pub struct LastUpdatedTimestamps {
+    // Entries which haven't yet been moved into stable memory. New entries are always written to
+    // stable memory, and existing ones are moved across in batches by `migrate_to_stable_memory`.
+    // This can be removed once every chat has been migrated. It is always serialized so that a
+    // canister can still be rolled back to a version expecting it.
     by_timestamp: BTreeSet<(TimestampMillis, Option<MessageIndex>, EventIndex)>,
     #[serde(skip)]
     by_event_index: BTreeMap<(Option<MessageIndex>, EventIndex), TimestampMillis>,
     latest_update_removed: TimestampMillis,
+    // The most recent time that any event was marked as updated, which is always at least as
+    // recent as every entry, so that it can be read without reading from stable memory
+    #[serde(rename = "l", default, skip_serializing_if = "Option::is_none")]
+    latest_update: Option<TimestampMillis>,
 }
 
 impl LastUpdatedTimestamps {
     pub fn mark_updated(
         &mut self,
+        chat: Chat,
         thread_root_message_index: Option<MessageIndex>,
         event_index: EventIndex,
         now: TimestampMillis,
     ) {
-        self.prune(now);
+        self.prune(chat, now);
 
-        if let Some(previous) = self.by_event_index.insert((thread_root_message_index, event_index), now) {
+        if let Some(previous) = self.by_event_index.remove(&(thread_root_message_index, event_index)) {
             self.by_timestamp.remove(&(previous, thread_root_message_index, event_index));
         }
-        self.by_timestamp.insert((now, thread_root_message_index, event_index));
+        insert_into_stable_memory(chat, thread_root_message_index, event_index, now);
+        self.latest_update = max(self.latest_update, Some(now));
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (Option<MessageIndex>, EventIndex, TimestampMillis)> + '_ {
-        self.by_timestamp.iter().rev().cloned().map(|(ts, r, e)| (r, e, ts))
+    // The events which were last updated after `since`, most recently updated first
+    pub fn recently_updated_events(
+        &self,
+        chat: Chat,
+        since: TimestampMillis,
+        max_count: usize,
+    ) -> Vec<(Option<MessageIndex>, EventIndex, TimestampMillis)> {
+        let Some(from) = since.checked_add(1) else {
+            return Vec::new();
+        };
+        if self.latest_update.is_none_or(|ts| ts < from) {
+            return Vec::new();
+        }
+
+        let prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(chat);
+        let start = prefix.create_key(&(from, None, MIN_EVENT_INDEX));
+        let end = prefix.create_key(&(TimestampMillis::MAX, Some(u32::MAX.into()), MAX_EVENT_INDEX));
+        let mut events: Vec<_> = with_map(|m| {
+            m.range(start..=end)
+                .rev()
+                .take(max_count)
+                .map(|(k, _)| (k.thread_root_message_index(), k.event_index(), k.last_updated()))
+                .collect()
+        });
+
+        if !self.by_timestamp.is_empty() {
+            events.extend(
+                self.by_timestamp
+                    .range((from, None, MIN_EVENT_INDEX)..)
+                    .rev()
+                    .take(max_count)
+                    .map(|(ts, r, e)| (*r, *e, *ts)),
+            );
+            events.sort_unstable_by_key(|(r, e, ts)| Reverse((*ts, *r, *e)));
+            events.truncate(max_count);
+        }
+        events
     }
 
     pub fn last_updated(
         &self,
+        chat: Chat,
         thread_root_message_index: Option<MessageIndex>,
         event_index: EventIndex,
     ) -> Option<TimestampMillis> {
-        self.by_event_index.get(&(thread_root_message_index, event_index)).copied()
+        if let Some(ts) = self.by_event_index.get(&(thread_root_message_index, event_index)) {
+            return Some(*ts);
+        }
+        self.latest_update?;
+
+        let key = EventLastUpdatedKeyPrefix::new_from_chat(chat).create_key(&(thread_root_message_index, event_index));
+        with_map(|m| m.get(key)).map(|bytes| bytes_to_timestamp(&bytes))
+    }
+
+    pub fn latest_update(&self) -> Option<TimestampMillis> {
+        self.latest_update
     }
 
     pub fn latest_update_removed(&self) -> TimestampMillis {
         self.latest_update_removed
     }
 
-    pub fn prune(&mut self, now: TimestampMillis) -> u32 {
+    // Moves up to `max_count` entries from the heap into stable memory, returning how many were
+    // moved
+    pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
+        let mut count = 0;
+        while count < max_count
+            && let Some((ts, thread_root_message_index, event_index)) = self.by_timestamp.pop_first()
+        {
+            self.by_event_index.remove(&(thread_root_message_index, event_index));
+            insert_into_stable_memory(chat, thread_root_message_index, event_index, ts);
+            count += 1;
+        }
+        count
+    }
+
+    pub fn on_heap_count(&self) -> usize {
+        self.by_timestamp.len()
+    }
+
+    // Removes the entries which are too old to be included in summary updates. Only a limited
+    // number of entries are removed from stable memory at a time, any remaining entries are
+    // removed by subsequent calls.
+    fn prune(&mut self, chat: Chat, now: TimestampMillis) {
         let cutoff = calculate_summary_updates_data_removal_cutoff(now);
 
-        let still_valid = self.by_timestamp.split_off(&(cutoff, None, 0.into()));
+        let still_valid = self.by_timestamp.split_off(&(cutoff, None, MIN_EVENT_INDEX));
         let removed = std::mem::replace(&mut self.by_timestamp, still_valid);
-        let count_removed = removed.len() as u32;
 
         if let Some((ts, _, _)) = removed.last() {
-            self.latest_update_removed = *ts;
+            self.latest_update_removed = max(self.latest_update_removed, *ts);
         }
         for (_, tr, e) in removed {
             self.by_event_index.remove(&(tr, e));
         }
-        count_removed
+
+        let by_event_prefix = EventLastUpdatedKeyPrefix::new_from_chat(chat);
+        let by_timestamp_prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(chat);
+        let start = by_timestamp_prefix.create_key(&(TimestampMillis::MIN, None, MIN_EVENT_INDEX));
+        let end = by_timestamp_prefix.create_key(&(cutoff, None, MIN_EVENT_INDEX));
+
+        with_map_mut(|m| {
+            let expired: Vec<_> = m
+                .range(start..end)
+                .take(MAX_STABLE_MEMORY_ENTRIES_TO_PRUNE)
+                .map(|(k, _)| k)
+                .collect();
+
+            for key in expired {
+                self.latest_update_removed = max(self.latest_update_removed, key.last_updated());
+                m.remove(by_event_prefix.create_key(&(key.thread_root_message_index(), key.event_index())));
+                m.remove(key);
+            }
+        });
     }
+}
+
+// Each event has an entry keyed by the event, whose value is the time it was last updated, plus an
+// entry keyed by that time, so that the most recently updated events can be iterated over
+fn insert_into_stable_memory(
+    chat: Chat,
+    thread_root_message_index: Option<MessageIndex>,
+    event_index: EventIndex,
+    ts: TimestampMillis,
+) {
+    let by_event_key = EventLastUpdatedKeyPrefix::new_from_chat(chat).create_key(&(thread_root_message_index, event_index));
+    let by_timestamp_prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(chat);
+
+    with_map_mut(|m| {
+        if let Some(previous) = m.insert(by_event_key, ts.to_be_bytes().to_vec()) {
+            m.remove(by_timestamp_prefix.create_key(&(bytes_to_timestamp(&previous), thread_root_message_index, event_index)));
+        }
+        m.insert(
+            by_timestamp_prefix.create_key(&(ts, thread_root_message_index, event_index)),
+            Vec::new(),
+        );
+    });
+}
+
+fn bytes_to_timestamp(bytes: &[u8]) -> TimestampMillis {
+    TimestampMillis::from_be_bytes(bytes.try_into().unwrap())
 }
 
 #[derive(Deserialize)]
@@ -65,6 +193,8 @@ pub struct LastUpdatedTimestampsTrimmed {
     by_timestamp: BTreeSet<(TimestampMillis, Option<MessageIndex>, EventIndex)>,
     #[serde(default)]
     latest_update_removed: TimestampMillis,
+    #[serde(rename = "l", default)]
+    latest_update: Option<TimestampMillis>,
 }
 
 impl From<LastUpdatedTimestampsTrimmed> for LastUpdatedTimestamps {
@@ -73,11 +203,190 @@ impl From<LastUpdatedTimestampsTrimmed> for LastUpdatedTimestamps {
         for (ts, tr, e) in value.by_timestamp.iter() {
             by_event_index.insert((*tr, *e), *ts);
         }
+        let latest_on_heap = value.by_timestamp.last().map(|(ts, _, _)| *ts);
 
         LastUpdatedTimestamps {
             by_timestamp: value.by_timestamp,
             by_event_index,
             latest_update_removed: value.latest_update_removed,
+            latest_update: max(value.latest_update, latest_on_heap),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use constants::DURATION_TO_MAINTAIN_SUMMARY_UPDATES_DATA;
+    use ic_stable_structures::DefaultMemoryImpl;
+    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
+    use rand::{Rng, RngExt, rng};
+
+    type Model = BTreeMap<(Option<MessageIndex>, EventIndex), TimestampMillis>;
+
+    #[test]
+    fn recently_updated_events_are_returned_most_recent_first() {
+        init_stable_memory_map();
+        let chat1 = Chat::Direct(Principal::from_slice(&[1]).into());
+        let chat2 = Chat::Direct(Principal::from_slice(&[2]).into());
+        let mut timestamps1 = LastUpdatedTimestamps::default();
+        let mut timestamps2 = LastUpdatedTimestamps::default();
+        let mut model = Model::new();
+
+        assert!(timestamps1.recently_updated_events(chat1, 0, usize::MAX).is_empty());
+
+        for now in 1000..1500 {
+            // Update a mixture of new and previously updated events, some of which are in threads
+            let thread_root_message_index = rng().random_bool(0.3).then(|| MessageIndex::from(rng().next_u32() % 5));
+            let event_index = EventIndex::from(rng().next_u32() % 200);
+            timestamps1.mark_updated(chat1, thread_root_message_index, event_index, now);
+            timestamps2.mark_updated(chat2, thread_root_message_index, event_index, now + 1000);
+            model.insert((thread_root_message_index, event_index), now);
+        }
+
+        assert_eq!(timestamps1.latest_update(), Some(1499));
+        for (since, max_count) in [(0, usize::MAX), (0, 10), (1200, usize::MAX), (1200, 50), (1499, usize::MAX)] {
+            assert_eq!(
+                timestamps1.recently_updated_events(chat1, since, max_count),
+                expected_recently_updated_events(&model, since, max_count)
+            );
+        }
+        for ((thread_root_message_index, event_index), ts) in model.iter() {
+            assert_eq!(
+                timestamps1.last_updated(chat1, *thread_root_message_index, *event_index),
+                Some(*ts)
+            );
+        }
+        assert_eq!(timestamps1.last_updated(chat1, None, 1000.into()), None);
+
+        // The other chat's entries are unaffected
+        assert!(
+            timestamps2
+                .recently_updated_events(chat2, 0, usize::MAX)
+                .iter()
+                .all(|(_, _, ts)| *ts >= 2000)
+        );
+        assert_eq!(timestamps2.recently_updated_events(chat2, 0, usize::MAX).len(), model.len());
+    }
+
+    #[test]
+    fn heap_entries_are_migrated_to_stable_memory() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::from_slice(&[1]).into());
+        let mut model = Model::new();
+
+        // Recreate the state of a chat from before the timestamps were stored in stable memory
+        let mut by_timestamp = BTreeSet::new();
+        for i in 0..100u32 {
+            let thread_root_message_index = (i % 3 == 0).then(|| MessageIndex::from(i % 7));
+            by_timestamp.insert((1000 + i as u64, thread_root_message_index, EventIndex::from(i)));
+            model.insert((thread_root_message_index, i.into()), 1000 + i as u64);
+        }
+        let mut timestamps = LastUpdatedTimestamps::from(LastUpdatedTimestampsTrimmed {
+            by_timestamp,
+            latest_update_removed: 0,
+            latest_update: None,
+        });
+        assert_eq!(timestamps.latest_update(), Some(1099));
+
+        // Plus some updates since then, including to events whose timestamps are on the heap
+        for i in 90..110u32 {
+            let thread_root_message_index = (i % 3 == 0).then(|| MessageIndex::from(i % 7));
+            timestamps.mark_updated(chat, thread_root_message_index, i.into(), 2000 + i as u64);
+            model.insert((thread_root_message_index, i.into()), 2000 + i as u64);
+        }
+        assert_eq!(timestamps.on_heap_count(), 90);
+        assert_eq!(timestamps.latest_update(), Some(2109));
+        assert_recently_updated_events_match(&timestamps, chat, &model);
+
+        let bytes = msgpack::serialize_then_unwrap(&timestamps);
+        // Must keep the field name used by the previous version so that upgrades and rollbacks both work
+        assert!(bytes.windows(12).any(|w| w == b"by_timestamp"));
+        let mut timestamps: LastUpdatedTimestamps = msgpack::deserialize_then_unwrap(&bytes);
+        assert_eq!(timestamps.on_heap_count(), 90);
+        assert_eq!(timestamps.latest_update(), Some(2109));
+        assert_recently_updated_events_match(&timestamps, chat, &model);
+
+        assert_eq!(timestamps.migrate_to_stable_memory(chat, 30), 30);
+        assert_eq!(timestamps.on_heap_count(), 60);
+        assert_recently_updated_events_match(&timestamps, chat, &model);
+        assert_eq!(timestamps.migrate_to_stable_memory(chat, 1000), 60);
+        assert_eq!(timestamps.on_heap_count(), 0);
+        assert_eq!(timestamps.migrate_to_stable_memory(chat, 1000), 0);
+        assert_recently_updated_events_match(&timestamps, chat, &model);
+
+        for ((thread_root_message_index, event_index), ts) in model.iter() {
+            assert_eq!(
+                timestamps.last_updated(chat, *thread_root_message_index, *event_index),
+                Some(*ts)
+            );
+        }
+    }
+
+    #[test]
+    fn old_entries_are_pruned() {
+        init_stable_memory_map();
+        let chat = Chat::Channel(Principal::from_slice(&[1]).into(), 1u32.into());
+        let mut timestamps = LastUpdatedTimestamps::from(LastUpdatedTimestampsTrimmed {
+            by_timestamp: (0..10u32).map(|i| (i as u64, None, EventIndex::from(i))).collect(),
+            latest_update_removed: 0,
+            latest_update: None,
+        });
+        for i in 10..250u32 {
+            timestamps.mark_updated(chat, None, i.into(), i as u64);
+        }
+        assert_eq!(timestamps.latest_update_removed(), 0);
+
+        // Entries updated before 300 are now too old to keep. Only a limited number are removed
+        // from stable memory each time an event is updated.
+        let now = DURATION_TO_MAINTAIN_SUMMARY_UPDATES_DATA + 300;
+        timestamps.mark_updated(chat, None, 1000.into(), now);
+        assert_eq!(timestamps.on_heap_count(), 0);
+        assert_eq!(timestamps.latest_update_removed(), 109);
+        assert_eq!(timestamps.recently_updated_events(chat, 0, usize::MAX).len(), 141);
+        assert_eq!(timestamps.last_updated(chat, None, 109.into()), None);
+        assert_eq!(timestamps.last_updated(chat, None, 110.into()), Some(110));
+
+        timestamps.mark_updated(chat, None, 1001.into(), now);
+        assert_eq!(timestamps.latest_update_removed(), 209);
+        timestamps.mark_updated(chat, None, 1002.into(), now);
+        assert_eq!(timestamps.latest_update_removed(), 249);
+
+        assert_eq!(
+            timestamps.recently_updated_events(chat, 0, usize::MAX),
+            vec![(None, 1002.into(), now), (None, 1001.into(), now), (None, 1000.into(), now)]
+        );
+        assert_eq!(timestamps.latest_update(), Some(now));
+    }
+
+    fn assert_recently_updated_events_match(timestamps: &LastUpdatedTimestamps, chat: Chat, model: &Model) {
+        for (since, max_count) in [(0, usize::MAX), (0, 25), (1050, usize::MAX), (1050, 60), (2100, usize::MAX)] {
+            assert_eq!(
+                timestamps.recently_updated_events(chat, since, max_count),
+                expected_recently_updated_events(model, since, max_count),
+                "since: {since}, max_count: {max_count}"
+            );
+        }
+    }
+
+    fn expected_recently_updated_events(
+        model: &Model,
+        since: TimestampMillis,
+        max_count: usize,
+    ) -> Vec<(Option<MessageIndex>, EventIndex, TimestampMillis)> {
+        let mut expected: Vec<_> = model
+            .iter()
+            .filter(|(_, ts)| **ts > since)
+            .map(|((r, e), ts)| (*r, *e, *ts))
+            .collect();
+        expected.sort_unstable_by_key(|(r, e, ts)| Reverse((*ts, *r, *e)));
+        expected.truncate(max_count);
+        expected
+    }
+
+    fn init_stable_memory_map() {
+        let memory = MemoryManager::init(DefaultMemoryImpl::default());
+        stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
     }
 }

--- a/backend/libraries/group_chat_core/src/lib.rs
+++ b/backend/libraries/group_chat_core/src/lib.rs
@@ -206,12 +206,7 @@ impl GroupChatCore {
             .unwrap_or_default();
 
         let events_ttl = self.events.get_events_time_to_live();
-        let mut updated_events: Vec<_> = self
-            .events
-            .iter_recently_updated_events()
-            .take_while(|(_, _, ts)| *ts > since)
-            .take(1000)
-            .collect();
+        let mut updated_events = self.events.recently_updated_events(since, 1000);
 
         if let Some(member) = &member {
             let new_proposal_votes = member

--- a/backend/libraries/stable_memory_map/src/keys.rs
+++ b/backend/libraries/stable_memory_map/src/keys.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 mod chat_event;
 mod community_event;
 mod expiring_event;
+mod last_updated;
 mod macros;
 mod message_id;
 mod principal;
@@ -15,6 +16,7 @@ mod user_id;
 pub use chat_event::*;
 pub use community_event::*;
 pub use expiring_event::*;
+pub use last_updated::*;
 pub use message_id::*;
 pub use principal::*;
 pub use storage::*;
@@ -115,6 +117,12 @@ pub enum KeyType {
     DirectChatExpiringEvent = 23,
     GroupChatExpiringEvent = 24,
     ChannelExpiringEvent = 25,
+    DirectChatEventLastUpdated = 26,
+    GroupChatEventLastUpdated = 27,
+    ChannelEventLastUpdated = 28,
+    DirectChatEventsByLastUpdated = 29,
+    GroupChatEventsByLastUpdated = 30,
+    ChannelEventsByLastUpdated = 31,
     #[cfg(test)]
     TestSmallEntries = 255,
 }
@@ -161,7 +169,13 @@ impl KeyType {
             | KeyType::ChannelThreadMessageId
             | KeyType::DirectChatExpiringEvent
             | KeyType::GroupChatExpiringEvent
-            | KeyType::ChannelExpiringEvent => MapClass::SmallEntries,
+            | KeyType::ChannelExpiringEvent
+            | KeyType::DirectChatEventLastUpdated
+            | KeyType::GroupChatEventLastUpdated
+            | KeyType::ChannelEventLastUpdated
+            | KeyType::DirectChatEventsByLastUpdated
+            | KeyType::GroupChatEventsByLastUpdated
+            | KeyType::ChannelEventsByLastUpdated => MapClass::SmallEntries,
             #[cfg(test)]
             KeyType::TestSmallEntries => MapClass::SmallEntries,
         }
@@ -217,6 +231,12 @@ impl TryFrom<u8> for KeyType {
             23 => Ok(KeyType::DirectChatExpiringEvent),
             24 => Ok(KeyType::GroupChatExpiringEvent),
             25 => Ok(KeyType::ChannelExpiringEvent),
+            26 => Ok(KeyType::DirectChatEventLastUpdated),
+            27 => Ok(KeyType::GroupChatEventLastUpdated),
+            28 => Ok(KeyType::ChannelEventLastUpdated),
+            29 => Ok(KeyType::DirectChatEventsByLastUpdated),
+            30 => Ok(KeyType::GroupChatEventsByLastUpdated),
+            31 => Ok(KeyType::ChannelEventsByLastUpdated),
             #[cfg(test)]
             255 => Ok(KeyType::TestSmallEntries),
             _ => Err(()),

--- a/backend/libraries/stable_memory_map/src/keys/last_updated.rs
+++ b/backend/libraries/stable_memory_map/src/keys/last_updated.rs
@@ -1,0 +1,253 @@
+use crate::keys::extract_key_type;
+use crate::keys::macros::key;
+use crate::{BaseKeyPrefix, ChatEventKeyPrefix, KeyPrefix, KeyType};
+use types::{Chat, EventIndex, MessageIndex, TimestampMillis};
+
+// When each event in a chat (including events in threads) was last updated, so that clients can be
+// told which events have changed. There are two sets of entries per chat, one mapping each event to
+// the time it was last updated, and one ordered by that time.
+//
+// The prefixes have the same layout as the `ChatEventKeyPrefix` of the chat's main events list,
+// with only the key type differing.
+key!(
+    EventLastUpdatedKey,
+    EventLastUpdatedKeyPrefix,
+    KeyType::DirectChatEventLastUpdated | KeyType::GroupChatEventLastUpdated | KeyType::ChannelEventLastUpdated
+);
+
+key!(
+    EventsByLastUpdatedKey,
+    EventsByLastUpdatedKeyPrefix,
+    KeyType::DirectChatEventsByLastUpdated | KeyType::GroupChatEventsByLastUpdated | KeyType::ChannelEventsByLastUpdated
+);
+
+// Each event is identified by its thread (if any) followed by its event index, which is encoded as
+// a fixed length suffix so that keys can be parsed from the end:
+// Thread flag (0 = main events list, 1 = thread)   1 byte
+// Thread root message index (0 if not a thread)    4 bytes
+// Event index                                      4 bytes
+const EVENT_SUFFIX_LEN: usize = 9;
+
+impl EventLastUpdatedKeyPrefix {
+    pub fn new_from_chat(chat: Chat) -> Self {
+        Self::try_from(&ChatEventKeyPrefix::new_from_chat(chat, None)).unwrap()
+    }
+}
+
+// Fails if the events prefix is for a thread, since the entries for events in threads are stored
+// under the prefix of the chat's main events list
+impl TryFrom<&ChatEventKeyPrefix> for EventLastUpdatedKeyPrefix {
+    type Error = ();
+
+    fn try_from(value: &ChatEventKeyPrefix) -> Result<Self, Self::Error> {
+        let mut bytes = BaseKeyPrefix::from(value.clone()).0;
+        bytes[0] = match extract_key_type(&bytes).unwrap() {
+            KeyType::DirectChatEvent => KeyType::DirectChatEventLastUpdated,
+            KeyType::GroupChatEvent => KeyType::GroupChatEventLastUpdated,
+            KeyType::ChannelEvent => KeyType::ChannelEventLastUpdated,
+            _ => return Err(()),
+        } as u8;
+        Ok(EventLastUpdatedKeyPrefix(bytes))
+    }
+}
+
+impl EventsByLastUpdatedKeyPrefix {
+    pub fn new_from_chat(chat: Chat) -> Self {
+        Self::try_from(&ChatEventKeyPrefix::new_from_chat(chat, None)).unwrap()
+    }
+}
+
+// Fails if the events prefix is for a thread, since the entries for events in threads are stored
+// under the prefix of the chat's main events list
+impl TryFrom<&ChatEventKeyPrefix> for EventsByLastUpdatedKeyPrefix {
+    type Error = ();
+
+    fn try_from(value: &ChatEventKeyPrefix) -> Result<Self, Self::Error> {
+        let mut bytes = BaseKeyPrefix::from(value.clone()).0;
+        bytes[0] = match extract_key_type(&bytes).unwrap() {
+            KeyType::DirectChatEvent => KeyType::DirectChatEventsByLastUpdated,
+            KeyType::GroupChatEvent => KeyType::GroupChatEventsByLastUpdated,
+            KeyType::ChannelEvent => KeyType::ChannelEventsByLastUpdated,
+            _ => return Err(()),
+        } as u8;
+        Ok(EventsByLastUpdatedKeyPrefix(bytes))
+    }
+}
+
+impl KeyPrefix for EventLastUpdatedKeyPrefix {
+    type Key = EventLastUpdatedKey;
+    type Suffix = (Option<MessageIndex>, EventIndex);
+
+    fn create_key(&self, (thread_root_message_index, event_index): &(Option<MessageIndex>, EventIndex)) -> EventLastUpdatedKey {
+        let mut bytes = Vec::with_capacity(self.0.len() + EVENT_SUFFIX_LEN);
+        bytes.extend_from_slice(self.0.as_slice());
+        write_event_suffix(&mut bytes, *thread_root_message_index, *event_index);
+        EventLastUpdatedKey(bytes)
+    }
+}
+
+impl KeyPrefix for EventsByLastUpdatedKeyPrefix {
+    type Key = EventsByLastUpdatedKey;
+    type Suffix = (TimestampMillis, Option<MessageIndex>, EventIndex);
+
+    fn create_key(
+        &self,
+        (last_updated, thread_root_message_index, event_index): &(TimestampMillis, Option<MessageIndex>, EventIndex),
+    ) -> EventsByLastUpdatedKey {
+        let mut bytes = Vec::with_capacity(self.0.len() + 8 + EVENT_SUFFIX_LEN);
+        bytes.extend_from_slice(self.0.as_slice());
+        bytes.extend_from_slice(&last_updated.to_be_bytes());
+        write_event_suffix(&mut bytes, *thread_root_message_index, *event_index);
+        EventsByLastUpdatedKey(bytes)
+    }
+}
+
+impl EventLastUpdatedKey {
+    pub fn thread_root_message_index(&self) -> Option<MessageIndex> {
+        read_event_suffix(&self.0).0
+    }
+
+    pub fn event_index(&self) -> EventIndex {
+        read_event_suffix(&self.0).1
+    }
+}
+
+impl EventsByLastUpdatedKey {
+    pub fn last_updated(&self) -> TimestampMillis {
+        let start = self.0.len() - EVENT_SUFFIX_LEN - 8;
+        let end = start + 8;
+        u64::from_be_bytes(self.0[start..end].try_into().unwrap())
+    }
+
+    pub fn thread_root_message_index(&self) -> Option<MessageIndex> {
+        read_event_suffix(&self.0).0
+    }
+
+    pub fn event_index(&self) -> EventIndex {
+        read_event_suffix(&self.0).1
+    }
+}
+
+fn write_event_suffix(bytes: &mut Vec<u8>, thread_root_message_index: Option<MessageIndex>, event_index: EventIndex) {
+    match thread_root_message_index {
+        None => bytes.extend_from_slice(&[0; 5]),
+        Some(root_message_index) => {
+            bytes.push(1);
+            bytes.extend_from_slice(&u32::from(root_message_index).to_be_bytes());
+        }
+    }
+    bytes.extend_from_slice(&u32::from(event_index).to_be_bytes());
+}
+
+fn read_event_suffix(bytes: &[u8]) -> (Option<MessageIndex>, EventIndex) {
+    let start = bytes.len() - EVENT_SUFFIX_LEN;
+    let thread_root_message_index =
+        (bytes[start] == 1).then(|| u32::from_be_bytes(bytes[start + 1..start + 5].try_into().unwrap()).into());
+    let event_index = u32::from_be_bytes(bytes[start + 5..].try_into().unwrap()).into();
+    (thread_root_message_index, event_index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BaseKey, Key, MapClass};
+    use ic_principal::Principal;
+    use rand::{Rng, RngExt, rng};
+    use types::ChannelId;
+
+    #[test]
+    fn last_updated_keys_e2e() {
+        for thread in [false, true] {
+            for _ in 0..100 {
+                let user_id_bytes: [u8; 10] = rng().random();
+                let user_id = Principal::from_slice(&user_id_bytes).into();
+                let channel_id = ChannelId::from(rng().next_u32());
+                let thread_root_message_index = thread.then(|| MessageIndex::from(rng().next_u32()));
+                let event_index = EventIndex::from(rng().next_u32());
+                let last_updated = rng().next_u64();
+
+                for (chat, key_types, prefix_len) in [
+                    (
+                        Chat::Direct(user_id),
+                        (KeyType::DirectChatEventLastUpdated, KeyType::DirectChatEventsByLastUpdated),
+                        12,
+                    ),
+                    (
+                        Chat::Group(Principal::anonymous().into()),
+                        (KeyType::GroupChatEventLastUpdated, KeyType::GroupChatEventsByLastUpdated),
+                        1,
+                    ),
+                    (
+                        Chat::Channel(Principal::anonymous().into(), channel_id),
+                        (KeyType::ChannelEventLastUpdated, KeyType::ChannelEventsByLastUpdated),
+                        5,
+                    ),
+                ] {
+                    let events_prefix = ChatEventKeyPrefix::new_from_chat(chat, None);
+
+                    let prefix = EventLastUpdatedKeyPrefix::new_from_chat(chat);
+                    let key = BaseKey::from(prefix.create_key(&(thread_root_message_index, event_index)));
+                    let last_updated_key = EventLastUpdatedKey::try_from(key).unwrap();
+
+                    assert_eq!(*last_updated_key.0.first().unwrap(), key_types.0 as u8);
+                    assert_eq!(key_types.0.map_class(), MapClass::SmallEntries);
+                    assert_eq!(last_updated_key.0.len(), prefix_len + 9);
+                    assert!(last_updated_key.matches_prefix(&prefix));
+                    assert_eq!(last_updated_key.thread_root_message_index(), thread_root_message_index);
+                    assert_eq!(last_updated_key.event_index(), event_index);
+                    assert_eq!(prefix.0[1..], BaseKeyPrefix::from(events_prefix.clone()).as_slice()[1..]);
+
+                    let serialized = msgpack::serialize_then_unwrap(&last_updated_key);
+                    let deserialized: EventLastUpdatedKey = msgpack::deserialize_then_unwrap(&serialized);
+                    assert_eq!(deserialized, last_updated_key);
+
+                    let prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(chat);
+                    let key = BaseKey::from(prefix.create_key(&(last_updated, thread_root_message_index, event_index)));
+                    let by_last_updated_key = EventsByLastUpdatedKey::try_from(key).unwrap();
+
+                    assert_eq!(*by_last_updated_key.0.first().unwrap(), key_types.1 as u8);
+                    assert_eq!(key_types.1.map_class(), MapClass::SmallEntries);
+                    assert_eq!(by_last_updated_key.0.len(), prefix_len + 17);
+                    assert!(by_last_updated_key.matches_prefix(&prefix));
+                    assert_eq!(by_last_updated_key.last_updated(), last_updated);
+                    assert_eq!(by_last_updated_key.thread_root_message_index(), thread_root_message_index);
+                    assert_eq!(by_last_updated_key.event_index(), event_index);
+                    assert_eq!(prefix.0[1..], BaseKeyPrefix::from(events_prefix).as_slice()[1..]);
+
+                    let thread_events_prefix = ChatEventKeyPrefix::new_from_chat(chat, Some(1.into()));
+                    assert!(EventLastUpdatedKeyPrefix::try_from(&thread_events_prefix).is_err());
+                    assert!(EventsByLastUpdatedKeyPrefix::try_from(&thread_events_prefix).is_err());
+
+                    let serialized = msgpack::serialize_then_unwrap(&by_last_updated_key);
+                    let deserialized: EventsByLastUpdatedKey = msgpack::deserialize_then_unwrap(&serialized);
+                    assert_eq!(deserialized, by_last_updated_key);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn events_by_last_updated_keys_are_ordered_by_timestamp() {
+        let prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(Chat::Group(Principal::anonymous().into()));
+        let mut entries: Vec<(TimestampMillis, Option<MessageIndex>, EventIndex)> = (0..100)
+            .map(|_| {
+                (
+                    rng().next_u64(),
+                    rng().random_bool(0.5).then(|| MessageIndex::from(rng().next_u32())),
+                    EventIndex::from(rng().next_u32()),
+                )
+            })
+            .collect();
+        let mut keys: Vec<_> = entries.iter().map(|e| prefix.create_key(e)).collect();
+
+        entries.sort();
+        keys.sort();
+
+        assert_eq!(
+            keys.iter()
+                .map(|k| (k.last_updated(), k.thread_root_message_index(), k.event_index()))
+                .collect::<Vec<_>>(),
+            entries
+        );
+    }
+}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1375533235
+      instructions: 1462987961
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 234707387
+      instructions: 234797100
       heap_increase: 12
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
Follows #9350. Moves each chat's `LastUpdatedTimestamps` (when each event, including thread events, was last updated) off the heap and into the stable memory map for small entries.

## Changes

- **New key types** (`SmallEntries` class), each with one prefix per chat. The prefix has the same layout as the chat's main events list `ChatEventKeyPrefix`, apart from the key type:
  - `DirectChatEventLastUpdated` (26), `GroupChatEventLastUpdated` (27), `ChannelEventLastUpdated` (28). The key is the prefix plus the event, and the value is the timestamp (u64 BE).
  - `DirectChatEventsByLastUpdated` (29), `GroupChatEventsByLastUpdated` (30), `ChannelEventsByLastUpdated` (31). The key is the prefix, then the timestamp (u64 BE), then the event. Values are empty.
  - An event is encoded as a fixed 9-byte suffix: a thread flag, the root message index (zero if not a thread), then the event index. Thread events share the chat's prefixes, so each chat has just two prefixes.
- **`LastUpdatedTimestamps`**:
  - `mark_updated` writes both entries to stable memory. If the event already had an entry, the value returned by the insert gives its old timestamp, so the stale by-timestamp key can be removed. Any heap entry for the event is removed.
  - `recently_updated_events(since, max_count)` replaces `iter()`. It returns a `Vec`, reading the by-timestamp entries in reverse and merging in any heap entries. `ChatEvents::iter_recently_updated_events` is renamed to match. The user and group summary-update callers keep their behaviour: no limit for direct chats, 1000 for groups.
  - Pruning keeps the 31-day cutoff, but removes at most 100 stable entries per `mark_updated`, so each update has a bounded cost. `latest_update_removed` only advances past entries that were actually removed, so its guarantee still holds.
  - New serialized field `latest_update` (`"l"`) caches the most recent update time. It is always at least the newest entry, so:
    - `ChatEvents::last_updated()` stays heap-only. It's called per chat on every `updates` / `summary_updates`.
    - `recently_updated_events` and `latest_message_event_if_updated` skip stable memory entirely when nothing has changed since `since`.
    - On deserialize it's initialised from the heap entries.
  - One behaviour change: once all entries have been pruned, `ChatEvents::last_updated()` still returns the latest update time. It no longer falls back to the latest event timestamp, so it never goes backwards.
  - Legacy heap entries keep their serde name (`by_timestamp`) and are always serialized, so rollbacks still work.
- `ChatEventsListReader` now holds the `Chat`, so it can look up an event's last-updated timestamp.
- **Migration job**: `ChatEvents::migrate_to_stable_memory` and `heap_entries_to_migrate_count` now include the last-updated heap entries, so the existing `migrate_chat_events_to_stable_memory` job moves them across.
- **GC**: for main-list prefixes, `ChatEvents::stable_memory_key_prefixes` also returns both last-updated prefixes.
- **Group → community conversion**: last-updated entries already in stable memory are not carried over; heap entries and `latest_update` are. The channel is new to clients once imported, so the lost per-event update times don't matter.

## Testing

- **Unit tests**:
  - key round trip, ordering, and thread prefixes rejected
  - recently updated events against a model, for various `since` / `max_count`, across two chats
  - mixed heap and stable entries through serialization and batched migration, including the serde field name
  - bounded pruning and `latest_update_removed`
- **Integration tests**: the small-map counts in the disappearing-message and direct-chat GC tests now include the thread roots' last-updated entries (each reply marks its root as updated). The direct-chat test shows these are garbage collected when the chat is deleted.
- canbench `--persist`: `add_reactions` +6.4% (1.375B → 1.463B for 1000 reactions, about 87K instructions each). The cost is the two stable writes and the prune range check. `push_simple_text_messages` is unchanged.

## Rollout notes

- This adds no new upgrade-order constraint beyond #9350's (community canisters before group canisters). If a community on the previous version imports a group running this version, only the per-event update times that are already in stable memory are lost, and those don't matter for a newly imported channel (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

