### PR TITLE
Move each chat's per-user metrics into the stable memory map for small entries

### DIFF
--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
-- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 
 ### Fixed
 

--- a/backend/canisters/community/impl/src/jobs/import_groups.rs
+++ b/backend/canisters/community/impl/src/jobs/import_groups.rs
@@ -1,4 +1,5 @@
 use crate::activity_notifications::extract_activity;
+use crate::jobs::migrate_chat_events_to_stable_memory;
 use crate::model::channels::Channel;
 use crate::model::events::{CommunityEventInternal, GroupImportedInternal};
 use crate::model::groups_being_imported::{GroupToImport, GroupToImportAction};
@@ -226,6 +227,10 @@ pub(crate) fn finalize_group_import(group_id: ChatId) {
                 chat,
                 date_imported: None, // This is only set once everything is complete
             });
+
+            // Moves the imported group's data which is still on the heap (eg. its users' metrics)
+            // into stable memory under the channel's prefixes
+            migrate_chat_events_to_stable_memory::start_job_if_required(state);
 
             state.data.timer_jobs.enqueue_job(
                 TimerJob::ProcessGroupImportChannelMembers(ProcessGroupImportChannelMembersJob {

--- a/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/community/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -12,8 +12,9 @@ thread_local! {
 }
 
 // Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
-// its expiring events and its events' last updated timestamps) into stable memory. This can be
-// removed once every canister has been migrated.
+// its expiring events, its events' last updated timestamps and its users' metrics) into stable
+// memory. It is also used to move the users' metrics of imported groups into stable memory (see
+// `finalize_group_import`), so it must be kept for that even once every channel has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none()
         && state

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
-- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 
 ### Fixed
 

--- a/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/group/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -12,8 +12,8 @@ thread_local! {
 }
 
 // Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
-// its expiring events and its events' last updated timestamps) into stable memory. This can be
-// removed once every canister has been migrated.
+// its expiring events, its events' last updated timestamps and its users' metrics) into stable
+// memory. This can be removed once every canister has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none() && state.data.chat.events.heap_entries_to_migrate_count() > 0 {
         let timer_id = ic_cdk_timers::set_timer(Duration::ZERO, async { run() });

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -302,6 +302,9 @@ impl RuntimeState {
             Err(OCErrorCode::ChatFrozen.into())
         } else {
             let transfers_required = self.prepare_transfers_for_import_into_community();
+            // The community only receives what is serialized here plus the events, so the metrics
+            // in stable memory must be copied onto the heap to be carried over
+            self.data.chat.events.copy_user_metrics_to_heap_for_export();
             let serialized = serialize_then_unwrap(&self.data.chat);
             let total_bytes = serialized.len() as u64;
 

--- a/backend/canisters/group/impl/src/updates/c2c_unfreeze_group.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_unfreeze_group.rs
@@ -1,6 +1,6 @@
 use crate::activity_notifications::handle_activity_notification;
 use crate::guards::caller_is_group_index_or_local_user_index;
-use crate::{RuntimeState, execute_update};
+use crate::{RuntimeState, execute_update, jobs};
 use canister_api_macros::update;
 use canister_tracing_macros::trace;
 use group_canister::c2c_unfreeze_group::{Response::*, *};
@@ -21,6 +21,9 @@ pub(crate) fn c2c_unfreeze_group_impl(user_id: UserId, state: &mut RuntimeState)
         state.data.community_being_imported_into = None;
         state.push_bot_notification(push_event_result.bot_notification);
         handle_activity_notification(state);
+        // If an import into a community has been abandoned, the users' metrics which were copied
+        // onto the heap for the import need moving back into stable memory
+        jobs::migrate_chat_events_to_stable_memory::start_job_if_required(state);
 
         Success(EventWrapper {
             index: push_event_result.index,

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -24,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
-- Stop storing the other user's metrics in direct chats, since only the canister's own user's metrics are ever read ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
+- Stop storing the other user's metrics in direct chats, since only the canister's own user's metrics are ever read ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
-- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's `MessageId` to `EventIndex` map from the heap into the stable memory map for small entries ([#9349](https://github.com/open-chat-labs/open-chat/pull/9349))
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
+- Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#PR_NUMBER](https://github.com/open-chat-labs/open-chat/pull/PR_NUMBER))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
+++ b/backend/canisters/user/impl/src/jobs/migrate_chat_events_to_stable_memory.rs
@@ -12,8 +12,8 @@ thread_local! {
 }
 
 // Moves the chat events data which is still on the heap (each chat's MessageId -> EventIndex map,
-// its expiring events and its events' last updated timestamps) into stable memory. This can be
-// removed once every canister has been migrated.
+// its expiring events, its events' last updated timestamps and its users' metrics) into stable
+// memory. This can be removed once every canister has been migrated.
 pub(crate) fn start_job_if_required(state: &RuntimeState) -> bool {
     if TIMER_ID.get().is_none()
         && state

--- a/backend/integration_tests/src/communities/convert_group_into_community_tests.rs
+++ b/backend/integration_tests/src/communities/convert_group_into_community_tests.rs
@@ -4,12 +4,12 @@ use crate::stable_memory::{STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID, get_stable
 use crate::utils::tick_many;
 use crate::{CanisterIds, TestEnv, User, client};
 use candid::Principal;
-use chat_events::ChatEventInternal;
+use chat_events::{ChatEventInternal, ChatMetricsInternal};
 use constants::DAY_IN_MS;
 use itertools::Itertools;
 use oc_error_codes::OCErrorCode;
 use pocket_ic::PocketIc;
-use stable_memory_map::{ChatEventKeyPrefix, ExpiringEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix};
+use stable_memory_map::{ChatEventKeyPrefix, ExpiringEventKeyPrefix, KeyPrefix, MessageIdKeyPrefix, UserMetricsKeyPrefix};
 use std::ops::Deref;
 use std::time::Duration;
 use testing::rng::{random_from_u128, random_string};
@@ -47,6 +47,9 @@ fn convert_into_community_succeeds() {
         messages_sent.push((message_id, send_result.event_index));
     }
 
+    let group_summary = client::group::happy_path::summary(env, user1.principal, group_id);
+    assert_eq!(group_summary.membership.unwrap().my_metrics.text_messages, 9);
+
     let convert_into_community_response = client::group::convert_into_community(
         env,
         user1.principal,
@@ -65,6 +68,8 @@ fn convert_into_community_succeeds() {
         let expected_channel_names = vec![group_name];
 
         let summary1 = client::community::happy_path::summary(env, user1.principal, result.community_id);
+        // The users' metrics should have been carried over from the group
+        assert_eq!(summary1.channels[0].membership.as_ref().unwrap().my_metrics.text_messages, 9);
         assert_eq!(
             summary1.channels.into_iter().map(|c| c.name).collect_vec(),
             expected_channel_names
@@ -108,6 +113,13 @@ fn convert_into_community_succeeds() {
                 Some(u32::from(*event_index).to_be_bytes().to_vec())
             );
         }
+
+        // The users' metrics should have been moved into stable memory under the channel's prefix
+        let user_metrics_key = UserMetricsKeyPrefix::new_from_chat(Chat::Channel(result.community_id, result.channel_id))
+            .create_key(&user1.user_id);
+        let user_metrics =
+            ChatMetricsInternal::from_bytes(&small_entries_map.get(&user_metrics_key.as_ref().to_vec()).unwrap());
+        assert_eq!(user_metrics.hydrate().text_messages, 9);
 
         // Looking up an imported message by its id should succeed
         client::community::happy_path::add_reaction(

--- a/backend/integration_tests/src/communities/delete_channel_tests.rs
+++ b/backend/integration_tests/src/communities/delete_channel_tests.rs
@@ -117,9 +117,10 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 100
     );
+    // A message id and an expiring event for each message, plus the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 200
+        initial_small_entries_keys + 201
     );
 
     for _ in 0..80 {
@@ -132,7 +133,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 280
+        initial_small_entries_keys + 282
     );
 
     client::community::happy_path::delete_channel(env, user1.principal, community_id, channel_id1);
@@ -146,7 +147,7 @@ fn stable_memory_garbage_collected_after_deleting_channel() {
     );
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 80
+        initial_small_entries_keys + 81
     );
 
     client::community::happy_path::delete_channel(env, user1.principal, community_id, channel_id2);

--- a/backend/integration_tests/src/communities/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/communities/disappearing_message_tests.rs
@@ -169,11 +169,12 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
-    // A message id for each message, an expiring event for each message in the main events list, plus
-    // two entries (keyed by event and by timestamp) recording when each thread root was last updated
+    // A message id for each message, an expiring event for each message in the main events list, two
+    // entries (keyed by event and by timestamp) recording when each thread root was last updated, plus
+    // the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 45
+        initial_small_entries_keys + 46
     );
 
     // Tick once to expire the messages
@@ -190,9 +191,9 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
     );
     // The expiring events are removed and the message ids of the expired threads are garbage
     // collected, but the message ids of the expired messages in the main events list are retained, as
-    // are the thread roots' last updated timestamps until they are pruned
+    // are the thread roots' last updated timestamps until they are pruned, and the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, community_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 15
+        initial_small_entries_keys + 16
     );
 }

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -108,11 +108,12 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     tick_many(env, 3);
 
     assert!(get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_MEMORY_ID).len() > initial_stable_memory_map_keys);
-    // A message id for each message, an expiring event for each message in the main events list, plus
-    // two entries (keyed by event and by timestamp) recording when the thread root was last updated
+    // A message id for each message, an expiring event for each message in the main events list, two
+    // entries (keyed by event and by timestamp) recording when the thread root was last updated, plus
+    // the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        small_entries_keys_before_messages + 12
+        small_entries_keys_before_messages + 13
     );
 
     let delete_direct_chat_response = client::user::delete_direct_chat(

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -4,11 +4,10 @@ use crate::utils::{now_millis, tick_many};
 use crate::{TestEnv, client};
 use constants::DAY_IN_MS;
 use ic_stable_structures::memory_manager::MemoryId;
-use stable_memory_map::{KeyPrefix, MessageIdKeyPrefix, UserMetricsKeyPrefix};
 use std::ops::Deref;
 use std::time::Duration;
-use testing::rng::{random_from_u128, random_string};
-use types::{Chat, ChatId, MessageContentInitial, MessageId, OptionUpdate, TextContent};
+use testing::rng::random_string;
+use types::{ChatId, MessageContentInitial, OptionUpdate, TextContent};
 
 #[test]
 fn delete_direct_chat_succeeds() {
@@ -91,8 +90,7 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     let small_entries_keys_before_messages =
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
 
-    let message_id: MessageId = random_from_u128();
-    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), Some(message_id));
+    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
     for _ in 0..3 {
         client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
     }
@@ -117,18 +115,6 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
         small_entries_keys_before_messages + 13
     );
-
-    // Each canister only stores the metrics of its own user, since only those are ever read
-    let user1_small_entries = get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
-    let user1_metrics_key = UserMetricsKeyPrefix::new_from_chat(Chat::Direct(user2.user_id.into())).create_key(&user1.user_id);
-    assert!(user1_small_entries.contains_key(&user1_metrics_key.as_ref().to_vec()));
-
-    let user2_chat = Chat::Direct(user1.user_id.into());
-    let user2_small_entries = get_stable_memory_map(env, user2.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
-    let user2_message_id_key = MessageIdKeyPrefix::new_from_chat(user2_chat, None).create_key(&message_id);
-    assert!(user2_small_entries.contains_key(&user2_message_id_key.as_ref().to_vec()));
-    let user2_metrics_key = UserMetricsKeyPrefix::new_from_chat(user2_chat).create_key(&user1.user_id);
-    assert!(!user2_small_entries.contains_key(&user2_metrics_key.as_ref().to_vec()));
 
     let delete_direct_chat_response = client::user::delete_direct_chat(
         env,

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -4,10 +4,11 @@ use crate::utils::{now_millis, tick_many};
 use crate::{TestEnv, client};
 use constants::DAY_IN_MS;
 use ic_stable_structures::memory_manager::MemoryId;
+use stable_memory_map::{KeyPrefix, MessageIdKeyPrefix, UserMetricsKeyPrefix};
 use std::ops::Deref;
 use std::time::Duration;
-use testing::rng::random_string;
-use types::{ChatId, MessageContentInitial, OptionUpdate, TextContent};
+use testing::rng::{random_from_u128, random_string};
+use types::{Chat, ChatId, MessageContentInitial, MessageId, OptionUpdate, TextContent};
 
 #[test]
 fn delete_direct_chat_succeeds() {
@@ -90,7 +91,8 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     let small_entries_keys_before_messages =
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
 
-    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
+    let message_id: MessageId = random_from_u128();
+    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), Some(message_id));
     for _ in 0..3 {
         client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
     }
@@ -115,6 +117,18 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
         small_entries_keys_before_messages + 13
     );
+
+    // Each canister only stores the metrics of its own user, since only those are ever read
+    let user1_small_entries = get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
+    let user1_metrics_key = UserMetricsKeyPrefix::new_from_chat(Chat::Direct(user2.user_id.into())).create_key(&user1.user_id);
+    assert!(user1_small_entries.contains_key(&user1_metrics_key.as_ref().to_vec()));
+
+    let user2_chat = Chat::Direct(user1.user_id.into());
+    let user2_small_entries = get_stable_memory_map(env, user2.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
+    let user2_message_id_key = MessageIdKeyPrefix::new_from_chat(user2_chat, None).create_key(&message_id);
+    assert!(user2_small_entries.contains_key(&user2_message_id_key.as_ref().to_vec()));
+    let user2_metrics_key = UserMetricsKeyPrefix::new_from_chat(user2_chat).create_key(&user1.user_id);
+    assert!(!user2_small_entries.contains_key(&user2_metrics_key.as_ref().to_vec()));
 
     let delete_direct_chat_response = client::user::delete_direct_chat(
         env,

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -408,11 +408,12 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
         get_stable_memory_map(env, group_id, CHAT_EVENTS_MEMORY_ID).len(),
         initial_stable_memory_map_keys + 30
     );
-    // A message id for each message, an expiring event for each message in the main events list, plus
-    // two entries (keyed by event and by timestamp) recording when each thread root was last updated
+    // A message id for each message, an expiring event for each message in the main events list, two
+    // entries (keyed by event and by timestamp) recording when each thread root was last updated, plus
+    // the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 45
+        initial_small_entries_keys + 46
     );
 
     // Tick once to expire the messages
@@ -429,9 +430,9 @@ fn stable_memory_garbage_collected_after_messages_disappear() {
     );
     // The expiring events are removed and the message ids of the expired threads are garbage
     // collected, but the message ids of the expired messages in the main events list are retained, as
-    // are the thread roots' last updated timestamps until they are pruned
+    // are the thread roots' last updated timestamps until they are pruned, and the sender's metrics
     assert_eq!(
         get_stable_memory_map(env, group_id, STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
-        initial_small_entries_keys + 15
+        initial_small_entries_keys + 16
     );
 }

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -2,6 +2,7 @@ use crate::chat_events_list::Reader;
 use crate::expiring_events::ExpiringEvents;
 use crate::last_updated_timestamps::LastUpdatedTimestamps;
 use crate::metrics::{ChatMetricsInternal, MetricKey};
+use crate::per_user_metrics::PerUserMetrics;
 use crate::search_index::SearchIndex;
 use crate::*;
 use constants::{ONE_MB, OPENCHAT_BOT_USER_ID};
@@ -12,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use stable_memory_map::{
     BaseKeyPrefix, ChatEventKeyPrefix, EventLastUpdatedKeyPrefix, EventsByLastUpdatedKeyPrefix, ExpiringEventKeyPrefix,
-    MessageIdKeyPrefix,
+    MessageIdKeyPrefix, UserMetricsKeyPrefix,
 };
 use std::cmp::max;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
@@ -48,7 +49,7 @@ pub struct ChatEvents {
     main: ChatEventsList,
     threads: BTreeMap<MessageIndex, ChatEventsList>,
     metrics: ChatMetricsInternal,
-    per_user_metrics: BTreeMap<UserId, ChatMetricsInternal>,
+    per_user_metrics: PerUserMetrics,
     frozen: bool,
     events_ttl: Timestamped<Option<Milliseconds>>,
     expiring_events: ExpiringEvents,
@@ -70,15 +71,18 @@ impl ChatEvents {
     // main events list or a thread), so that they can all be garbage collected once it is deleted
     pub fn stable_memory_key_prefixes(events_prefix: ChatEventKeyPrefix) -> Vec<BaseKeyPrefix> {
         let message_ids_prefix = MessageIdKeyPrefix::from(&events_prefix);
-        // Only the main events list has expiring events and last updated timestamps (the last
-        // updated timestamps of events in threads are stored under the main events list's prefixes)
+        // Only the main events list has expiring events, last updated timestamps and user metrics
+        // (the last updated timestamps of events in threads are stored under the main events list's
+        // prefixes)
         let expiring_events_prefix = ExpiringEventKeyPrefix::try_from(&events_prefix).ok();
         let last_updated_prefix = EventLastUpdatedKeyPrefix::try_from(&events_prefix).ok();
         let by_last_updated_prefix = EventsByLastUpdatedKeyPrefix::try_from(&events_prefix).ok();
+        let user_metrics_prefix = UserMetricsKeyPrefix::try_from(&events_prefix).ok();
         let mut prefixes = vec![events_prefix.into(), message_ids_prefix.into()];
         prefixes.extend(expiring_events_prefix.map(BaseKeyPrefix::from));
         prefixes.extend(last_updated_prefix.map(BaseKeyPrefix::from));
         prefixes.extend(by_last_updated_prefix.map(BaseKeyPrefix::from));
+        prefixes.extend(user_metrics_prefix.map(BaseKeyPrefix::from));
         prefixes
     }
 
@@ -94,7 +98,7 @@ impl ChatEvents {
             main: ChatEventsList::new(chat, None),
             threads: BTreeMap::new(),
             metrics: ChatMetricsInternal::default(),
-            per_user_metrics: BTreeMap::new(),
+            per_user_metrics: PerUserMetrics::default(),
             frozen: false,
             events_ttl: Timestamped::new(events_ttl, now),
             expiring_events: ExpiringEvents::default(),
@@ -126,7 +130,7 @@ impl ChatEvents {
             main: ChatEventsList::new(chat, None),
             threads: BTreeMap::new(),
             metrics: ChatMetricsInternal::default(),
-            per_user_metrics: BTreeMap::new(),
+            per_user_metrics: PerUserMetrics::default(),
             frozen: false,
             events_ttl: Timestamped::new(events_ttl, now),
             expiring_events: ExpiringEvents::default(),
@@ -188,6 +192,9 @@ impl ChatEvents {
                 .migrate_to_stable_memory(self.chat, max_count - moved);
         }
         if moved < max_count {
+            moved += self.per_user_metrics.migrate_to_stable_memory(self.chat, max_count - moved);
+        }
+        if moved < max_count {
             moved += self.main.migrate_message_ids_to_stable_memory(max_count - moved);
         }
         for thread in self.threads.values_mut() {
@@ -215,10 +222,18 @@ impl ChatEvents {
         self.expiring_events.discard_on_heap();
     }
 
+    // Copies each user's metrics from stable memory onto the heap, so that they are included when
+    // the chat is serialized to be imported into a community. The community moves them back into
+    // stable memory, under the new channel's prefix, via `migrate_to_stable_memory`.
+    pub fn copy_user_metrics_to_heap_for_export(&mut self) {
+        self.per_user_metrics.copy_to_heap(self.chat);
+    }
+
     // The number of entries on the heap which are yet to be moved into stable memory
     pub fn heap_entries_to_migrate_count(&self) -> usize {
         self.expiring_events.on_heap_count()
             + self.last_updated_timestamps.on_heap_count()
+            + self.per_user_metrics.on_heap_count()
             + self.main.message_ids_on_heap_count()
             + self.threads.values().map(|t| t.message_ids_on_heap_count()).sum::<usize>()
     }
@@ -294,6 +309,7 @@ impl ChatEvents {
         add_to_metrics(
             &mut self.metrics,
             &mut self.per_user_metrics,
+            self.chat,
             args.sender,
             |m| message_internal.add_to_metrics(m),
             args.now,
@@ -381,6 +397,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     sender,
                     |m| m.incr(MetricKey::Edits, 1),
                     now,
@@ -509,6 +526,7 @@ impl ChatEvents {
                     add_to_metrics(
                         &mut self.metrics,
                         &mut self.per_user_metrics,
+                        self.chat,
                         sender,
                         |m| m.incr(MetricKey::ReportedMessages, 1),
                         args.now,
@@ -517,6 +535,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     args.caller,
                     |m| m.incr(MetricKey::DeletedMessages, 1),
                     args.now,
@@ -607,6 +626,7 @@ impl ChatEvents {
                     add_to_metrics(
                         &mut self.metrics,
                         &mut self.per_user_metrics,
+                        self.chat,
                         sender,
                         |m| m.decr(MetricKey::ReportedMessages, 1),
                         args.now,
@@ -615,6 +635,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     args.caller,
                     |m| m.decr(MetricKey::DeletedMessages, 1),
                     args.now,
@@ -718,6 +739,7 @@ impl ChatEvents {
                                 add_to_metrics(
                                     &mut self.metrics,
                                     &mut self.per_user_metrics,
+                                    self.chat,
                                     args.user_id,
                                     |m| m.incr(MetricKey::PollVotes, 1),
                                     args.now,
@@ -728,6 +750,7 @@ impl ChatEvents {
                             add_to_metrics(
                                 &mut self.metrics,
                                 &mut self.per_user_metrics,
+                                self.chat,
                                 args.user_id,
                                 |m| m.decr(MetricKey::PollVotes, 1),
                                 args.now,
@@ -1045,6 +1068,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     user_id,
                     |m| m.incr(MetricKey::Reactions, 1),
                     now,
@@ -1110,6 +1134,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     args.user_id,
                     |m| m.decr(MetricKey::Reactions, 1),
                     args.now,
@@ -1162,6 +1187,7 @@ impl ChatEvents {
                 add_to_metrics(
                     &mut self.metrics,
                     &mut self.per_user_metrics,
+                    self.chat,
                     args.user_id,
                     |m| m.incr(MetricKey::Tips, 1),
                     args.now,
@@ -2041,9 +2067,9 @@ impl ChatEvents {
         &self.metrics
     }
 
-    pub fn user_metrics(&self, user_id: &UserId, if_updated_since: Option<TimestampMillis>) -> Option<&ChatMetricsInternal> {
+    pub fn user_metrics(&self, user_id: &UserId, if_updated_since: Option<TimestampMillis>) -> Option<ChatMetricsInternal> {
         self.per_user_metrics
-            .get(user_id)
+            .get(self.chat, user_id)
             .filter(|m| if let Some(since) = if_updated_since { m.last_active > since } else { true })
     }
 
@@ -2710,7 +2736,8 @@ impl ChatEvents {
 
 fn add_to_metrics<F: FnMut(&mut ChatMetricsInternal)>(
     metrics: &mut ChatMetricsInternal,
-    per_user_metrics: &mut BTreeMap<UserId, ChatMetricsInternal>,
+    per_user_metrics: &mut PerUserMetrics,
+    chat: Chat,
     user_id: UserId,
     mut action: F,
     timestamp: TimestampMillis,
@@ -2718,9 +2745,7 @@ fn add_to_metrics<F: FnMut(&mut ChatMetricsInternal)>(
     action(metrics);
     metrics.last_active = max(metrics.last_active, timestamp);
 
-    let user_metrics = per_user_metrics.entry(user_id).or_default();
-    action(user_metrics);
-    user_metrics.last_active = max(user_metrics.last_active, timestamp);
+    per_user_metrics.update(chat, user_id, action, timestamp);
 }
 
 pub struct PushMessageArgs {

--- a/backend/libraries/chat_events/src/lib.rs
+++ b/backend/libraries/chat_events/src/lib.rs
@@ -11,6 +11,7 @@ mod last_updated_timestamps;
 mod message_content_internal;
 mod message_ids;
 mod metrics;
+mod per_user_metrics;
 mod search_index;
 mod stable_memory;
 

--- a/backend/libraries/chat_events/src/metrics.rs
+++ b/backend/libraries/chat_events/src/metrics.rs
@@ -162,28 +162,54 @@ impl ChatMetricsInternal {
     }
 
     // The compact encoding used when storing metrics in stable memory:
-    // Last active      8 bytes
-    // Counters         4 bytes each
+    // Last active      6 bytes (big endian millis, enough until the year 10889)
+    // Counters         1 varint each (LEB128 of `(count << 5) | key`), so counts below 4 take 1 byte,
+    //                  below 512 take 2 bytes, below 65536 take 3 bytes, and MAX_COUNT takes 5 bytes
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(8 + 4 * self.metrics.len());
-        bytes.extend_from_slice(&self.last_active.to_be_bytes());
+        let mut bytes = Vec::with_capacity(LAST_ACTIVE_LEN + 2 * self.metrics.len());
+        bytes.extend_from_slice(&self.last_active.to_be_bytes()[8 - LAST_ACTIVE_LEN..]);
         for metric in self.metrics.iter() {
-            bytes.extend_from_slice(&metric.0);
+            let mut value = (metric.count() << METRIC_KEY_BITS) | metric.key() as u32;
+            while value >= 0x80 {
+                bytes.push((value as u8) | 0x80);
+                value >>= 7;
+            }
+            bytes.push(value as u8);
         }
         bytes
     }
 
     pub fn from_bytes(bytes: &[u8]) -> ChatMetricsInternal {
-        let (last_active, counters) = bytes.split_at(8);
+        let (last_active_bytes, counters) = bytes.split_at(LAST_ACTIVE_LEN);
+        let mut last_active = [0; 8];
+        last_active[8 - LAST_ACTIVE_LEN..].copy_from_slice(last_active_bytes);
+
+        let mut metrics = Vec::new();
+        let mut value = 0u32;
+        let mut shift = 0;
+        for byte in counters {
+            value |= ((byte & 0x7F) as u32) << shift;
+            if byte & 0x80 == 0 {
+                let key = MetricKey::from((value & METRIC_KEY_MASK) as u8);
+                metrics.push(MetricCounter::new(key, value >> METRIC_KEY_BITS));
+                value = 0;
+                shift = 0;
+            } else {
+                shift += 7;
+            }
+        }
+
         ChatMetricsInternal {
-            metrics: counters
-                .chunks_exact(4)
-                .map(|c| MetricCounter(c.try_into().unwrap()))
-                .collect(),
-            last_active: TimestampMillis::from_be_bytes(last_active.try_into().unwrap()),
+            metrics,
+            last_active: TimestampMillis::from_be_bytes(last_active),
         }
     }
 }
+
+const LAST_ACTIVE_LEN: usize = 6;
+// Metric keys go up to 22 so they fit in 5 bits
+const METRIC_KEY_BITS: u32 = 5;
+const METRIC_KEY_MASK: u32 = (1 << METRIC_KEY_BITS) - 1;
 
 #[cfg(test)]
 mod tests {
@@ -250,20 +276,52 @@ mod tests {
             last_active: 1_700_000_000_000,
             ..Default::default()
         };
+        assert_eq!(metrics.to_bytes().len(), 6);
         assert_eq!(ChatMetricsInternal::from_bytes(&metrics.to_bytes()), metrics);
 
-        metrics.incr(MetricKey::TextMessages, 5);
-        metrics.incr(MetricKey::Reactions, 3);
+        metrics.incr(MetricKey::TextMessages, 3);
+        metrics.incr(MetricKey::Reactions, 511);
+        metrics.incr(MetricKey::Replies, 65535);
         metrics.incr(MetricKey::CustomTypeMessages, MetricCounter::MAX_COUNT);
 
         let bytes = metrics.to_bytes();
-        assert_eq!(bytes.len(), 8 + 3 * 4);
+        assert_eq!(bytes.len(), 6 + 1 + 2 + 3 + 5);
 
         let decoded = ChatMetricsInternal::from_bytes(&bytes);
         assert_eq!(decoded, metrics);
-        assert_eq!(decoded.get(MetricKey::TextMessages), 5);
-        assert_eq!(decoded.get(MetricKey::Reactions), 3);
+        assert_eq!(decoded.get(MetricKey::TextMessages), 3);
+        assert_eq!(decoded.get(MetricKey::Reactions), 511);
+        assert_eq!(decoded.get(MetricKey::Replies), 65535);
         assert_eq!(decoded.get(MetricKey::CustomTypeMessages), MetricCounter::MAX_COUNT);
+    }
+
+    #[test]
+    fn bytes_roundtrip_every_key_and_count_boundary() {
+        for key in 1u8..=22 {
+            for count in [
+                1,
+                3,
+                4,
+                511,
+                512,
+                65535,
+                65536,
+                (1 << 23) - 1,
+                1 << 23,
+                MetricCounter::MAX_COUNT,
+            ] {
+                let mut metrics = ChatMetricsInternal {
+                    last_active: (1 << 48) - 1,
+                    ..Default::default()
+                };
+                metrics.incr(MetricKey::from(key), count);
+                metrics.incr(MetricKey::TextMessages, 1);
+
+                let decoded = ChatMetricsInternal::from_bytes(&metrics.to_bytes());
+                assert_eq!(decoded, metrics);
+                assert_eq!(decoded.get(MetricKey::from(key)), metrics.get(MetricKey::from(key)));
+            }
+        }
     }
 
     #[test]

--- a/backend/libraries/chat_events/src/metrics.rs
+++ b/backend/libraries/chat_events/src/metrics.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::{max, min};
 use types::{ChatMetrics, TimestampMillis};
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct ChatMetricsInternal {
     #[serde(rename = "m")]
     metrics: Vec<MetricCounter>,
@@ -10,7 +10,7 @@ pub struct ChatMetricsInternal {
     pub last_active: TimestampMillis,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct MetricCounter([u8; 4]);
 
 impl MetricCounter {
@@ -160,6 +160,29 @@ impl ChatMetricsInternal {
     fn get(&self, key: MetricKey) -> u32 {
         self.metrics.iter().find(|m| m.key() == key).map_or(0, |m| m.count())
     }
+
+    // The compact encoding used when storing metrics in stable memory:
+    // Last active      8 bytes
+    // Counters         4 bytes each
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8 + 4 * self.metrics.len());
+        bytes.extend_from_slice(&self.last_active.to_be_bytes());
+        for metric in self.metrics.iter() {
+            bytes.extend_from_slice(&metric.0);
+        }
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> ChatMetricsInternal {
+        let (last_active, counters) = bytes.split_at(8);
+        ChatMetricsInternal {
+            metrics: counters
+                .chunks_exact(4)
+                .map(|c| MetricCounter(c.try_into().unwrap()))
+                .collect(),
+            last_active: TimestampMillis::from_be_bytes(last_active.try_into().unwrap()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -219,6 +242,28 @@ mod tests {
             assert_eq!(metric.key(), key);
             assert_eq!(metric.count(), MetricCounter::MAX_COUNT);
         }
+    }
+
+    #[test]
+    fn bytes_roundtrip() {
+        let mut metrics = ChatMetricsInternal {
+            last_active: 1_700_000_000_000,
+            ..Default::default()
+        };
+        assert_eq!(ChatMetricsInternal::from_bytes(&metrics.to_bytes()), metrics);
+
+        metrics.incr(MetricKey::TextMessages, 5);
+        metrics.incr(MetricKey::Reactions, 3);
+        metrics.incr(MetricKey::CustomTypeMessages, MetricCounter::MAX_COUNT);
+
+        let bytes = metrics.to_bytes();
+        assert_eq!(bytes.len(), 8 + 3 * 4);
+
+        let decoded = ChatMetricsInternal::from_bytes(&bytes);
+        assert_eq!(decoded, metrics);
+        assert_eq!(decoded.get(MetricKey::TextMessages), 5);
+        assert_eq!(decoded.get(MetricKey::Reactions), 3);
+        assert_eq!(decoded.get(MetricKey::CustomTypeMessages), MetricCounter::MAX_COUNT);
     }
 
     #[test]

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -4,10 +4,13 @@ use serde::{Deserialize, Serialize};
 use stable_memory_map::{Key, KeyPrefix, UserMetricsKeyPrefix, with_map, with_map_mut};
 use std::cmp::max;
 use std::collections::BTreeMap;
-use types::{Chat, TimestampMillis, UserId};
+use types::{Chat, ChatId, TimestampMillis, UserId};
 
 // Each user's metrics within a chat. The entries are stored in the stable memory map for small
 // entries.
+//
+// In a direct chat, only the metrics of the user whose canister holds the chat are ever read, so
+// the other user's metrics aren't stored.
 #[derive(Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct PerUserMetrics {
@@ -23,6 +26,10 @@ pub struct PerUserMetrics {
 
 impl PerUserMetrics {
     pub fn get(&self, chat: Chat, user_id: &UserId) -> Option<ChatMetricsInternal> {
+        if !is_stored(chat, user_id) {
+            return None;
+        }
+
         if let Some(metrics) = self.on_heap.get(user_id) {
             return Some(metrics.clone());
         }
@@ -38,6 +45,10 @@ impl PerUserMetrics {
         action: F,
         timestamp: TimestampMillis,
     ) {
+        if !is_stored(chat, &user_id) {
+            return;
+        }
+
         let key = UserMetricsKeyPrefix::new_from_chat(chat).create_key(&user_id);
 
         with_map_mut(|m| {
@@ -66,7 +77,7 @@ impl PerUserMetrics {
     }
 
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
-    // moved
+    // moved. Entries for the other user in a direct chat are dropped rather than moved.
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
         let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
         let mut count = 0;
@@ -75,7 +86,9 @@ impl PerUserMetrics {
             while count < max_count
                 && let Some((user_id, metrics)) = self.on_heap.pop_first()
             {
-                m.insert(prefix.create_key(&user_id), metrics.to_bytes());
+                if is_stored(chat, &user_id) {
+                    m.insert(prefix.create_key(&user_id), metrics.to_bytes());
+                }
                 count += 1;
             }
         });
@@ -85,6 +98,10 @@ impl PerUserMetrics {
     pub fn on_heap_count(&self) -> usize {
         self.on_heap.len()
     }
+}
+
+fn is_stored(chat: Chat, user_id: &UserId) -> bool {
+    !matches!(chat, Chat::Direct(them) if them == ChatId::from(*user_id))
 }
 
 #[cfg(test)]
@@ -197,6 +214,58 @@ mod tests {
         assert_matches_model(&metrics, group, &model);
         metrics.migrate_to_stable_memory(group, usize::MAX);
         assert_matches_model(&metrics, group, &model);
+    }
+
+    #[test]
+    fn other_users_metrics_are_not_stored_in_direct_chats() {
+        init_stable_memory_map();
+        let me = user_id(1);
+        let them = user_id(2);
+        let other = user_id(3);
+        let chat = Chat::Direct(them.into());
+        let mut model = Model::new();
+
+        // Legacy entries on the heap for both users
+        let mut legacy = Model::new();
+        for user_id in [me, them] {
+            let mut metrics = ChatMetricsInternal::default();
+            metrics.incr(MetricKey::TextMessages, 5);
+            legacy.insert(user_id, metrics);
+        }
+        model.insert(me, legacy[&me].clone());
+        let mut metrics: PerUserMetrics = msgpack::deserialize_then_unwrap(&msgpack::serialize_then_unwrap(legacy));
+        assert!(metrics.get(chat, &them).is_none());
+
+        for now in 1000..1100 {
+            for user_id in [me, them, other] {
+                let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
+                if user_id == them {
+                    metrics.update(chat, user_id, |m| m.incr(key, 1), now);
+                } else {
+                    apply(&mut metrics, &mut model, chat, user_id, key, true, now);
+                }
+            }
+        }
+        assert!(metrics.get(chat, &them).is_none());
+        assert_matches_model(&metrics, chat, &model);
+
+        // The other user's legacy entry is dropped rather than moved into stable memory
+        assert_eq!(metrics.on_heap_count(), 1);
+        assert_eq!(metrics.migrate_to_stable_memory(chat, usize::MAX), 1);
+        assert_eq!(metrics.on_heap_count(), 0);
+        assert!(metrics.get(chat, &them).is_none());
+        assert_matches_model(&metrics, chat, &model);
+
+        metrics.copy_to_heap(chat);
+        assert_eq!(metrics.on_heap_count(), 2);
+        let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
+        let stable_user_ids: Vec<_> = with_map(|m| {
+            m.range(prefix.create_key(&Principal::from_slice(&[]).into())..)
+                .take_while(|(k, _)| k.matches_prefix(&prefix))
+                .map(|(k, _)| k.user_id())
+                .collect()
+        });
+        assert_eq!(stable_user_ids, vec![me, other]);
     }
 
     fn apply(

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -4,13 +4,10 @@ use serde::{Deserialize, Serialize};
 use stable_memory_map::{Key, KeyPrefix, UserMetricsKeyPrefix, with_map, with_map_mut};
 use std::cmp::max;
 use std::collections::BTreeMap;
-use types::{Chat, ChatId, TimestampMillis, UserId};
+use types::{Chat, TimestampMillis, UserId};
 
 // Each user's metrics within a chat. The entries are stored in the stable memory map for small
 // entries.
-//
-// In a direct chat, only the metrics of the user whose canister holds the chat are ever read, so
-// the other user's metrics aren't stored.
 #[derive(Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct PerUserMetrics {
@@ -26,10 +23,6 @@ pub struct PerUserMetrics {
 
 impl PerUserMetrics {
     pub fn get(&self, chat: Chat, user_id: &UserId) -> Option<ChatMetricsInternal> {
-        if !is_stored(chat, user_id) {
-            return None;
-        }
-
         if let Some(metrics) = self.on_heap.get(user_id) {
             return Some(metrics.clone());
         }
@@ -45,10 +38,6 @@ impl PerUserMetrics {
         action: F,
         timestamp: TimestampMillis,
     ) {
-        if !is_stored(chat, &user_id) {
-            return;
-        }
-
         let key = UserMetricsKeyPrefix::new_from_chat(chat).create_key(&user_id);
 
         with_map_mut(|m| {
@@ -77,7 +66,7 @@ impl PerUserMetrics {
     }
 
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
-    // moved. Entries for the other user in a direct chat are dropped rather than moved.
+    // moved
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
         let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
         let mut count = 0;
@@ -86,9 +75,7 @@ impl PerUserMetrics {
             while count < max_count
                 && let Some((user_id, metrics)) = self.on_heap.pop_first()
             {
-                if is_stored(chat, &user_id) {
-                    m.insert(prefix.create_key(&user_id), metrics.to_bytes());
-                }
+                m.insert(prefix.create_key(&user_id), metrics.to_bytes());
                 count += 1;
             }
         });
@@ -98,10 +85,6 @@ impl PerUserMetrics {
     pub fn on_heap_count(&self) -> usize {
         self.on_heap.len()
     }
-}
-
-fn is_stored(chat: Chat, user_id: &UserId) -> bool {
-    !matches!(chat, Chat::Direct(them) if them == ChatId::from(*user_id))
 }
 
 #[cfg(test)]
@@ -214,58 +197,6 @@ mod tests {
         assert_matches_model(&metrics, group, &model);
         metrics.migrate_to_stable_memory(group, usize::MAX);
         assert_matches_model(&metrics, group, &model);
-    }
-
-    #[test]
-    fn other_users_metrics_are_not_stored_in_direct_chats() {
-        init_stable_memory_map();
-        let me = user_id(1);
-        let them = user_id(2);
-        let other = user_id(3);
-        let chat = Chat::Direct(them.into());
-        let mut model = Model::new();
-
-        // Legacy entries on the heap for both users
-        let mut legacy = Model::new();
-        for user_id in [me, them] {
-            let mut metrics = ChatMetricsInternal::default();
-            metrics.incr(MetricKey::TextMessages, 5);
-            legacy.insert(user_id, metrics);
-        }
-        model.insert(me, legacy[&me].clone());
-        let mut metrics: PerUserMetrics = msgpack::deserialize_then_unwrap(&msgpack::serialize_then_unwrap(legacy));
-        assert!(metrics.get(chat, &them).is_none());
-
-        for now in 1000..1100 {
-            for user_id in [me, them, other] {
-                let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
-                if user_id == them {
-                    metrics.update(chat, user_id, |m| m.incr(key, 1), now);
-                } else {
-                    apply(&mut metrics, &mut model, chat, user_id, key, true, now);
-                }
-            }
-        }
-        assert!(metrics.get(chat, &them).is_none());
-        assert_matches_model(&metrics, chat, &model);
-
-        // The other user's legacy entry is dropped rather than moved into stable memory
-        assert_eq!(metrics.on_heap_count(), 1);
-        assert_eq!(metrics.migrate_to_stable_memory(chat, usize::MAX), 1);
-        assert_eq!(metrics.on_heap_count(), 0);
-        assert!(metrics.get(chat, &them).is_none());
-        assert_matches_model(&metrics, chat, &model);
-
-        metrics.copy_to_heap(chat);
-        assert_eq!(metrics.on_heap_count(), 2);
-        let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
-        let stable_user_ids: Vec<_> = with_map(|m| {
-            m.range(prefix.create_key(&Principal::from_slice(&[]).into())..)
-                .take_while(|(k, _)| k.matches_prefix(&prefix))
-                .map(|(k, _)| k.user_id())
-                .collect()
-        });
-        assert_eq!(stable_user_ids, vec![me, other]);
     }
 
     fn apply(

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -1,0 +1,235 @@
+use crate::metrics::ChatMetricsInternal;
+use candid::Principal;
+use serde::{Deserialize, Serialize};
+use stable_memory_map::{Key, KeyPrefix, UserMetricsKeyPrefix, with_map, with_map_mut};
+use std::cmp::max;
+use std::collections::BTreeMap;
+use types::{Chat, TimestampMillis, UserId};
+
+// Each user's metrics within a chat. The entries are stored in the stable memory map for small
+// entries.
+#[derive(Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct PerUserMetrics {
+    // Entries which haven't yet been moved into stable memory. New entries are always written to
+    // stable memory, and existing ones are moved across in batches by `migrate_to_stable_memory`.
+    // This can be removed once every chat has been migrated. It is always serialized, which is also
+    // how the metrics are carried over when a group is imported into a community.
+    //
+    // A user with an entry here has no entry in stable memory, unless the entries in stable memory
+    // have been copied here by `copy_to_heap`, in which case both entries are the same.
+    on_heap: BTreeMap<UserId, ChatMetricsInternal>,
+}
+
+impl PerUserMetrics {
+    pub fn get(&self, chat: Chat, user_id: &UserId) -> Option<ChatMetricsInternal> {
+        if let Some(metrics) = self.on_heap.get(user_id) {
+            return Some(metrics.clone());
+        }
+
+        let key = UserMetricsKeyPrefix::new_from_chat(chat).create_key(user_id);
+        with_map(|m| m.get(key)).map(|bytes| ChatMetricsInternal::from_bytes(&bytes))
+    }
+
+    pub fn update<F: FnOnce(&mut ChatMetricsInternal)>(
+        &mut self,
+        chat: Chat,
+        user_id: UserId,
+        action: F,
+        timestamp: TimestampMillis,
+    ) {
+        let key = UserMetricsKeyPrefix::new_from_chat(chat).create_key(&user_id);
+
+        with_map_mut(|m| {
+            let mut metrics = self.on_heap.remove(&user_id).unwrap_or_else(|| {
+                m.get(key.clone())
+                    .map(|bytes| ChatMetricsInternal::from_bytes(&bytes))
+                    .unwrap_or_default()
+            });
+            action(&mut metrics);
+            metrics.last_active = max(metrics.last_active, timestamp);
+            m.insert(key, metrics.to_bytes());
+        });
+    }
+
+    // Copies every entry in stable memory onto the heap, so that they are included when the chat is
+    // serialized to be imported into a community
+    pub fn copy_to_heap(&mut self, chat: Chat) {
+        let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
+        let start = prefix.create_key(&Principal::from_slice(&[]).into());
+
+        with_map(|m| {
+            for (key, bytes) in m.range(start..).take_while(|(k, _)| k.matches_prefix(&prefix)) {
+                self.on_heap.insert(key.user_id(), ChatMetricsInternal::from_bytes(&bytes));
+            }
+        });
+    }
+
+    // Moves up to `max_count` entries from the heap into stable memory, returning how many were
+    // moved
+    pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
+        let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
+        let mut count = 0;
+
+        with_map_mut(|m| {
+            while count < max_count
+                && let Some((user_id, metrics)) = self.on_heap.pop_first()
+            {
+                m.insert(prefix.create_key(&user_id), metrics.to_bytes());
+                count += 1;
+            }
+        });
+        count
+    }
+
+    pub fn on_heap_count(&self) -> usize {
+        self.on_heap.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::MetricKey;
+    use ic_stable_structures::DefaultMemoryImpl;
+    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
+    use rand::{Rng, rng};
+    use types::ChannelId;
+
+    type Model = BTreeMap<UserId, ChatMetricsInternal>;
+
+    #[test]
+    fn metrics_are_stored_per_chat() {
+        init_stable_memory_map();
+        let chat1 = Chat::Channel(Principal::anonymous().into(), ChannelId::from(1u32));
+        let chat2 = Chat::Channel(Principal::anonymous().into(), ChannelId::from(2u32));
+        let mut metrics1 = PerUserMetrics::default();
+        let mut metrics2 = PerUserMetrics::default();
+        let mut model1 = Model::new();
+        let mut model2 = Model::new();
+
+        for now in 1000..1500 {
+            let user_id = user_id(rng().next_u32() % 20);
+            let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
+            let incr = !rng().next_u32().is_multiple_of(3);
+
+            apply(&mut metrics1, &mut model1, chat1, user_id, key, incr, now);
+            apply(&mut metrics2, &mut model2, chat2, user_id, key, !incr, now + 1000);
+        }
+
+        assert_eq!(metrics1.on_heap_count(), 0);
+        assert_matches_model(&metrics1, chat1, &model1);
+        assert_matches_model(&metrics2, chat2, &model2);
+        assert!(metrics1.get(chat1, &user_id(100)).is_none());
+    }
+
+    #[test]
+    fn heap_entries_are_migrated_to_stable_memory() {
+        init_stable_memory_map();
+        let chat = Chat::Group(Principal::anonymous().into());
+        let mut model = Model::new();
+
+        // Build up some legacy entries on the heap
+        for i in 0..50 {
+            let mut metrics = ChatMetricsInternal::default();
+            metrics.last_active = 1000 + i as u64;
+            metrics.incr(MetricKey::TextMessages, i + 1);
+            model.insert(user_id(i), metrics);
+        }
+        let bytes = msgpack::serialize_then_unwrap(&model);
+        let mut metrics: PerUserMetrics = msgpack::deserialize_then_unwrap(&bytes);
+        // The legacy entries are serialized the same way as the map they were previously held in
+        assert_eq!(msgpack::serialize_then_unwrap(&metrics), bytes);
+        assert_eq!(metrics.on_heap_count(), 50);
+        assert_matches_model(&metrics, chat, &model);
+
+        // Updating a user moves their entry into stable memory
+        apply(&mut metrics, &mut model, chat, user_id(10), MetricKey::Reactions, true, 5000);
+        apply(&mut metrics, &mut model, chat, user_id(100), MetricKey::Reactions, true, 5000);
+        assert_eq!(metrics.on_heap_count(), 49);
+        assert_matches_model(&metrics, chat, &model);
+
+        assert_eq!(metrics.migrate_to_stable_memory(chat, 20), 20);
+        assert_eq!(metrics.on_heap_count(), 29);
+        assert_matches_model(&metrics, chat, &model);
+
+        assert_eq!(metrics.migrate_to_stable_memory(chat, 100), 29);
+        assert_eq!(metrics.on_heap_count(), 0);
+        assert_matches_model(&metrics, chat, &model);
+    }
+
+    #[test]
+    fn metrics_survive_being_imported_into_a_community() {
+        init_stable_memory_map();
+        let group = Chat::Group(Principal::anonymous().into());
+        let channel = Chat::Channel(Principal::from_slice(&[1]).into(), ChannelId::from(1u32));
+        let mut model = Model::new();
+
+        let mut legacy = Model::new();
+        for i in 0..10 {
+            let mut metrics = ChatMetricsInternal::default();
+            metrics.incr(MetricKey::Polls, i + 1);
+            legacy.insert(user_id(i), metrics.clone());
+            model.insert(user_id(i), metrics);
+        }
+        let mut metrics: PerUserMetrics = msgpack::deserialize_then_unwrap(&msgpack::serialize_then_unwrap(legacy));
+
+        for now in 1000..1200 {
+            let user_id = user_id(rng().next_u32() % 30);
+            apply(&mut metrics, &mut model, group, user_id, MetricKey::TextMessages, true, now);
+        }
+
+        // The group copies its entries onto the heap before serializing them
+        metrics.copy_to_heap(group);
+        assert_eq!(metrics.on_heap_count(), model.len());
+        assert_matches_model(&metrics, group, &model);
+
+        // The community deserializes them then moves them into stable memory under the channel
+        let bytes = msgpack::serialize_then_unwrap(&metrics);
+        let mut imported: PerUserMetrics = msgpack::deserialize_then_unwrap(&bytes);
+        assert_matches_model(&imported, channel, &model);
+        assert_eq!(imported.migrate_to_stable_memory(channel, usize::MAX), model.len());
+        assert_matches_model(&imported, channel, &model);
+
+        // If the import is abandoned, the group's copies on the heap are the same as the entries in
+        // stable memory, so it can carry on as before
+        apply(&mut metrics, &mut model, group, user_id(3), MetricKey::Edits, true, 2000);
+        assert_matches_model(&metrics, group, &model);
+        metrics.migrate_to_stable_memory(group, usize::MAX);
+        assert_matches_model(&metrics, group, &model);
+    }
+
+    fn apply(
+        metrics: &mut PerUserMetrics,
+        model: &mut Model,
+        chat: Chat,
+        user_id: UserId,
+        key: MetricKey,
+        incr: bool,
+        now: TimestampMillis,
+    ) {
+        let action = |m: &mut ChatMetricsInternal| {
+            if incr { m.incr(key, 1) } else { m.decr(key, 1) }
+        };
+        metrics.update(chat, user_id, action, now);
+
+        let expected = model.entry(user_id).or_default();
+        action(expected);
+        expected.last_active = max(expected.last_active, now);
+    }
+
+    fn assert_matches_model(metrics: &PerUserMetrics, chat: Chat, model: &Model) {
+        for (user_id, expected) in model {
+            assert_eq!(metrics.get(chat, user_id).as_ref(), Some(expected));
+        }
+    }
+
+    fn user_id(i: u32) -> UserId {
+        Principal::from_slice(&i.to_be_bytes()).into()
+    }
+
+    fn init_stable_memory_map() {
+        let memory = MemoryManager::init(DefaultMemoryImpl::default());
+        stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
+    }
+}

--- a/backend/libraries/stable_memory_map/src/keys.rs
+++ b/backend/libraries/stable_memory_map/src/keys.rs
@@ -12,6 +12,7 @@ mod message_id;
 mod principal;
 mod storage;
 mod user_id;
+mod user_metrics;
 
 pub use chat_event::*;
 pub use community_event::*;
@@ -21,6 +22,7 @@ pub use message_id::*;
 pub use principal::*;
 pub use storage::*;
 pub use user_id::*;
+pub use user_metrics::*;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(transparent)]
@@ -123,6 +125,9 @@ pub enum KeyType {
     DirectChatEventsByLastUpdated = 29,
     GroupChatEventsByLastUpdated = 30,
     ChannelEventsByLastUpdated = 31,
+    DirectChatUserMetrics = 32,
+    GroupChatUserMetrics = 33,
+    ChannelUserMetrics = 34,
     #[cfg(test)]
     TestSmallEntries = 255,
 }
@@ -175,7 +180,10 @@ impl KeyType {
             | KeyType::ChannelEventLastUpdated
             | KeyType::DirectChatEventsByLastUpdated
             | KeyType::GroupChatEventsByLastUpdated
-            | KeyType::ChannelEventsByLastUpdated => MapClass::SmallEntries,
+            | KeyType::ChannelEventsByLastUpdated
+            | KeyType::DirectChatUserMetrics
+            | KeyType::GroupChatUserMetrics
+            | KeyType::ChannelUserMetrics => MapClass::SmallEntries,
             #[cfg(test)]
             KeyType::TestSmallEntries => MapClass::SmallEntries,
         }
@@ -237,6 +245,9 @@ impl TryFrom<u8> for KeyType {
             29 => Ok(KeyType::DirectChatEventsByLastUpdated),
             30 => Ok(KeyType::GroupChatEventsByLastUpdated),
             31 => Ok(KeyType::ChannelEventsByLastUpdated),
+            32 => Ok(KeyType::DirectChatUserMetrics),
+            33 => Ok(KeyType::GroupChatUserMetrics),
+            34 => Ok(KeyType::ChannelUserMetrics),
             #[cfg(test)]
             255 => Ok(KeyType::TestSmallEntries),
             _ => Err(()),

--- a/backend/libraries/stable_memory_map/src/keys/user_metrics.rs
+++ b/backend/libraries/stable_memory_map/src/keys/user_metrics.rs
@@ -1,0 +1,115 @@
+use crate::keys::extract_key_type;
+use crate::keys::macros::key;
+use crate::{BaseKeyPrefix, ChatEventKeyPrefix, KeyPrefix, KeyType};
+use ic_principal::Principal;
+use types::{Chat, UserId};
+
+// Each user's metrics within a chat (eg. how many messages they have sent).
+//
+// The prefix has the same layout as the `ChatEventKeyPrefix` of the chat's main events list, with
+// only the key type differing. The key is the prefix followed by the user's id.
+key!(
+    UserMetricsKey,
+    UserMetricsKeyPrefix,
+    KeyType::DirectChatUserMetrics | KeyType::GroupChatUserMetrics | KeyType::ChannelUserMetrics
+);
+
+impl UserMetricsKeyPrefix {
+    pub fn new_from_chat(chat: Chat) -> Self {
+        Self::try_from(&ChatEventKeyPrefix::new_from_chat(chat, None)).unwrap()
+    }
+}
+
+// Fails if the events prefix is for a thread, since metrics are stored per chat rather than per
+// events list
+impl TryFrom<&ChatEventKeyPrefix> for UserMetricsKeyPrefix {
+    type Error = ();
+
+    fn try_from(value: &ChatEventKeyPrefix) -> Result<Self, Self::Error> {
+        let mut bytes = BaseKeyPrefix::from(value.clone()).0;
+        bytes[0] = match extract_key_type(&bytes).unwrap() {
+            KeyType::DirectChatEvent => KeyType::DirectChatUserMetrics,
+            KeyType::GroupChatEvent => KeyType::GroupChatUserMetrics,
+            KeyType::ChannelEvent => KeyType::ChannelUserMetrics,
+            _ => return Err(()),
+        } as u8;
+        Ok(UserMetricsKeyPrefix(bytes))
+    }
+}
+
+impl KeyPrefix for UserMetricsKeyPrefix {
+    type Key = UserMetricsKey;
+    type Suffix = UserId;
+
+    fn create_key(&self, user_id: &UserId) -> UserMetricsKey {
+        let user_id_bytes = user_id.as_slice();
+        let mut bytes = Vec::with_capacity(self.0.len() + user_id_bytes.len());
+        bytes.extend_from_slice(self.0.as_slice());
+        bytes.extend_from_slice(user_id_bytes);
+        UserMetricsKey(bytes)
+    }
+}
+
+impl UserMetricsKey {
+    pub fn user_id(&self) -> UserId {
+        // User ids vary in length, so the prefix length is determined by the key type
+        let prefix_len = match extract_key_type(&self.0).unwrap() {
+            // Key type, then the other user's id preceded by its length
+            KeyType::DirectChatUserMetrics => 2 + self.0[1] as usize,
+            KeyType::GroupChatUserMetrics => 1,
+            // Key type, then the channel id
+            KeyType::ChannelUserMetrics => 5,
+            _ => unreachable!(),
+        };
+        Principal::from_slice(&self.0[prefix_len..]).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BaseKey, Key, MapClass};
+    use rand::{Rng, RngExt, rng};
+    use types::ChannelId;
+
+    #[test]
+    fn user_metrics_keys_e2e() {
+        for _ in 0..100 {
+            let them_bytes: [u8; 10] = rng().random();
+            let them = Principal::from_slice(&them_bytes).into();
+            let user_id_len = rng().random_range(0..=29);
+            let user_id_bytes: Vec<u8> = (0..user_id_len).map(|_| rng().random()).collect();
+            let user_id = Principal::from_slice(&user_id_bytes).into();
+            let channel_id = ChannelId::from(rng().next_u32());
+
+            for (chat, key_type, prefix_len) in [
+                (Chat::Direct(them), KeyType::DirectChatUserMetrics, 12),
+                (Chat::Group(Principal::anonymous().into()), KeyType::GroupChatUserMetrics, 1),
+                (
+                    Chat::Channel(Principal::anonymous().into(), channel_id),
+                    KeyType::ChannelUserMetrics,
+                    5,
+                ),
+            ] {
+                let events_prefix = ChatEventKeyPrefix::new_from_chat(chat, None);
+                let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
+                let key = BaseKey::from(prefix.create_key(&user_id));
+                let metrics_key = UserMetricsKey::try_from(key).unwrap();
+
+                assert_eq!(*metrics_key.0.first().unwrap(), key_type as u8);
+                assert_eq!(key_type.map_class(), MapClass::SmallEntries);
+                assert_eq!(metrics_key.0.len(), prefix_len + user_id_len);
+                assert!(metrics_key.matches_prefix(&prefix));
+                assert_eq!(metrics_key.user_id(), user_id);
+                assert_eq!(prefix.0[1..], BaseKeyPrefix::from(events_prefix).as_slice()[1..]);
+
+                let thread_events_prefix = ChatEventKeyPrefix::new_from_chat(chat, Some(1.into()));
+                assert!(UserMetricsKeyPrefix::try_from(&thread_events_prefix).is_err());
+
+                let serialized = msgpack::serialize_then_unwrap(&metrics_key);
+                let deserialized: UserMetricsKey = msgpack::deserialize_then_unwrap(&serialized);
+                assert_eq!(deserialized, metrics_key);
+            }
+        }
+    }
+}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1620623843
+      instructions: 1614617634
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 319383036
+      instructions: 328700808
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,15 +2,15 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1462987961
-      heap_increase: 5
+      instructions: 1620623843
+      heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 234797100
-      heap_increase: 12
+      instructions: 319383036
+      heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
 version: 0.6.0

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1614617634
+      instructions: 1614639634
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 328700808
+      instructions: 328723808
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1614639634
+      instructions: 1614617634
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 328723808
+      instructions: 328700808
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
Follows #9351. Moves each chat's per-user metrics (`ChatEvents::per_user_metrics`) off the heap and into the stable memory map for small entries. The chat-level metrics stay on the heap.

## Changes

- **New key types** (`SmallEntries` class): `DirectChatUserMetrics` (32), `GroupChatUserMetrics` (33) and `ChannelUserMetrics` (34).
  - Each chat has one prefix, with the same layout as its main events list's `ChatEventKeyPrefix` apart from the key type.
  - The key is the prefix followed by the user id. `UserMetricsKey::user_id()` works out the prefix length from the key type, because user ids vary in length.
- **Value encoding**: `ChatMetricsInternal::to_bytes` / `from_bytes` use a compact format rather than the heap's 4-byte counters.
  - `last_active` takes 6 bytes (big-endian millis), which lasts until the year 10889.
  - Each counter is one LEB128 varint of `(count << 5) | key`. Metric keys go up to 22, so they fit in 5 bits. Counts below 4 take 1 byte, below 512 take 2, and below 65,536 take 3.
  - For a realistic mix of metrics, the average value drops from 16.8 bytes (8 + 4n) to 10.5. In a 256-byte-page map built in random order, that's 11–15% fewer stable bytes per entry: group 58.7 → 50.1, channel 64.6 → 55.4, direct 74.1 → 65.9. Most of the per-entry cost is the map's own overhead (length prefixes, node headers and fill factor), so that's about as much as the value encoding can save.
- **`PerUserMetrics`** (new) replaces the `BTreeMap<UserId, ChatMetricsInternal>` field:
  - It's `#[serde(transparent)]`, so the legacy heap entries keep the same field name and format.
  - `update` does a stable read-modify-write, and moves any heap entry for that user into stable memory.
  - `get` checks the heap first, then stable memory.
  - `ChatEvents::user_metrics` now returns an owned `ChatMetricsInternal`. The callers are unchanged, since they all just `.map(|m| m.hydrate())`.
- **Migration job**: `ChatEvents::migrate_to_stable_memory` and `heap_entries_to_migrate_count` now include the per-user metrics.
- **GC**: for main-list prefixes, `ChatEvents::stable_memory_key_prefixes` also returns the user metrics prefix, so it's cleaned up when a direct chat or channel is deleted.
- **Group → community conversion / import**: the metrics now go across in the serialized chat state, as before.
  - Before serializing, `start_importing_into_community` calls `ChatEvents::copy_user_metrics_to_heap_for_export`, which copies the stable entries onto the heap.
  - Once imported, `finalize_group_import` starts the `migrate_chat_events_to_stable_memory` job, which moves them into stable memory under the channel's prefix. It does this in batches rather than in one message, because large groups can have many users with metrics.
  - If an import is abandoned, the group's heap copies match its stable entries, so nothing breaks. `c2c_unfreeze_group_impl`, which both the rollback and a manual unfreeze go through, now starts the migration job, which moves the copies back into stable memory and rewrites the same values.

## Testing

- **Unit tests**:
  - key round trip, prefix layout and thread prefixes rejected
  - value encoding round trip, including every metric key at each varint length boundary and at `MAX_COUNT`
  - metrics kept separate per chat, checked against a model
  - legacy heap entries: serde format unchanged, `update` moves an entry to stable memory, batched migration
  - export / import round trip: copy to the heap in the group, serialize, then migrate under the channel prefix; plus an abandoned import
- **Integration tests**:
  - The small-map counts in the disappearing-message GC tests (group and channel), the direct-chat deletion GC test and the channel deletion GC test now include one metrics entry per sender. The deletion tests show these entries are garbage collected.
  - `convert_into_community_succeeds` now checks that the sender's `my_metrics` survive the conversion, and that the metrics end up in the community's stable memory under the channel's prefix.
- canbench `--persist`. Both benchmarks use a new user for each of their 1000 operations, so every metrics update is a stable read that misses, followed by an insert of a new key. That makes them a worst case; updates by existing users overwrite a value in place.
  - `push_simple_text_messages`: +40% (235M → 329M, about 94K instructions per message)
  - `add_reactions`: +10.4% (1.463B → 1.615B, about 152K per reaction)
  - Heap increase is down in both.

## Rollout notes

- This adds no new upgrade-order constraint. The group carries its metrics across on the heap, and every community version can read them from there. #9350's constraint (community canisters before group canisters) still applies.
- In the Community canister, the `migrate_chat_events_to_stable_memory` job now also handles imported groups' metrics. So unlike in the User and Group canisters, it has to stay once the existing heap entries have been migrated.

## Follow-up

- A User canister only reads its own user's metrics for a direct chat, so the other user's metrics don't need storing. That would halve the metrics entries for direct chats. An earlier commit here skipped them, but it was reverted: in a self chat the other user is the canister's own user, and `ChatEvents` has no way to tell. That change will be made separately, with the User canister telling `ChatEvents` which chats it applies to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
