### PR TITLE
Use `insert_many` for bulk writes to the stable memory map

### DIFF
--- a/backend/benchmarks/src/chat_events.rs
+++ b/backend/benchmarks/src/chat_events.rs
@@ -5,7 +5,7 @@ use chat_events::{
 };
 use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
-use types::{EventIndex, MessageId, MultiUserChat, Reaction};
+use types::{ChannelId, Chat, EventIndex, MessageId, MultiUserChat, Reaction, TimestampMillis};
 
 #[bench(raw)]
 fn push_simple_text_messages() -> BenchResult {
@@ -103,4 +103,89 @@ fn add_reactions() -> BenchResult {
             let _ = chat_events.add_reaction::<NullEventPusher>(args, None);
         }
     })
+}
+
+// Imports the events of a group containing 1000 messages into a channel, as happens when a group
+// is imported into a community
+#[bench(raw)]
+fn import_events() -> BenchResult {
+    let memory = MemoryManager::init(DefaultMemoryImpl::default());
+    stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
+
+    let start = 1700000000000;
+    let chat_events = group_chat_with_messages(1000, start);
+
+    let mut batches = Vec::new();
+    let mut after = None;
+    loop {
+        let batch = chat_events.read_events_as_bytes_from_stable_memory(after);
+        let Some((last, _)) = batch.last() else {
+            break;
+        };
+        after = Some(last.clone());
+        batches.push(batch);
+    }
+
+    let channel = Chat::Channel(canister_id_from_u64(3).into(), ChannelId::from(1u32));
+
+    bench_fn(|| {
+        for batch in batches {
+            ChatEvents::import_events(channel, batch);
+        }
+    })
+}
+
+// Moves the metrics of 1000 users into stable memory under a channel's prefix, as happens after a
+// group is imported into a community
+#[bench(raw)]
+fn migrate_imported_user_metrics() -> BenchResult {
+    let memory = MemoryManager::init(DefaultMemoryImpl::default());
+    stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
+
+    let start = 1700000000000;
+    let mut chat_events = group_chat_with_messages(1000, start);
+    chat_events.copy_user_metrics_to_heap_for_export();
+    chat_events.set_chat(Chat::Channel(canister_id_from_u64(3).into(), ChannelId::from(1u32)));
+
+    bench_fn(|| {
+        chat_events.migrate_to_stable_memory(usize::MAX);
+    })
+}
+
+// A group chat containing `count` messages, each sent by a different user and each with a random
+// message id
+fn group_chat_with_messages(count: u64, start: TimestampMillis) -> ChatEvents {
+    let mut chat_events = ChatEvents::new_group_chat(
+        MultiUserChat::Group(canister_id_from_u64(1).into()),
+        "abc".to_string(),
+        "xyz".to_string(),
+        canister_id_from_u64(2).into(),
+        None,
+        u128::MAX,
+        start,
+    );
+
+    for i in 0..count {
+        chat_events.push_message::<NullEventPusher>(
+            PushMessageArgs {
+                sender: canister_id_from_u64(i).into(),
+                thread_root_message_index: None,
+                // Message ids are random, so scramble them
+                message_id: MessageId::from((i + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15)),
+                content: MessageContentInternal::Text(TextContentInternal {
+                    text: "1".repeat(i as usize % 200),
+                }),
+                sender_context: None,
+                mentioned: Vec::new(),
+                replies_to: None,
+                forwarded: false,
+                sender_is_bot: false,
+                block_level_markdown: false,
+                og_previews: Vec::new(),
+                now: start + (i * 1000),
+            },
+            None,
+        );
+    }
+    chat_events
 }

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
-- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#9353](https://github.com/open-chat-labs/open-chat/pull/9353))
 
 ### Fixed
 

--- a/backend/canisters/community/CHANGELOG.md
+++ b/backend/canisters/community/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
-- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#9353](https://github.com/open-chat-labs/open-chat/pull/9353))
 
 ### Fixed
 

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move each chat's expiring events from the heap into the stable memory map for small entries ([#9350](https://github.com/open-chat-labs/open-chat/pull/9350))
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
-- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#PRNUM](https://github.com/open-chat-labs/open-chat/pull/PRNUM))
+- Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#9353](https://github.com/open-chat-labs/open-chat/pull/9353))
 
 ### Fixed
 

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use stable_memory_map::StableMemoryMap;
+use stable_memory_map::{KeyPrefix, StableMemoryMap, with_map_mut};
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
@@ -289,14 +289,24 @@ impl ChatEventsList {
             .map(|(m, e)| (*m, *e))
             .collect();
 
-        let mut message_ids = self.message_ids();
-        for (message_id, event_index) in batch.iter().copied() {
-            self.message_ids_on_heap.remove(&message_id);
-            // `push_event` checks both stores and an imported group's heap ids are discarded, so
-            // there can't already be a stable entry for this id. If there were, overwriting it
-            // would leave lookups unchanged, since they check the heap first.
-            message_ids.insert(message_id, event_index);
-        }
+        // `push_event` checks both stores and an imported group's heap ids are discarded, so there
+        // can't already be a stable entry for any of these ids. If there were, overwriting it would
+        // leave lookups unchanged, since they check the heap first.
+        let message_ids = self.message_ids();
+        let mut entries: Vec<_> = batch
+            .iter()
+            .map(|(message_id, event_index)| {
+                self.message_ids_on_heap.remove(message_id);
+                (
+                    message_ids.prefix().create_key(message_id),
+                    MessageIdsStableStorage::value_to_bytes(*event_index),
+                )
+            })
+            .collect();
+        // The heap entries are unordered, so sort them into key order to minimise the number of
+        // nodes written
+        entries.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        with_map_mut(|m| m.insert_many(entries));
 
         if self.message_ids_on_heap.is_empty() {
             // Release the map's allocation

--- a/backend/libraries/chat_events/src/expiring_events.rs
+++ b/backend/libraries/chat_events/src/expiring_events.rs
@@ -71,13 +71,28 @@ impl ExpiringEvents {
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
     // moved
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
-        let mut count = 0;
-        while count < max_count
-            && let Some((expires_at, event_index)) = self.on_heap.pop_first()
-        {
-            self.insert(chat, event_index, expires_at);
-            count += 1;
+        if max_count == 0 {
+            return 0;
         }
+        let Some((first_expiry, _)) = self.on_heap.first().copied() else {
+            return 0;
+        };
+        if self.next_expiry_in_stable_memory.is_none_or(|ts| first_expiry < ts) {
+            self.next_expiry_in_stable_memory = Some(first_expiry);
+        }
+
+        let prefix = ExpiringEventKeyPrefix::new_from_chat(chat);
+        let mut count = 0;
+
+        // Entries are popped in (expiry date, event index) order, which is also their key order
+        with_map_mut(|m| {
+            m.insert_many(
+                std::iter::from_fn(|| self.on_heap.pop_first())
+                    .take(max_count)
+                    .inspect(|_| count += 1)
+                    .map(|key| (prefix.create_key(&key), Vec::new())),
+            )
+        });
         count
     }
 

--- a/backend/libraries/chat_events/src/last_updated_timestamps.rs
+++ b/backend/libraries/chat_events/src/last_updated_timestamps.rs
@@ -18,6 +18,9 @@ pub struct LastUpdatedTimestamps {
     // stable memory, and existing ones are moved across in batches by `migrate_to_stable_memory`.
     // This can be removed once every chat has been migrated. It is always serialized so that a
     // canister can still be rolled back to a version expecting it.
+    //
+    // An event with an entry here has no entry in stable memory, since marking an event as updated
+    // removes its entry from here before writing to stable memory.
     by_timestamp: BTreeSet<(TimestampMillis, Option<MessageIndex>, EventIndex)>,
     #[serde(skip)]
     by_event_index: BTreeMap<(Option<MessageIndex>, EventIndex), TimestampMillis>,
@@ -110,14 +113,37 @@ impl LastUpdatedTimestamps {
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
     // moved
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
-        let mut count = 0;
-        while count < max_count
+        let mut batch = Vec::new();
+        while batch.len() < max_count
             && let Some((ts, thread_root_message_index, event_index)) = self.by_timestamp.pop_first()
         {
             self.by_event_index.remove(&(thread_root_message_index, event_index));
-            insert_into_stable_memory(chat, thread_root_message_index, event_index, ts);
-            count += 1;
+            batch.push((ts, thread_root_message_index, event_index));
         }
+        let count = batch.len();
+        if count == 0 {
+            return 0;
+        }
+
+        // None of these events have entries in stable memory, so there are no previous entries to
+        // remove and the entries can be inserted in bulk
+        let by_event_prefix = EventLastUpdatedKeyPrefix::new_from_chat(chat);
+        let by_timestamp_prefix = EventsByLastUpdatedKeyPrefix::new_from_chat(chat);
+
+        with_map_mut(|m| {
+            // The batch is in timestamp order, which is the key order of the entries keyed by timestamp
+            m.insert_many(
+                batch
+                    .iter()
+                    .map(|&(ts, tr, e)| (by_timestamp_prefix.create_key(&(ts, tr, e)), Vec::new())),
+            );
+            batch.sort_unstable_by_key(|&(_, tr, e)| (tr, e));
+            m.insert_many(
+                batch
+                    .into_iter()
+                    .map(|(ts, tr, e)| (by_event_prefix.create_key(&(tr, e)), ts.to_be_bytes().to_vec())),
+            );
+        });
         count
     }
 

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -66,18 +66,20 @@ impl PerUserMetrics {
     }
 
     // Moves up to `max_count` entries from the heap into stable memory, returning how many were
-    // moved
+    // moved. Any existing entry in stable memory for one of these users is a copy of the heap entry
+    // (see `copy_to_heap`), so it can simply be overwritten.
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
         let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
         let mut count = 0;
 
+        // Entries are popped in user id order, which matches key order for user ids of the same length
         with_map_mut(|m| {
-            while count < max_count
-                && let Some((user_id, metrics)) = self.on_heap.pop_first()
-            {
-                m.insert(prefix.create_key(&user_id), metrics.to_bytes());
-                count += 1;
-            }
+            m.insert_many(
+                std::iter::from_fn(|| self.on_heap.pop_first())
+                    .take(max_count)
+                    .inspect(|_| count += 1)
+                    .map(|(user_id, metrics)| (prefix.create_key(&user_id), metrics.to_bytes())),
+            )
         });
         count
     }

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -2,7 +2,7 @@ use crate::metrics::ChatMetricsInternal;
 use candid::Principal;
 use serde::{Deserialize, Serialize};
 use stable_memory_map::{Key, KeyPrefix, UserMetricsKeyPrefix, with_map, with_map_mut};
-use std::cmp::max;
+use std::cmp::{max, min};
 use std::collections::BTreeMap;
 use types::{Chat, TimestampMillis, UserId};
 
@@ -70,17 +70,16 @@ impl PerUserMetrics {
     // (see `copy_to_heap`), so it can simply be overwritten.
     pub fn migrate_to_stable_memory(&mut self, chat: Chat, max_count: usize) -> usize {
         let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
-        let mut count = 0;
+        let count = min(max_count, self.on_heap.len());
+        let mut entries = Vec::with_capacity(count);
+        for (user_id, metrics) in std::iter::from_fn(|| self.on_heap.pop_first()).take(count) {
+            entries.push((prefix.create_key(&user_id), metrics.to_bytes()));
+        }
 
-        // Entries are popped in user id order, which matches key order for user ids of the same length
-        with_map_mut(|m| {
-            m.insert_many(
-                std::iter::from_fn(|| self.on_heap.pop_first())
-                    .take(max_count)
-                    .inspect(|_| count += 1)
-                    .map(|(user_id, metrics)| (prefix.create_key(&user_id), metrics.to_bytes())),
-            )
-        });
+        // User ids are ordered by length before their bytes, whereas keys are ordered by their bytes
+        // alone, so sort the entries into key order to minimise the number of nodes written
+        entries.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        with_map_mut(|m| m.insert_many(entries));
         count
     }
 

--- a/backend/libraries/chat_events/src/stable_memory/mod.rs
+++ b/backend/libraries/chat_events/src/stable_memory/mod.rs
@@ -46,25 +46,37 @@ pub fn read_events_as_bytes(chat: Chat, after: Option<EventContext>, max_bytes: 
 
 // Used to efficiently write all events to stable memory when migrating a group into a community
 pub fn write_events_as_bytes(chat: Chat, events: Vec<(EventContext, ByteBuf)>) {
-    with_map_mut(|m| {
-        for (context, bytes) in events {
-            let prefix = ChatEventKeyPrefix::new_from_chat(chat, context.thread_root_message_index);
-            let key = prefix.create_key(&context.event_index);
-            let value = bytes.into_vec();
-            // Deserializing also checks the event is valid
-            let event = bytes_to_event(&value);
-            if let ChatEventInternal::Message(message) = &event.event {
-                let message_id_key = MessageIdKeyPrefix::from(&prefix).create_key(&message.message_id);
-                m.insert(message_id_key, MessageIdsStableStorage::value_to_bytes(context.event_index));
-            }
-            if let Some(expires_at) = event.expires_at
-                && let Ok(expiring_events_prefix) = ExpiringEventKeyPrefix::try_from(&prefix)
-            {
-                let expiring_event_key = expiring_events_prefix.create_key(&(expires_at, context.event_index));
-                m.insert(expiring_event_key, Vec::new());
-            }
-            m.insert(key, value);
+    let mut event_entries = Vec::with_capacity(events.len());
+    let mut message_id_entries = Vec::new();
+    let mut expiring_event_entries = Vec::new();
+
+    for (context, bytes) in events {
+        let prefix = ChatEventKeyPrefix::new_from_chat(chat, context.thread_root_message_index);
+        let value = bytes.into_vec();
+        // Deserializing also checks the event is valid
+        let event = bytes_to_event(&value);
+        if let ChatEventInternal::Message(message) = &event.event {
+            let message_id_key = MessageIdKeyPrefix::from(&prefix).create_key(&message.message_id);
+            message_id_entries.push((message_id_key, MessageIdsStableStorage::value_to_bytes(context.event_index)));
         }
+        if let Some(expires_at) = event.expires_at
+            && let Ok(expiring_events_prefix) = ExpiringEventKeyPrefix::try_from(&prefix)
+        {
+            let expiring_event_key = expiring_events_prefix.create_key(&(expires_at, context.event_index));
+            expiring_event_entries.push((expiring_event_key, Vec::new()));
+        }
+        event_entries.push((prefix.create_key(&context.event_index), value));
+    }
+
+    // The events are exported in key order, but the other entries need sorting into key order so
+    // that each batch of inserts writes as few nodes as possible
+    message_id_entries.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+    expiring_event_entries.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
+    with_map_mut(|m| {
+        m.insert_many(event_entries);
+        m.insert_many(message_id_entries);
+        m.insert_many(expiring_event_entries);
     });
 }
 

--- a/backend/libraries/group_chat_core/src/members/stable_memory.rs
+++ b/backend/libraries/group_chat_core/src/members/stable_memory.rs
@@ -75,16 +75,18 @@ impl MembersStableStorage {
 // Used to write all members to stable memory when migrating a group into a community
 pub fn write_members_from_bytes(chat: MultiUserChat, members: Vec<(UserId, ByteBuf)>) -> Option<UserId> {
     let prefix = UserIdKeyPrefix::new_from_chat(chat);
-    let mut latest = None;
-    with_map_mut(|m| {
-        for (user_id, byte_buf) in members {
+    let latest = members.last().map(|(user_id, _)| *user_id);
+    // The members are exported in key order, so they can be inserted in bulk efficiently
+    let entries: Vec<_> = members
+        .into_iter()
+        .map(|(user_id, byte_buf)| {
             let bytes = byte_buf.into_vec();
             // Check that the bytes are valid
             let _ = bytes_to_member(&bytes);
-            latest = Some(user_id);
-            m.insert(prefix.create_key(&user_id), bytes);
-        }
-    });
+            (prefix.create_key(&user_id), bytes)
+        })
+        .collect();
+    with_map_mut(|m| m.insert_many(entries));
     latest
 }
 

--- a/backend/libraries/stable_memory_map/src/lib.rs
+++ b/backend/libraries/stable_memory_map/src/lib.rs
@@ -160,6 +160,31 @@ impl StableMemoryMapInner {
         self.map_mut(map_class(key.as_slice())).insert(key, value)
     }
 
+    // Inserts many entries, writing each modified node to stable memory at most once rather than
+    // once per entry. Unlike `insert`, the previous values aren't returned. Nodes are only written
+    // once the input has moved past them, so this only helps when consecutive keys are close
+    // together, meaning the entries should be supplied in key order. Out of order entries are still
+    // inserted correctly, but cost no less than calling `insert` for each one.
+    pub fn insert_many<K: Key>(&mut self, entries: impl IntoIterator<Item = (K, Vec<u8>)>) {
+        let mut entries = entries
+            .into_iter()
+            .map(|(key, value)| -> (BaseKey, Vec<u8>) { (key.into(), value) })
+            .peekable();
+
+        let Some((first, _)) = entries.peek() else {
+            return;
+        };
+        let class = map_class(first.as_slice());
+
+        self.map_mut(class).insert_many(entries.inspect(move |(key, _)| {
+            assert_eq!(
+                map_class(key.as_slice()),
+                class,
+                "Entries inserted together must be in the same map"
+            );
+        }));
+    }
+
     pub fn remove<K: Key>(&mut self, key: K) -> Option<Vec<u8>> {
         let key = key.into();
         self.map_mut(map_class(key.as_slice())).remove(&key)
@@ -323,6 +348,41 @@ mod tests {
             assert_eq!(m.remove(small_key(7)), Some(7u32.to_be_bytes().to_vec()));
             assert!(m.get(small_key(7)).is_none());
             assert_eq!(m.small_entries_map.as_ref().unwrap().len(), 99);
+        });
+    }
+
+    #[test]
+    fn insert_many_matches_inserting_one_at_a_time() {
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+        init_with_small_entries_map(memory_manager.get(MAIN), memory_manager.get(SMALL));
+
+        // Interleave existing keys with new ones, and include some out of order keys and an
+        // overwritten key
+        with_map_mut(|m| {
+            for i in (0..1000).step_by(2) {
+                m.insert(small_key(i), vec![0]);
+            }
+            m.insert_many(
+                (0..1000)
+                    .map(|i| (small_key(i), i.to_be_bytes().to_vec()))
+                    .chain([(small_key(5000), vec![1]), (small_key(10), vec![2])]),
+            );
+            m.insert_many(std::iter::once((default_key(), vec![3])));
+            m.insert_many(Vec::<(TestSmallEntriesKey, Vec<u8>)>::new());
+        });
+
+        with_map(|m| {
+            assert_eq!(m.map.len(), 1);
+            assert_eq!(m.small_entries_map.as_ref().unwrap().len(), 1001);
+            for i in (0..1000).filter(|i| *i != 10) {
+                assert_eq!(m.get(small_key(i)), Some(i.to_be_bytes().to_vec()));
+            }
+            assert_eq!(m.get(small_key(10)), Some(vec![2]));
+            assert_eq!(m.get(small_key(5000)), Some(vec![1]));
+            assert_eq!(m.get(default_key()), Some(vec![3]));
+
+            let keys: Vec<_> = m.range(small_key(0)..).map(|(k, _)| suffix(&k)).collect();
+            assert_eq!(keys, (0..1000).chain([5000]).collect::<Vec<_>>());
         });
     }
 

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -2,14 +2,28 @@ benches:
   add_reactions:
     total:
       calls: 1
-      instructions: 1614617634
+      instructions: 1614916728
       heap_increase: 3
+      stable_memory_increase: 0
+    scopes: {}
+  import_events:
+    total:
+      calls: 1
+      instructions: 49586873
+      heap_increase: 1
+      stable_memory_increase: 0
+    scopes: {}
+  migrate_imported_user_metrics:
+    total:
+      calls: 1
+      instructions: 10248395
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   push_simple_text_messages:
     total:
       calls: 1
-      instructions: 328700808
+      instructions: 328723346
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}

--- a/canbench_results.yml
+++ b/canbench_results.yml
@@ -16,7 +16,7 @@ benches:
   migrate_imported_user_metrics:
     total:
       calls: 1
-      instructions: 10248395
+      instructions: 10469263
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
Follows #9352. Now that we use the patched `ic-stable-structures` (#9347), bulk writes to the stable memory map can use `BTreeMap::insert_many`. It keeps the path from the root to the current leaf in memory, and writes each modified node (and the map's header) once, when the input moves past it, rather than once per entry.

## Changes

- **`StableMemoryMapInner::insert_many`** wraps the map's `insert_many`.
  - Every entry must be routed to the same map (main or small entries), and it asserts this.
  - Unlike `insert`, it doesn't return the previous values. So each call site below only uses it where there's no existing entry that needs cleaning up.
  - It's only faster when the entries arrive in key order, so each call site sorts its entries first where needed.
- **Migrating heap entries into stable memory** (the `migrate_chat_events_to_stable_memory` job in the User, Group and Community canisters):
  - `PerUserMetrics`: the batch is sorted by key before inserting. The heap map is ordered by user id, but user ids are ordered by length first, whereas keys are ordered by their bytes alone. Any existing stable entry is a copy made by `copy_to_heap`, so overwriting it is fine.
  - `ExpiringEvents`: entries are popped in key order. It lowers `next_expiry_in_stable_memory` once, using the batch's first entry.
  - `LastUpdatedTimestamps`: the batch is inserted twice. The by-timestamp entries go in the order they were popped; the by-event entries go in after sorting by `(thread root, event index)`.
    - The previous code handled an existing stable entry for the event. That can't happen, because `mark_updated` removes the heap entry before writing to stable memory. This is now written down on the field.
  - Message ids: the heap `HashMap` is unordered, so the batch is sorted by key before inserting. This skips the `StableMemoryMap` trait's `insert`, whose `on_inserted` hook can't be honoured for a bulk insert. `MessageIdsStableStorage` doesn't use the hook anyway.
- **Importing a group into a community**:
  - `write_events_as_bytes` collects each batch's events, message ids and expiring events separately. The events are already in key order. The message ids and expiring events are sorted, and each set is inserted with one `insert_many`.
  - `write_members_from_bytes` inserts each batch of members in one go. They're exported in key order.

## Performance

Two new canbench benchmarks, compared against the previous code on the same benchmarks:

| Benchmark | Before | After | Change |
|---|---|---|---|
| `import_events`: import 1000 exported messages (random message ids) into a channel | 190.3M | 49.6M | −74% |
| `migrate_imported_user_metrics`: move 1000 users' metrics from the heap into stable memory | 78.0M | 10.5M | −87% |

The existing benchmarks are unchanged, since they don't do bulk writes.

## Testing

- New unit test comparing `insert_many` with inserting one at a time. It covers keys interleaved with existing entries, out-of-order keys, an overwritten key and empty input.
- The existing migration and import unit tests cover each call site.
- Integration tests: `stable_memory`, `import_group`, `convert_group_into_community`, `disappearing_message`, `delete_channel` and `delete_direct_chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
