### PR TITLE
Stop storing the other user's metrics in direct chats

### DIFF
--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 - Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#9353](https://github.com/open-chat-labs/open-chat/pull/9353))
+- Stop storing the other user's metrics in direct chats (other than a user's chat with themselves), since only the user's own metrics are ever read ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
 
 ### Fixed
 

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move the timestamps of when each chat's events were last updated from the heap into the stable memory map for small entries ([#9351](https://github.com/open-chat-labs/open-chat/pull/9351))
 - Move each chat's per-user metrics from the heap into the stable memory map for small entries ([#9352](https://github.com/open-chat-labs/open-chat/pull/9352))
 - Use `insert_many` for bulk writes to the stable memory map, writing each modified node once rather than once per entry ([#9353](https://github.com/open-chat-labs/open-chat/pull/9353))
-- Stop storing the other user's metrics in direct chats (other than a user's chat with themselves), since only the user's own metrics are ever read ([#PR](https://github.com/open-chat-labs/open-chat/pull/PR))
+- Stop storing the other user's metrics in direct chats (other than a user's chat with themselves), since only the user's own metrics are ever read ([#9354](https://github.com/open-chat-labs/open-chat/pull/9354))
 
 ### Fixed
 

--- a/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -1,6 +1,6 @@
-use crate::Data;
 use crate::lifecycle::init_state;
 use crate::memory::{get_stable_memory_map_memory, get_stable_memory_map_small_entries_memory, get_upgrades_memory};
+use crate::{Data, mutate_state};
 use canister_api_macros::post_upgrade;
 use canister_logger::LogEntry;
 use canister_tracing_macros::trace;
@@ -27,6 +27,15 @@ fn post_upgrade(args: Args) {
 
     let env = Box::new(CanisterEnv::new(data.rng_seed));
     init_state(env, data, args.wasm_version);
+
+    // Stop storing the other user's metrics in existing direct chats, deleting any already stored.
+    // TODO: Remove this after next release
+    mutate_state(|state| {
+        let my_user_id = state.env.canister_id().into();
+        for chat in state.data.direct_chats.iter_mut() {
+            chat.events.skip_their_metrics(my_user_id);
+        }
+    });
 
     let total_instructions = ic_cdk::api::call_context_instruction_counter();
     info!(version = %args.wasm_version, total_instructions, "Post-upgrade complete");

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -22,8 +22,8 @@ pub struct DirectChat {
 
 impl DirectChat {
     pub fn new(
-        them: UserId,
         my_user_id: UserId,
+        them: UserId,
         user_type: UserType,
         events_ttl: Option<Milliseconds>,
         anonymized_chat_id: u128,

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -23,6 +23,7 @@ pub struct DirectChat {
 impl DirectChat {
     pub fn new(
         them: UserId,
+        my_user_id: UserId,
         user_type: UserType,
         events_ttl: Option<Milliseconds>,
         anonymized_chat_id: u128,
@@ -31,7 +32,7 @@ impl DirectChat {
         DirectChat {
             them,
             date_created: now,
-            events: ChatEvents::new_direct_chat(them, events_ttl, anonymized_chat_id, now),
+            events: ChatEvents::new_direct_chat(them, my_user_id, events_ttl, anonymized_chat_id, now),
             unread_message_index_map: UnreadMessageIndexMap::default(),
             read_by_me_up_to: Timestamped::new(None, now),
             read_by_them_up_to: Timestamped::new(None, now),

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -32,7 +32,7 @@ impl DirectChat {
         DirectChat {
             them,
             date_created: now,
-            events: ChatEvents::new_direct_chat(them, my_user_id, events_ttl, anonymized_chat_id, now),
+            events: ChatEvents::new_direct_chat(my_user_id, them, events_ttl, anonymized_chat_id, now),
             unread_message_index_map: UnreadMessageIndexMap::default(),
             read_by_me_up_to: Timestamped::new(None, now),
             read_by_them_up_to: Timestamped::new(None, now),

--- a/backend/canisters/user/impl/src/model/direct_chats.rs
+++ b/backend/canisters/user/impl/src/model/direct_chats.rs
@@ -37,12 +37,13 @@ impl DirectChats {
         &mut self,
         their_user_id: UserId,
         their_user_type: UserType,
+        my_user_id: UserId,
         anonymized_id: F,
         now: TimestampMillis,
     ) -> &mut DirectChat {
         self.direct_chats
             .entry(their_user_id.into())
-            .or_insert_with(|| DirectChat::new(their_user_id, their_user_type, None, anonymized_id(), now))
+            .or_insert_with(|| DirectChat::new(their_user_id, my_user_id, their_user_type, None, anonymized_id(), now))
     }
 
     pub fn updated_since(&self, since: TimestampMillis) -> impl Iterator<Item = &DirectChat> {

--- a/backend/canisters/user/impl/src/model/direct_chats.rs
+++ b/backend/canisters/user/impl/src/model/direct_chats.rs
@@ -35,15 +35,15 @@ impl DirectChats {
 
     pub fn get_or_create<F: FnOnce() -> u128>(
         &mut self,
+        my_user_id: UserId,
         their_user_id: UserId,
         their_user_type: UserType,
-        my_user_id: UserId,
         anonymized_id: F,
         now: TimestampMillis,
     ) -> &mut DirectChat {
         self.direct_chats
             .entry(their_user_id.into())
-            .or_insert_with(|| DirectChat::new(their_user_id, my_user_id, their_user_type, None, anonymized_id(), now))
+            .or_insert_with(|| DirectChat::new(my_user_id, their_user_id, their_user_type, None, anonymized_id(), now))
     }
 
     pub fn updated_since(&self, since: TimestampMillis) -> impl Iterator<Item = &DirectChat> {

--- a/backend/canisters/user/impl/src/updates/c2c_install_bot.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_install_bot.rs
@@ -36,9 +36,9 @@ fn c2c_install_bot_impl(args: Args, state: &mut RuntimeState) -> OCResult {
 
     // If there isn't already a direct chat with the bot, create one now
     let chat = state.data.direct_chats.get_or_create(
+        state.env.canister_id().into(),
         args.bot_id,
         UserType::BotV2,
-        state.env.canister_id().into(),
         || state.env.rng().random(),
         now,
     );

--- a/backend/canisters/user/impl/src/updates/c2c_install_bot.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_install_bot.rs
@@ -35,10 +35,13 @@ fn c2c_install_bot_impl(args: Args, state: &mut RuntimeState) -> OCResult {
     }
 
     // If there isn't already a direct chat with the bot, create one now
-    let chat = state
-        .data
-        .direct_chats
-        .get_or_create(args.bot_id, UserType::BotV2, || state.env.rng().random(), now);
+    let chat = state.data.direct_chats.get_or_create(
+        args.bot_id,
+        UserType::BotV2,
+        state.env.canister_id().into(),
+        || state.env.rng().random(),
+        now,
+    );
 
     // Subscribe to permitted chat events
     if let (Some(subscriptions), Some(permissions)) = (args.default_subscriptions, args.granted_autonomous_permissions.clone())

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -154,9 +154,9 @@ pub(crate) fn handle_message_impl(
     let files = args.content.blob_references();
 
     let chat = state.data.direct_chats.get_or_create(
+        state.env.canister_id().into(),
         args.sender,
         args.sender_user_type,
-        state.env.canister_id().into(),
         || state.env.rng().random(),
         args.now,
     );

--- a/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_send_messages.rs
@@ -153,10 +153,13 @@ pub(crate) fn handle_message_impl(
     let replies_to = convert_reply_context(args.replies_to, args.sender, state);
     let files = args.content.blob_references();
 
-    let chat = state
-        .data
-        .direct_chats
-        .get_or_create(args.sender, args.sender_user_type, || state.env.rng().random(), args.now);
+    let chat = state.data.direct_chats.get_or_create(
+        args.sender,
+        args.sender_user_type,
+        state.env.canister_id().into(),
+        || state.env.rng().random(),
+        args.now,
+    );
 
     let thread_root_message_index = args.thread_root_message_id.map(|id| chat.main_message_id_to_index(id));
 

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -151,10 +151,13 @@ fn process_event(event: UserCanisterEvent, caller_user_id: UserId, state: &mut R
         }
         UserCanisterEvent::SetEventsTtl(args) => {
             let is_new_chat = !state.data.direct_chats.exists(&caller_user_id.into());
-            let chat = state
-                .data
-                .direct_chats
-                .get_or_create(caller_user_id, UserType::User, || state.env.rng().random(), now);
+            let chat = state.data.direct_chats.get_or_create(
+                caller_user_id,
+                UserType::User,
+                state.env.canister_id().into(),
+                || state.env.rng().random(),
+                now,
+            );
 
             let last_updated_timestamp = chat.events.get_events_time_to_live().timestamp;
 

--- a/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_user_canister.rs
@@ -152,9 +152,9 @@ fn process_event(event: UserCanisterEvent, caller_user_id: UserId, state: &mut R
         UserCanisterEvent::SetEventsTtl(args) => {
             let is_new_chat = !state.data.direct_chats.exists(&caller_user_id.into());
             let chat = state.data.direct_chats.get_or_create(
+                state.env.canister_id().into(),
                 caller_user_id,
                 UserType::User,
-                state.env.canister_id().into(),
                 || state.env.rng().random(),
                 now,
             );

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -295,7 +295,7 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
         let chat = state
             .data
             .direct_chats
-            .get_or_create(bot_id, UserType::BotV2, || state.env.rng().random(), now);
+            .get_or_create(bot_id, UserType::BotV2, my_user_id, || state.env.rng().random(), now);
 
         chat.push_message::<UserEventPusher>(
             PushMessageArgs {
@@ -461,10 +461,11 @@ fn send_message_impl(
         sender_context: None,
     };
 
-    let chat = state
-        .data
-        .direct_chats
-        .get_or_create(recipient, recipient_type.into(), || state.env.rng().random(), now);
+    let chat =
+        state
+            .data
+            .direct_chats
+            .get_or_create(recipient, recipient_type.into(), my_user_id, || state.env.rng().random(), now);
 
     let message_event = chat.push_message(
         push_message_args,

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -295,7 +295,7 @@ fn c2c_bot_send_message_impl(args: c2c_bot_send_message::Args, state: &mut Runti
         let chat = state
             .data
             .direct_chats
-            .get_or_create(bot_id, UserType::BotV2, my_user_id, || state.env.rng().random(), now);
+            .get_or_create(my_user_id, bot_id, UserType::BotV2, || state.env.rng().random(), now);
 
         chat.push_message::<UserEventPusher>(
             PushMessageArgs {
@@ -465,7 +465,7 @@ fn send_message_impl(
         state
             .data
             .direct_chats
-            .get_or_create(recipient, recipient_type.into(), my_user_id, || state.env.rng().random(), now);
+            .get_or_create(my_user_id, recipient, recipient_type.into(), || state.env.rng().random(), now);
 
     let message_event = chat.push_message(
         push_message_args,

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -109,9 +109,9 @@ pub fn handle_start_video_call(
     };
 
     let chat = state.data.direct_chats.get_or_create(
+        state.env.canister_id().into(),
         other,
         UserType::User,
-        state.env.canister_id().into(),
         || state.env.rng().random(),
         now,
     );

--- a/backend/canisters/user/impl/src/updates/start_video_call.rs
+++ b/backend/canisters/user/impl/src/updates/start_video_call.rs
@@ -108,10 +108,13 @@ pub fn handle_start_video_call(
         sender_context: None,
     };
 
-    let chat = state
-        .data
-        .direct_chats
-        .get_or_create(other, UserType::User, || state.env.rng().random(), now);
+    let chat = state.data.direct_chats.get_or_create(
+        other,
+        UserType::User,
+        state.env.canister_id().into(),
+        || state.env.rng().random(),
+        now,
+    );
 
     let mute_notification = their_message_index.is_some() || chat.notifications_muted.value;
 

--- a/backend/canisters/user/impl/src/updates/update_chat_settings.rs
+++ b/backend/canisters/user/impl/src/updates/update_chat_settings.rs
@@ -23,9 +23,9 @@ async fn update_chat_settings_impl(args: Args) -> OCResult {
         mutate_state(|state| {
             let now = state.env.now();
             state.data.direct_chats.get_or_create(
+                state.env.canister_id().into(),
                 args.user_id,
                 user.user_type,
-                state.env.canister_id().into(),
                 || state.env.rng().random(),
                 now,
             );

--- a/backend/canisters/user/impl/src/updates/update_chat_settings.rs
+++ b/backend/canisters/user/impl/src/updates/update_chat_settings.rs
@@ -22,10 +22,13 @@ async fn update_chat_settings_impl(args: Args) -> OCResult {
 
         mutate_state(|state| {
             let now = state.env.now();
-            state
-                .data
-                .direct_chats
-                .get_or_create(args.user_id, user.user_type, || state.env.rng().random(), now);
+            state.data.direct_chats.get_or_create(
+                args.user_id,
+                user.user_type,
+                state.env.canister_id().into(),
+                || state.env.rng().random(),
+                now,
+            );
         });
     }
 

--- a/backend/integration_tests/src/delete_direct_chat_tests.rs
+++ b/backend/integration_tests/src/delete_direct_chat_tests.rs
@@ -4,10 +4,11 @@ use crate::utils::{now_millis, tick_many};
 use crate::{TestEnv, client};
 use constants::DAY_IN_MS;
 use ic_stable_structures::memory_manager::MemoryId;
+use stable_memory_map::{KeyPrefix, UserMetricsKeyPrefix};
 use std::ops::Deref;
 use std::time::Duration;
-use testing::rng::random_string;
-use types::{ChatId, MessageContentInitial, OptionUpdate, TextContent};
+use testing::rng::{random_from_u128, random_string};
+use types::{Chat, ChatId, MessageContentInitial, MessageId, OptionUpdate, TextContent};
 
 #[test]
 fn delete_direct_chat_succeeds() {
@@ -90,7 +91,8 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
     let small_entries_keys_before_messages =
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len();
 
-    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
+    let message_id: MessageId = random_from_u128();
+    let result = client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), Some(message_id));
     for _ in 0..3 {
         client::user::happy_path::send_text_message(env, &user1, user2.user_id, random_string(), None);
     }
@@ -115,6 +117,18 @@ fn stable_memory_garbage_collected_after_direct_chat_deleted() {
         get_stable_memory_map(env, user1.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID).len(),
         small_entries_keys_before_messages + 13
     );
+
+    // Each canister only stores its own user's metrics for a direct chat, since only those are ever
+    // read, so user1's messages are only counted by user1's canister and user2's reaction by user2's
+    client::user::happy_path::add_reaction(env, &user2, user1.user_id, "👍", message_id);
+    tick_many(env, 3);
+
+    for (me, them) in [(&user1, &user2), (&user2, &user1)] {
+        let prefix = UserMetricsKeyPrefix::new_from_chat(Chat::Direct(them.user_id.into()));
+        let small_entries = get_stable_memory_map(env, me.canister(), STABLE_MEMORY_MAP_SMALL_ENTRIES_MEMORY_ID);
+        assert!(small_entries.contains_key(&prefix.create_key(&me.user_id).as_ref().to_vec()));
+        assert!(!small_entries.contains_key(&prefix.create_key(&them.user_id).as_ref().to_vec()));
+    }
 
     let delete_direct_chat_response = client::user::delete_direct_chat(
         env,

--- a/backend/integration_tests/src/send_direct_message_tests.rs
+++ b/backend/integration_tests/src/send_direct_message_tests.rs
@@ -1,12 +1,12 @@
 use crate::client::{start_canister, stop_canister};
 use crate::env::ENV;
-use crate::utils::tick_many;
+use crate::utils::{now_millis, tick_many};
 use crate::{TestEnv, client};
 use oc_error_codes::OCErrorCode;
 use std::ops::Deref;
 use std::time::Duration;
 use testing::rng::random_from_u128;
-use types::{ChatEvent, EventIndex, MessageContent, MessageContentInitial, TextContent};
+use types::{ChatEvent, ChatId, EventIndex, MessageContent, MessageContentInitial, TextContent};
 
 #[test]
 fn send_message_succeeds() {
@@ -29,6 +29,44 @@ fn send_message_succeeds() {
     assert!(matches!(events_response1.events[0].event, ChatEvent::Message(_)));
     assert_eq!(events_response2.events.len(), 1);
     assert!(matches!(events_response2.events[0].event, ChatEvent::Message(_)));
+}
+
+#[test]
+fn metrics_recorded_in_chat_with_self() {
+    let mut wrapper = ENV.deref().get();
+    let TestEnv { env, canister_ids, .. } = wrapper.env();
+
+    let user = client::register_user(env, canister_ids);
+
+    let message_id = random_from_u128();
+    client::user::happy_path::send_text_message(env, &user, user.user_id, "TEXT", Some(message_id));
+
+    env.advance_time(Duration::from_secs(1));
+    let updates_since = now_millis(env);
+    env.advance_time(Duration::from_secs(1));
+
+    client::user::happy_path::add_reaction(env, &user, user.user_id, "👍", message_id);
+
+    let initial_state = client::user::happy_path::initial_state(env, &user);
+    let summary = initial_state
+        .direct_chats
+        .summaries
+        .iter()
+        .find(|c| c.them == user.user_id)
+        .unwrap();
+    assert_eq!(summary.my_metrics.text_messages, 1);
+    assert_eq!(summary.my_metrics.reactions, 1);
+
+    let updates = client::user::happy_path::updates(env, &user, updates_since).unwrap();
+    let chat_updates = updates
+        .direct_chats
+        .updated
+        .iter()
+        .find(|c| c.chat_id == ChatId::from(user.user_id))
+        .unwrap();
+    let my_metrics = chat_updates.my_metrics.as_ref().unwrap();
+    assert_eq!(my_metrics.text_messages, 1);
+    assert_eq!(my_metrics.reactions, 1);
 }
 
 #[test]

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -31,7 +31,7 @@ use types::{
     P2PSwapAccepted, P2PSwapCompleted, P2PSwapCompletedEventPayload, P2PSwapContent, P2PSwapStatus, PendingCryptoTransaction,
     PollVotes, ProposalRewardStatus, ProposalUpdate, Reaction, ReactionAddedEventPayload, RegisterVoteResult,
     ReserveP2PSwapSuccess, SenderContext, Tally, TimestampMillis, TimestampNanos, Timestamped, Tips, UserId, VideoCall,
-    VideoCallEndedEventPayload, VideoCallParticipants, VideoCallPresence, VideoCallType, VoteOperation,
+    VideoCallEndedEventPayload, VideoCallParticipants, VideoCallPresence, VideoCallType, VoteOperation, is_default,
 };
 
 // The patchable fields of a moderation-report card; each is applied when present so that
@@ -60,6 +60,9 @@ pub struct ChatEvents {
     bot_subscriptions: BTreeMap<ChatEventType, HashSet<UserId>>,
     #[serde(rename = "pt", default, skip_serializing_if = "BTreeMap::is_empty")]
     active_proposal_tallies: BTreeMap<EventIndex, Tally>,
+    // Whether to skip the other user's metrics in a direct chat (see `skip_their_metrics`)
+    #[serde(rename = "stm", default, skip_serializing_if = "is_default")]
+    skip_their_metrics: bool,
 }
 
 impl ChatEvents {
@@ -88,6 +91,7 @@ impl ChatEvents {
 
     pub fn new_direct_chat(
         them: UserId,
+        my_user_id: UserId,
         events_ttl: Option<Milliseconds>,
         anonymized_id: u128,
         now: TimestampMillis,
@@ -108,8 +112,10 @@ impl ChatEvents {
             search_index: SearchIndex::default(),
             bot_subscriptions: BTreeMap::new(),
             active_proposal_tallies: BTreeMap::new(),
+            skip_their_metrics: false,
         };
 
+        events.skip_their_metrics(my_user_id);
         events.push_event(None, ChatEventInternal::DirectChatCreated(DirectChatCreated {}), now);
 
         events
@@ -140,6 +146,7 @@ impl ChatEvents {
             search_index: SearchIndex::default(),
             bot_subscriptions: BTreeMap::new(),
             active_proposal_tallies: BTreeMap::new(),
+            skip_their_metrics: false,
         };
 
         events.push_event(
@@ -229,6 +236,15 @@ impl ChatEvents {
         self.per_user_metrics.copy_to_heap(self.chat);
     }
 
+    // Called by the User canister holding this direct chat, so that the other user's metrics are no
+    // longer stored (and any already stored are deleted), since only its own user's metrics are ever
+    // read. This has no effect on the user's chat with themselves.
+    pub fn skip_their_metrics(&mut self, my_user_id: UserId) {
+        if !self.skip_their_metrics {
+            self.skip_their_metrics = self.per_user_metrics.skip_their_metrics(self.chat, my_user_id);
+        }
+    }
+
     // The number of entries on the heap which are yet to be moved into stable memory
     pub fn heap_entries_to_migrate_count(&self) -> usize {
         self.expiring_events.on_heap_count()
@@ -310,6 +326,7 @@ impl ChatEvents {
             &mut self.metrics,
             &mut self.per_user_metrics,
             self.chat,
+            self.skip_their_metrics,
             args.sender,
             |m| message_internal.add_to_metrics(m),
             args.now,
@@ -398,6 +415,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     sender,
                     |m| m.incr(MetricKey::Edits, 1),
                     now,
@@ -527,6 +545,7 @@ impl ChatEvents {
                         &mut self.metrics,
                         &mut self.per_user_metrics,
                         self.chat,
+                        self.skip_their_metrics,
                         sender,
                         |m| m.incr(MetricKey::ReportedMessages, 1),
                         args.now,
@@ -536,6 +555,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     args.caller,
                     |m| m.incr(MetricKey::DeletedMessages, 1),
                     args.now,
@@ -627,6 +647,7 @@ impl ChatEvents {
                         &mut self.metrics,
                         &mut self.per_user_metrics,
                         self.chat,
+                        self.skip_their_metrics,
                         sender,
                         |m| m.decr(MetricKey::ReportedMessages, 1),
                         args.now,
@@ -636,6 +657,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     args.caller,
                     |m| m.decr(MetricKey::DeletedMessages, 1),
                     args.now,
@@ -740,6 +762,7 @@ impl ChatEvents {
                                     &mut self.metrics,
                                     &mut self.per_user_metrics,
                                     self.chat,
+                                    self.skip_their_metrics,
                                     args.user_id,
                                     |m| m.incr(MetricKey::PollVotes, 1),
                                     args.now,
@@ -751,6 +774,7 @@ impl ChatEvents {
                                 &mut self.metrics,
                                 &mut self.per_user_metrics,
                                 self.chat,
+                                self.skip_their_metrics,
                                 args.user_id,
                                 |m| m.decr(MetricKey::PollVotes, 1),
                                 args.now,
@@ -1069,6 +1093,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     user_id,
                     |m| m.incr(MetricKey::Reactions, 1),
                     now,
@@ -1135,6 +1160,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     args.user_id,
                     |m| m.decr(MetricKey::Reactions, 1),
                     args.now,
@@ -1188,6 +1214,7 @@ impl ChatEvents {
                     &mut self.metrics,
                     &mut self.per_user_metrics,
                     self.chat,
+                    self.skip_their_metrics,
                     args.user_id,
                     |m| m.incr(MetricKey::Tips, 1),
                     args.now,
@@ -2738,6 +2765,7 @@ fn add_to_metrics<F: FnMut(&mut ChatMetricsInternal)>(
     metrics: &mut ChatMetricsInternal,
     per_user_metrics: &mut PerUserMetrics,
     chat: Chat,
+    skip_their_metrics: bool,
     user_id: UserId,
     mut action: F,
     timestamp: TimestampMillis,
@@ -2745,7 +2773,7 @@ fn add_to_metrics<F: FnMut(&mut ChatMetricsInternal)>(
     action(metrics);
     metrics.last_active = max(metrics.last_active, timestamp);
 
-    per_user_metrics.update(chat, user_id, action, timestamp);
+    per_user_metrics.update(chat, skip_their_metrics, user_id, action, timestamp);
 }
 
 pub struct PushMessageArgs {

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -90,8 +90,8 @@ impl ChatEvents {
     }
 
     pub fn new_direct_chat(
-        them: UserId,
         my_user_id: UserId,
+        them: UserId,
         events_ttl: Option<Milliseconds>,
         anonymized_id: u128,
         now: TimestampMillis,

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -1172,7 +1172,13 @@ mod tests {
         let memory = MemoryManager::init(DefaultMemoryImpl::default());
         stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
 
-        let mut events = ChatEvents::new_direct_chat(Principal::from_slice(&[1]).into(), events_ttl, random(), 1);
+        let mut events = ChatEvents::new_direct_chat(
+            Principal::from_slice(&[1]).into(),
+            Principal::from_slice(&[2]).into(),
+            events_ttl,
+            random(),
+            1,
+        );
 
         push_events(&mut events, 2);
 

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -1173,8 +1173,8 @@ mod tests {
         stable_memory_map::init_with_small_entries_map(memory.get(MemoryId::new(1)), memory.get(MemoryId::new(2)));
 
         let mut events = ChatEvents::new_direct_chat(
-            Principal::from_slice(&[1]).into(),
             Principal::from_slice(&[2]).into(),
+            Principal::from_slice(&[1]).into(),
             events_ttl,
             random(),
             1,

--- a/backend/libraries/chat_events/src/per_user_metrics.rs
+++ b/backend/libraries/chat_events/src/per_user_metrics.rs
@@ -4,10 +4,13 @@ use serde::{Deserialize, Serialize};
 use stable_memory_map::{Key, KeyPrefix, UserMetricsKeyPrefix, with_map, with_map_mut};
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
-use types::{Chat, TimestampMillis, UserId};
+use types::{Chat, ChatId, TimestampMillis, UserId};
 
 // Each user's metrics within a chat. The entries are stored in the stable memory map for small
 // entries.
+//
+// A User canister only ever reads its own user's metrics for a direct chat, so the other user's
+// metrics can be skipped (see `skip_their_metrics`).
 #[derive(Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct PerUserMetrics {
@@ -34,10 +37,15 @@ impl PerUserMetrics {
     pub fn update<F: FnOnce(&mut ChatMetricsInternal)>(
         &mut self,
         chat: Chat,
+        skip_their_metrics: bool,
         user_id: UserId,
         action: F,
         timestamp: TimestampMillis,
     ) {
+        if skip_their_metrics && is_them(chat, user_id) {
+            return;
+        }
+
         let key = UserMetricsKeyPrefix::new_from_chat(chat).create_key(&user_id);
 
         with_map_mut(|m| {
@@ -50,6 +58,24 @@ impl PerUserMetrics {
             metrics.last_active = max(metrics.last_active, timestamp);
             m.insert(key, metrics.to_bytes());
         });
+    }
+
+    // Called with the user whose canister holds this direct chat. Their metrics are the only ones
+    // which are ever read, so the other user's metrics can be skipped, unless the chat is the user's
+    // chat with themselves, in which case the other user *is* the canister's user. Returns whether
+    // the other user's metrics should be skipped, in which case any already stored are deleted.
+    pub fn skip_their_metrics(&mut self, chat: Chat, my_user_id: UserId) -> bool {
+        let Chat::Direct(them) = chat else {
+            return false;
+        };
+        let them = UserId::from(them);
+        if them == my_user_id {
+            return false;
+        }
+
+        self.on_heap.remove(&them);
+        with_map_mut(|m| m.remove(UserMetricsKeyPrefix::new_from_chat(chat).create_key(&them)));
+        true
     }
 
     // Copies every entry in stable memory onto the heap, so that they are included when the chat is
@@ -88,6 +114,10 @@ impl PerUserMetrics {
     }
 }
 
+fn is_them(chat: Chat, user_id: UserId) -> bool {
+    matches!(chat, Chat::Direct(them) if them == ChatId::from(user_id))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,8 +144,8 @@ mod tests {
             let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
             let incr = !rng().next_u32().is_multiple_of(3);
 
-            apply(&mut metrics1, &mut model1, chat1, user_id, key, incr, now);
-            apply(&mut metrics2, &mut model2, chat2, user_id, key, !incr, now + 1000);
+            apply(&mut metrics1, &mut model1, chat1, false, user_id, key, incr, now);
+            apply(&mut metrics2, &mut model2, chat2, false, user_id, key, !incr, now + 1000);
         }
 
         assert_eq!(metrics1.on_heap_count(), 0);
@@ -145,8 +175,26 @@ mod tests {
         assert_matches_model(&metrics, chat, &model);
 
         // Updating a user moves their entry into stable memory
-        apply(&mut metrics, &mut model, chat, user_id(10), MetricKey::Reactions, true, 5000);
-        apply(&mut metrics, &mut model, chat, user_id(100), MetricKey::Reactions, true, 5000);
+        apply(
+            &mut metrics,
+            &mut model,
+            chat,
+            false,
+            user_id(10),
+            MetricKey::Reactions,
+            true,
+            5000,
+        );
+        apply(
+            &mut metrics,
+            &mut model,
+            chat,
+            false,
+            user_id(100),
+            MetricKey::Reactions,
+            true,
+            5000,
+        );
         assert_eq!(metrics.on_heap_count(), 49);
         assert_matches_model(&metrics, chat, &model);
 
@@ -177,7 +225,16 @@ mod tests {
 
         for now in 1000..1200 {
             let user_id = user_id(rng().next_u32() % 30);
-            apply(&mut metrics, &mut model, group, user_id, MetricKey::TextMessages, true, now);
+            apply(
+                &mut metrics,
+                &mut model,
+                group,
+                false,
+                user_id,
+                MetricKey::TextMessages,
+                true,
+                now,
+            );
         }
 
         // The group copies its entries onto the heap before serializing them
@@ -194,16 +251,152 @@ mod tests {
 
         // If the import is abandoned, the group's copies on the heap are the same as the entries in
         // stable memory, so it can carry on as before
-        apply(&mut metrics, &mut model, group, user_id(3), MetricKey::Edits, true, 2000);
+        apply(
+            &mut metrics,
+            &mut model,
+            group,
+            false,
+            user_id(3),
+            MetricKey::Edits,
+            true,
+            2000,
+        );
         assert_matches_model(&metrics, group, &model);
         metrics.migrate_to_stable_memory(group, usize::MAX);
         assert_matches_model(&metrics, group, &model);
     }
 
+    #[test]
+    fn other_users_metrics_are_skipped_in_direct_chats() {
+        init_stable_memory_map();
+        let me = user_id(1);
+        let them = user_id(2);
+        let chat = Chat::Direct(them.into());
+        let group = Chat::Group(Principal::anonymous().into());
+        let mut metrics = PerUserMetrics::default();
+        let mut group_metrics = PerUserMetrics::default();
+        let mut model = Model::new();
+        let mut group_model = Model::new();
+
+        // Until the chat knows whose canister holds it, every user's metrics are stored
+        apply(&mut metrics, &mut model, chat, false, me, MetricKey::TextMessages, true, 1000);
+        apply(
+            &mut metrics,
+            &mut model,
+            chat,
+            false,
+            them,
+            MetricKey::TextMessages,
+            true,
+            1000,
+        );
+        apply(
+            &mut group_metrics,
+            &mut group_model,
+            group,
+            false,
+            them,
+            MetricKey::TextMessages,
+            true,
+            1000,
+        );
+        assert_matches_model(&metrics, chat, &model);
+
+        // Once it does, the other user's metrics are deleted
+        assert!(metrics.skip_their_metrics(chat, me));
+        model.remove(&them);
+        assert!(metrics.get(chat, &them).is_none());
+        assert_matches_model(&metrics, chat, &model);
+
+        // And they are no longer stored
+        for now in 1001..1100 {
+            let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
+            apply(&mut metrics, &mut model, chat, true, me, key, true, now);
+            metrics.update(chat, true, them, |m| m.incr(key, 1), now);
+        }
+        assert!(metrics.get(chat, &them).is_none());
+        assert_matches_model(&metrics, chat, &model);
+        assert_eq!(stable_user_ids(chat), vec![me]);
+
+        // The other user's metrics in other chats are unaffected
+        assert_matches_model(&group_metrics, group, &group_model);
+    }
+
+    #[test]
+    fn metrics_are_stored_in_self_chats() {
+        init_stable_memory_map();
+        let me = user_id(1);
+        let chat = Chat::Direct(me.into());
+        let mut metrics = PerUserMetrics::default();
+        let mut model = Model::new();
+
+        apply(&mut metrics, &mut model, chat, false, me, MetricKey::TextMessages, true, 1000);
+
+        // In a user's chat with themselves, the other user is the user whose canister holds the chat,
+        // so nothing is skipped or deleted
+        assert!(!metrics.skip_their_metrics(chat, me));
+        assert_matches_model(&metrics, chat, &model);
+
+        for now in 1001..1100 {
+            let key = MetricKey::from((rng().next_u32() % 22 + 1) as u8);
+            apply(&mut metrics, &mut model, chat, false, me, key, true, now);
+        }
+        assert_matches_model(&metrics, chat, &model);
+        assert_eq!(stable_user_ids(chat), vec![me]);
+    }
+
+    #[test]
+    fn metrics_are_not_skipped_in_group_chats_or_channels() {
+        let me = user_id(1);
+        let mut metrics = PerUserMetrics::default();
+
+        assert!(!metrics.skip_their_metrics(Chat::Group(Principal::anonymous().into()), me));
+        assert!(!metrics.skip_their_metrics(Chat::Channel(Principal::anonymous().into(), ChannelId::from(1u32)), me));
+    }
+
+    #[test]
+    fn other_users_legacy_metrics_are_deleted_when_skipped() {
+        init_stable_memory_map();
+        let me = user_id(2);
+
+        // Where the other user's legacy entry has already been moved into stable memory, it is
+        // deleted from there
+        let them = user_id(1);
+        let chat = Chat::Direct(them.into());
+        let (mut metrics, mut model) = legacy_metrics(&[them, me]);
+        assert_eq!(metrics.migrate_to_stable_memory(chat, 1), 1);
+        assert_eq!(stable_user_ids(chat), vec![them]);
+
+        assert!(metrics.skip_their_metrics(chat, me));
+        model.remove(&them);
+        assert!(stable_user_ids(chat).is_empty());
+        assert_matches_model(&metrics, chat, &model);
+
+        assert_eq!(metrics.migrate_to_stable_memory(chat, usize::MAX), 1);
+        assert_eq!(stable_user_ids(chat), vec![me]);
+        assert_matches_model(&metrics, chat, &model);
+
+        // Where it is still on the heap, it is dropped rather than moved into stable memory
+        let them = user_id(3);
+        let chat = Chat::Direct(them.into());
+        let (mut metrics, mut model) = legacy_metrics(&[them, me]);
+
+        assert!(metrics.skip_their_metrics(chat, me));
+        model.remove(&them);
+        assert_eq!(metrics.on_heap_count(), 1);
+        assert_matches_model(&metrics, chat, &model);
+
+        assert_eq!(metrics.migrate_to_stable_memory(chat, usize::MAX), 1);
+        assert_eq!(stable_user_ids(chat), vec![me]);
+        assert_matches_model(&metrics, chat, &model);
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn apply(
         metrics: &mut PerUserMetrics,
         model: &mut Model,
         chat: Chat,
+        skip_their_metrics: bool,
         user_id: UserId,
         key: MetricKey,
         incr: bool,
@@ -212,7 +405,7 @@ mod tests {
         let action = |m: &mut ChatMetricsInternal| {
             if incr { m.incr(key, 1) } else { m.decr(key, 1) }
         };
-        metrics.update(chat, user_id, action, now);
+        metrics.update(chat, skip_their_metrics, user_id, action, now);
 
         let expected = model.entry(user_id).or_default();
         action(expected);
@@ -223,6 +416,30 @@ mod tests {
         for (user_id, expected) in model {
             assert_eq!(metrics.get(chat, user_id).as_ref(), Some(expected));
         }
+    }
+
+    // Deserializes entries on the heap, as they were held before being moved into stable memory
+    fn legacy_metrics(user_ids: &[UserId]) -> (PerUserMetrics, Model) {
+        let mut model = Model::new();
+        for (i, user_id) in user_ids.iter().enumerate() {
+            let mut metrics = ChatMetricsInternal::default();
+            metrics.incr(MetricKey::TextMessages, i as u32 + 1);
+            model.insert(*user_id, metrics);
+        }
+        (
+            msgpack::deserialize_then_unwrap(&msgpack::serialize_then_unwrap(&model)),
+            model,
+        )
+    }
+
+    fn stable_user_ids(chat: Chat) -> Vec<UserId> {
+        let prefix = UserMetricsKeyPrefix::new_from_chat(chat);
+        with_map(|m| {
+            m.range(prefix.create_key(&Principal::from_slice(&[]).into())..)
+                .take_while(|(k, _)| k.matches_prefix(&prefix))
+                .map(|(k, _)| k.user_id())
+                .collect()
+        })
     }
 
     fn user_id(i: u32) -> UserId {


### PR DESCRIPTION
A User canister only ever reads its own user's metrics for a direct chat (`direct_chat.rs` calls `chat.events.user_metrics(&my_user_id, ..)`), so the other user's entries are dead weight. Skipping them halves the per-user metrics entries for direct chats and saves a stable memory write for every message or reaction received. Builds on #9352.

### Design

`ChatEvents` can't tell a self chat apart from the other user acting: in a user's chat with themselves, `Chat::Direct(them)` has `them == my_user_id`. That's why the first attempt on #9352 (7d5b388f5, since reverted) was wrong. So the User canister passes its own user id in, and the decision is made in one place:

- `PerUserMetrics::skip_their_metrics(chat, my_user_id)` returns `false` for group chats, channels and self chats. Otherwise it deletes any existing entry for the other user, both on the heap and in stable memory, and returns `true`.
- `ChatEvents` persists the result as `skip_their_metrics` (`#[serde(rename = "stm", default)]`), which `PerUserMetrics::update` checks. A chat without the flag stores everything, as before.
- New chats: `DirectChats::get_or_create` → `DirectChat::new` → `ChatEvents::new_direct_chat` now take `my_user_id`.
- Existing chats: `post_upgrade` calls `skip_their_metrics` on every direct chat. This is one stable remove per direct chat on the first upgrade, and a no-op on later upgrades (marked `TODO: Remove this after next release`).

Bots only post into their own direct chat with the user, where the bot is `them`, so their metrics are skipped too. They're never read.

### Tests

- Unit tests in `per_user_metrics.rs` cover normal direct chats (the other user's metrics are deleted and not stored again, and their entries in other chats are unaffected), self chats, group chats and channels, and legacy entries: the other user's entry is deleted whether it's still on the heap or already moved into stable memory.
- `delete_direct_chat_tests`: each canister stores only its own user's metrics entry. user1's messages are counted only by user1's canister, and user2's reaction only by user2's.
- `send_direct_message_tests::metrics_recorded_in_chat_with_self`: self-chat `my_metrics` still work in both `initial_state` and `updates`.
- I ran two mutation checks locally. Dropping the self-chat check fails the unit and integration self-chat tests. Never skipping fails the direct chat unit tests and the `delete_direct_chat` assertion.
- I also checked the upgrade by hand, with a throwaway test that isn't committed. It created state with a user wasm built from master, where both users' metrics are stored, then upgraded to this branch's wasm. The other user's entries were gone from both canisters, the owner's own and self-chat entries remained, and new activity was still skipped.
- Full integration suite locally: 417 of 418 passed. `stable_memory_maps_survive_upgrades` failed once with `CanisterStopped` while running alongside every other test, and passes on its own. No trap in `post_upgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)